### PR TITLE
Quota rollover is lost if it happens when Smokey is down.

### DIFF
--- a/bodyfetcher.py
+++ b/bodyfetcher.py
@@ -136,6 +136,8 @@ class BodyFetcher:
             if response["quota_remaining"] == 0:
                 GlobalVars.charcoal_hq.send_message("API reports no quota left!  May be a glitch.")
                 GlobalVars.charcoal_hq.send_message(str(response))  # No code format for now?
+            if GlobalVars.apiquota == -1:
+                GlobalVars.charcoal_hq.send_message("Restart: API quota is {}.".format(response["quota_remaining"]))
             GlobalVars.apiquota = response["quota_remaining"]
         else:
             GlobalVars.charcoal_hq.send_message("The quota_remaining property was not in the API response.")


### PR DESCRIPTION
If Smokey has crashed or rebooted when the API rollover happens, Smokey doesn't detect it and we lose all sense of what the lowest quota remaining might be.
This change effectively adds an extra line soon after the customary start line that helps mitigate that loss.

The gold-standard way to track quota levels, is to update the quota in a file. But, this file would see about 10K read/write cycles a day.  Do we want to do that?