### PR TITLE
Update findspam.py

### DIFF
--- a/findspam.py
+++ b/findspam.py
@@ -9,7 +9,7 @@ class FindSpam:
     'sites': ["patents.stackexchange.com"], 'reason': "Phone number detected"},
    {'regex': "(?i)\\b([Nn]igga|[Nn]igger|niga|[Aa]sshole|crap|fag|[Ff]uck|idiot|[Ss]hit|[Ww]hore)s?\\b", 'all': True,
     'sites': [], 'reason': "Offensive title detected",'insensitive':True},
-   {'regex': "^[A-Z0-9\\(\\)\\.\\-\\?\\s'\"]*$", 'all': True, 'sites': [], 'reason': "All-caps title"}
+   {'regex': "^(?=.*[A-Z])[^a-z]*$", 'all': True, 'sites': [], 'reason': "All-caps title"}
   ]
 
   @staticmethod


### PR DESCRIPTION
Changed regex to match only titles that contain no lowercase letters, but at least one uppercase letter.
