### PR TITLE
Escape special characters in titles when posting the link (fixes #9)

### DIFF
--- a/ws.py
+++ b/ws.py
@@ -51,8 +51,10 @@ def checkifspam(data):
 def handlespam(data):
   try:
     d=json.loads(json.loads(data)["data"])
-    reason=",".join(FindSpam.testpost(d["titleEncodedFancy"],d["siteBaseHostAddress"]))
-    s="[ [SmokeDetector](https://github.com/Charcoal-SE/SmokeDetector) ] %s: [%s](%s) on `%s`" % (reason,d["titleEncodedFancy"],d["url"],d["siteBaseHostAddress"])
+    title = d["titleEncodedFancy"]
+    reason=",".join(FindSpam.testpost(title,d["siteBaseHostAddress"]))
+    escapedTitle = re.sub(r"([_*\\`\[\]])", r"\\\1", title)
+    s="[ [SmokeDetector](https://github.com/Charcoal-SE/SmokeDetector) ] %s: [%s](%s) on `%s`" % (reason,escapedTitle,d["url"],d["siteBaseHostAddress"])
     print parser.unescape(s).encode('ascii',errors='replace')
     room.send_message(s)
     roomm.send_message(s)


### PR DESCRIPTION
This is a fix for #9. Before posting, it escapes all special characters using a regular expression.
