### PR TITLE
Created !!/ami 

### DIFF
--- a/chatcommunicate.py
+++ b/chatcommunicate.py
@@ -517,7 +517,7 @@ def handle_commands(content_lower, message_parts, ev_room, ev_room_name, ev_user
             result += "\n----------\n"
             result += why
         return result
-    if content_lower.startswith("!!/amiprivileged"):
+    if content_lower.startswith("!!/amiprivileged") or content_lower.startswith("!!/ami"):
         if is_privileged(ev_room, ev_user_id, wrap2):
             return "Yes, you are a privileged user."
         else:


### PR DESCRIPTION
I have noticed lately in the SOCVR chat room that people often misspell `!!/amiprivileged`, which is why I think people should be able to type in `!!/ami` instead to do the same task.

Let me know what you all think.