### PR TITLE
Don't zero-out quota record on API glitches

### DIFF
--- a/bodyfetcher.py
+++ b/bodyfetcher.py
@@ -80,9 +80,6 @@ class BodyFetcher:
             if response["quota_remaining"] - GlobalVars.apiquota >= 1000 and GlobalVars.apiquota >= 0:
                 GlobalVars.charcoal_hq.send_message("API quota rolled over with {} requests remaining.".format(GlobalVars.apiquota))
             GlobalVars.apiquota = response["quota_remaining"]
-        else:
-            GlobalVars.apiquota = 0
-            return
 
         if site == "stackoverflow.com":
             if len(response["items"]) > 0 and "last_activity_date" in response["items"][0]:


### PR DESCRIPTION
Don't zero-out the quota record when the API glitches or when a filter that doesn't include quota_remaining is used.

See: 
- http://chat.stackexchange.com/transcript/11540?m=26314837#26314837
- http://chat.stackexchange.com/transcript/11540?m=26260124#26260124
- etc.