### PR TITLE
Adjusted keywords to reduce false positives.

### DIFF
--- a/findspam.py
+++ b/findspam.py
@@ -45,7 +45,7 @@ class FindSpam:
                     "vashi?k[ae]r[ae]n", "kolcak", "Zapyo", "we (offer|give out) (loans|funds|funding)",
                     "porn", "molvi", "judi bola", "ituBola.com", "lost lover'?s?",
                     "rejuvenated skin", "ProBrain", "restore[ -]?samsung[ -]?data",
-                    "LifeForce", "swtor2credits", "me2.do",  # Removed "black magic"; too many false positives
+                    "LifeForce", "swtor2credits", "me2.do", "^(?s).{0,200}black magic",
                     "bam2u", "Neuro(3X|flexyn|fuse|luma|plex)", "TesteroneXL", "Nitroxin",
                     "Bowtrol", "Slim ?Genix", "Cleanse EFX", "Alpha Rush",
                     "Blackline Elite", "TestCore Pro", "blank(ed)? ?ATM(card)?", "ATM Machine Vault",

--- a/findspam.py
+++ b/findspam.py
@@ -45,7 +45,7 @@ class FindSpam:
                     "vashi?k[ae]r[ae]n", "kolcak", "Zapyo", "we (offer|give out) (loans|funds|funding)",
                     "porn", "molvi", "judi bola", "ituBola.com", "lost lover'?s?",
                     "rejuvenated skin", "ProBrain", "restore[ -]?samsung[ -]?data",
-                    "LifeForce", "swtor2credits", "me2.do", "^(?s).{0,200}black magic",
+                    "LifeForce", "swtor2credits", "me2.do", # Removed "black magic"; too many false positives
                     "bam2u", "Neuro(3X|flexyn|fuse|luma|plex)", "TesteroneXL", "Nitroxin",
                     "Bowtrol", "Slim ?Genix", "Cleanse EFX", "Alpha Rush",
                     "Blackline Elite", "TestCore Pro", "blank(ed)? ?ATM(card)?", "ATM Machine Vault",
@@ -247,7 +247,7 @@ class FindSpam:
          'sites': [], 'reason': "Nested quote blocks with link", 'title': False, 'body': True, 'username': False, 'stripcodeblocks': True, 'body_summary': False},
         {'regex': ur"(?i)\b(muscles?|testo ?[sx]\w*|body ?build(er|ing)|wrinkles?|(?<!to )supplements?|probiotics?|acne)\b", 'all': True,
          'sites': ["fitness.stackexchange.com", "biology.stackexchange.com", "health.stackexchange.com"], 'reason': "Bad keyword in {}", 'title': True, 'body': False, 'username': False, 'stripcodeblocks': False, 'body_summary': False},
-        {'regex': ur"(?i)virility|diet ?(plan|pill)|\b(pro)?derma(?!t)|(fat|weight)[ -]?(loo?s[es]|reduction)|loo?s[es] ?weight|\bherpes\b", 'all': True,
+        {'regex': ur"(?i)virility|diet ?(plan|pill)|\b(pro)?derma(?!t)|(fat|\bweight)[ -]?(loo?s[es]|reduction)|loo?s[es] ?weight|\bherpes\b", 'all': True,
          'sites': ["fitness.stackexchange.com", "biology.stackexchange.com", "health.stackexchange.com", "skeptics.stackexchange.com", "bicycles.stackexchange.com"], 'reason': "Bad keyword in {}", 'title': True, 'body': True, 'username': False, 'stripcodeblocks': True, 'body_summary': True},
         {'regex': ur"(?i)(workout|fitness|diet|perfecthealth|muscle)[\w-]*\.(com|co\.|net)", 'all': True,
          'sites': ["fitness.stackexchange.com", "biology.stackexchange.com", "health.stackexchange.com", "skeptics.stackexchange.com", "bicycles.stackexchange.com"], 'reason': "Pattern-matching website in {}", 'title': True, 'body': True, 'username': True, 'stripcodeblocks': False, 'body_summary': True},

--- a/findspam.py
+++ b/findspam.py
@@ -45,7 +45,7 @@ class FindSpam:
                     "vashi?k[ae]r[ae]n", "kolcak", "Zapyo", "we (offer|give out) (loans|funds|funding)",
                     "porn", "molvi", "judi bola", "ituBola.com", "lost lover'?s?",
                     "rejuvenated skin", "ProBrain", "restore[ -]?samsung[ -]?data",
-                    "LifeForce", "swtor2credits", "me2.do", # Removed "black magic"; too many false positives
+                    "LifeForce", "swtor2credits", "me2.do",  # Removed "black magic"; too many false positives
                     "bam2u", "Neuro(3X|flexyn|fuse|luma|plex)", "TesteroneXL", "Nitroxin",
                     "Bowtrol", "Slim ?Genix", "Cleanse EFX", "Alpha Rush",
                     "Blackline Elite", "TestCore Pro", "blank(ed)? ?ATM(card)?", "ATM Machine Vault",

--- a/globalvars.py
+++ b/globalvars.py
@@ -43,7 +43,8 @@ class GlobalVars:
                                            "34124",  # Andrew Leach
                                            "54229",  # apnorton
                                            "20459",  # S.L. Barth
-                                           "32436"],  # tchrist
+                                           "32436",  # tchrist
+                                           "30477"],  # Brock Adams
                         meta_tavern_room_id: ["259867",  # Normal Human
                                               "244519",  # Roombatron5000
                                               "244382",  # TGMCians


### PR DESCRIPTION
Removed "black magic" and adjusted "weight loss" to reduce false positives.

Regarding "weight loss":

 - It was causing too many false positives due to [the term *deadweight loss*](https://en.wikipedia.org/wiki/Deadweight_loss), which frequently occurs in economics.
 - Reference [this chat on Charcoal HQ](http://chat.stackexchange.com/transcript/message/25247160#25247160)
 - Tweaked the regex to only match when word starts with "weight".

<br>
For "black magic" see:
 - Starting [here, on Tavern](http://chat.meta.stackexchange.com/transcript/message/4165391#4165391)  
  and
 - [Here, on Charcoal HQ](http://chat.stackexchange.com/transcript/message/25247400#25247400)
