### PR TITLE
Add upgrade of `pip` before `requests`

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ git clone https://github.com/Charcoal-SE/SmokeDetector.git
 cd SmokeDetector
 git submodule init
 git submodule update
+sudo pip install pip --upgrade
 sudo pip install beautifulsoup4
 sudo pip install requests --upgrade
 sudo pip install websocket-client --upgrade


### PR DESCRIPTION
Ubuntu comes by default with a pretty ancient version of `pip` in its repositories. Unfortunately, that version is no longer compatible with the latest version of `requests`, which deletes (?) a package called `IncompleteRead` on that old `pip` still depends.

So as soon as you upgraded `requests` with your old `pip`, it will be broken due to that now missing package. It can be repaired with `sudo easy_install --upgrade pip` (`easy_install` is a python package management tool similar to `pip`, but slightly older and with less features, however it does not have that problematic dependency, so it still works.), but it's best to prevent this from happening by upgrading `pip` before `requests`!