### PR TITLE
Determine bot user ID at runtime, and added !!/whoami

### DIFF
--- a/chatcommunicate.py
+++ b/chatcommunicate.py
@@ -372,6 +372,11 @@ def handle_commands(content_lower, message_parts, ev_room, ev_user_id, ev_user_n
         return "I'm [SmokeDetector](https://github.com/Charcoal-SE/SmokeDetector), a bot that detects spam and low-quality posts on the network and posts alerts to chat. [A command list is available here](https://github.com/Charcoal-SE/SmokeDetector/wiki/Commands)."
     if content_lower.startswith("!!/apiquota"):
         return GlobalVars.apiquota
+    if content_lower.startswith("!!/whoami"):
+        if (ev_room in GlobalVars.smokeDetector_user_id):
+            return "My id for this room is {}".format(GlobalVars.smokeDetector_user_id[ev_room])
+        else:
+            return "I don't know my user ID for this room. (Something is wrong, and it's apnorton's fault.)"
     if content_lower.startswith("!!/location"):
         return GlobalVars.location
     if content_lower.startswith("!!/queuestatus"):

--- a/globalvars.py
+++ b/globalvars.py
@@ -39,6 +39,7 @@ class GlobalVars:
                                            "31465",  # Seth
                                            "88577",  # Santa Claus
                                            "34124",  # Andrew Leach
+                                           "54229",  # apnorton
                                            "32436"],  # tchrist
                         meta_tavern_room_id: ["259867",  # Normal Human
                                               "244519",  # Roombatron5000

--- a/ws.py
+++ b/ws.py
@@ -45,6 +45,9 @@ GlobalVars.bodyfetcher = BodyFetcher()
 GlobalVars.wrap.login(username, password)
 GlobalVars.wrapm.login(username, password)
 GlobalVars.wrapso.login(username, password)
+GlobalVars.smokeDetector_user_id[GlobalVars.charcoal_room_id] = str(GlobalVars.wrap.get_me().id)
+GlobalVars.smokeDetector_user_id[GlobalVars.meta_tavern_room_id] = str(GlobalVars.wrapm.get_me().id)
+GlobalVars.smokeDetector_user_id[GlobalVars.socvr_room_id] = str(GlobalVars.wrapso.get_me().id)
 GlobalVars.s = "[ [SmokeDetector](https://github.com/Charcoal-SE/SmokeDetector) ] " \
                "SmokeDetector started at [rev " +\
                GlobalVars.commit_with_author +\


### PR DESCRIPTION
Before, the SmokeDetector user IDs were hardcoded.  Now, we use ChatExchange's .get_me() method to determine the ID.