### PR TITLE
It really should be "setup.sh".

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,6 @@ sudo pip install phonenumbers
 To run, use `python ws.py` (preferably in a daemon-able mode). Like in a `screen` session.
 
 
-You can run `. ChatExchange/setp.sh` to set local environment variables so that you don't have to log in every time. 
+You can run `. ChatExchange/setup.sh` to set local environment variables so that you don't have to log in every time. 
 
 Only supports Stack Exchange OpenIDs for now.


### PR DESCRIPTION
So, here's a README fix.