### PR TITLE
Create blacklisting of word combination sets.

### DIFF
--- a/findspam.py
+++ b/findspam.py
@@ -8,7 +8,7 @@ class FindSpam:
         'sites': [], 'reason': "Bad keyword in {}", 'title': True, 'username': True},
      {'regex': u"(?i)\\b(weight loss|muscles? build(ing)?|muscles?( (grow(th)?|diets?))?)\\b", 'all': True,
         'sites': ["fitness.stackexchange.com"], 'reason': "Bad keyword in {}", 'title': True, 'username': True},
-     {'regex': u"(?i)^(?:(?=.*?\\b(?:online|hd)\\b)(?=.*?(?:free|full|unlimited)).*?movies?\\b|(?=.*?\\b(acai|kisn)\\b)(?=.*?care).*products?\\b|(?=.*?packer)(?=.*?and).*mover)", 'all': True,
+     {'regex': u"(?i)^(?:(?=.*?\\b(?:online|hd)\\b)(?=.*?(?:free|full|unlimited)).*?movies?\\b|(?=.*?\\b(?:acai|kisn)\\b)(?=.*?care).*products?\\b|(?=.*?packer)(?=.*?and).*mover)", 'all': True,
         'sites': [], 'reason': "Bad keywords in {}", 'title': True, 'username': True},
      {'regex': u"\\d(?:_*\\d){9}|\\+?\\d_*\\d[\\s\\-]?(?:_*\\d){8,10}", 'all': True,
         'sites': ["patents.stackexchange.com"], 'reason': "Phone number detected", 'validation_method': 'checkphonenumbers', 'title': True, 'username': False},


### PR DESCRIPTION
This also moved "packers and movers" into the new set. This will match any titles with combinations of the key terms:
- online/hd (single word) + free/full/unlimited + movie(s) (boundary at end) [reference](http://drupal.stackexchange.com/questions/136559/king-the-horrible-bosses-2-online-free-full-movie-hdhq)
- acai/kisn (single word) + care + product(s) (boundary at end) [reference](http://drupal.stackexchange.com/questions/136578/what-is-popularity-of-kisn-care-products)
- packer + and + mover

Here is a [regex demo](http://regex101.com/r/lB6xI8/1), and a [relevant Stack Overflow thread](http://stackoverflow.com/q/24656131/3622940) about matching combinations of words in a sequence.
