### PR TITLE
health+pro = spam

### DIFF
--- a/findspam.py
+++ b/findspam.py
@@ -158,7 +158,11 @@ class FindSpam:
                             "cacherealestate\\.com", "Matrixhackka007", "aoatech\\.com",
                             "pharaohtools", "msoutlooktools\\.com", "softwarezee",
                             "i-hire\\.pro", "pandamw\\.com", "buy[\\w-]{6,}\\.(com|net|org)",
-                            "(testo|cleanse|supplement|serum)[\\w-]*\\.(com|net|org)"]
+                            "(testo|cleanse|supplement|serum|fatloss)[\\w-]*\\.(com|net|org)",
+                            "(natural|pro|magic)[\\w-]*health[\\w-]*\\.(com|net|org)",
+                            "health[\\w-]*(natural|pro|review|blog|advise|discussion)[\\w-]*\\.(com|net|org)",
+                            "scampunch\\.com", "multipelife\\.com", "seasoncars\\.com",
+                            "eltima\\.com", "flexihub\\.com"]
     rules = [
         {'regex': u"(?i)\\b(%s)\\b|%s" % ("|".join(bad_keywords), "|".join(bad_keywords_nwb)), 'all': True,
          'sites': [], 'reason': "Bad keyword in {}", 'title': True, 'body': True, 'username': True, 'stripcodeblocks': False, 'body_summary': True},


### PR DESCRIPTION
More general patterns of "health"+something spam domains (can't blacklist health on its own). If they work as expected, some of specific domains can be trimmed later from the blacklist.
 
Also added a few specific domains. 