### PR TITLE
Add `accountingassignments.help` and `phphelponline.com` to the blacklist

### DIFF
--- a/findspam.py
+++ b/findspam.py
@@ -323,6 +323,7 @@ class FindSpam:
                             "decalontop\\.com", "urlopener\\.com", "mobile57\\.com", "learn(spicy|perfact)",
                             "getfitness\\.in", "trustwiko\\.com", "attendasoft", "selfybuzz\\.com", "meritcampus\\.com",
                             "fastindiaservice\\.com", "shharshsajv", "fizyetimusing", "fornatgaex", "shwesanenid",
+                            "accountingassignments\\.help", "phphelponline\\.com",
                             "eremaxfuncionabr"]
     pattern_websites = [r"health\d{3,}\.(com|net)", r"http\S*?\.repair\W", r"filefix(er)?\.com", "\.page\.tl\W",
                         r"\.(com|net)/(xtra|muscle)[\w-]", r"http\S*?\Wfor-sale\W",


### PR DESCRIPTION
These websites have been used in spam:
accountingassignments.help: https://metasmoke.erwaysoftware.com/post/17725
phphelponline.com: https://metasmoke.erwaysoftware.com/post/17724