### PR TITLE
Update findspam.py

### DIFF
--- a/findspam.py
+++ b/findspam.py
@@ -7,7 +7,7 @@ class FindSpam:
     'sites': [], 'reason': "Bad keyword detected"},
    {'regex': "\\+\\d{10}|\\+?\\d{2}[\\s\\-]?\\d{8,1o}", 'all': True,
     'sites': ["patents.stackexchange.com"], 'reason': "Phone number detected"},
-   {'regex': "(?i)\\b(nigg?a|nigger|asshole|crap|fag|fuck(ing?)?|idiot|shit|whore)s?\\b", 'all': True,
+   {'regex': "(?i)\\b(nigg?(a|er)|asshole|crap|fag|fuck(ing?)?|idiot|shit|whore)s?\\b", 'all': True,
     'sites': [], 'reason': "Offensive title detected",'insensitive':True},
    {'regex': "^(?=.*[A-Z])[^a-z]*$", 'all': True, 'sites': [], 'reason': "All-caps title"}
   ]


### PR DESCRIPTION
Remove caps-lowercase alternatives in lists since we're in case-insensitive matching (?i). Also shortened regex by combining "nigga" with "niga" and "nigger" in "nigg?(a|er)".
