### PR TITLE
Add Users kos and ByteCommander to privileged list

### DIFF
--- a/globalvars.py
+++ b/globalvars.py
@@ -130,7 +130,7 @@ class GlobalVars:
                                               "310756",  # Ms Yvette
                                               "262399",  # Jeffrey Bosboom
                                               "242209",  # JAL
-                                              "280883",  # ByteCommander 
+                                              "280883",  # ByteCommander
                                               "302251"],  # kos
                         socvr_room_id: [
                             "1849664",  # Undo

--- a/globalvars.py
+++ b/globalvars.py
@@ -65,7 +65,8 @@ class GlobalVars:
                                            "58529",  # ferrybig
                                            "145208",  # Robert Longson
                                            "178825",  # Ms Yvette
-                                           "171800"],  # JAL
+                                           "171800",  # JAL
+                                           "137665",],  # ByteCommander
                         meta_tavern_room_id: ["259867",  # Normal Human
                                               "244519",  # CRABOLO
                                               "244382",  # TGMCians
@@ -128,7 +129,8 @@ class GlobalVars:
                                               "260388",  # Pandya
                                               "310756",  # Ms Yvette
                                               "262399",  # Jeffrey Bosboom
-                                              "242209"],  # JAL
+                                              "242209",  # JAL
+                                              "280883"],  # ByteCommander 
                         socvr_room_id: [
                             "1849664",  # Undo
                             "2581872",  # hichris123

--- a/globalvars.py
+++ b/globalvars.py
@@ -66,7 +66,7 @@ class GlobalVars:
                                            "145208",  # Robert Longson
                                            "178825",  # Ms Yvette
                                            "171800",  # JAL
-                                           "137665",],  # ByteCommander
+                                           "137665"],  # ByteCommander
                         meta_tavern_room_id: ["259867",  # Normal Human
                                               "244519",  # CRABOLO
                                               "244382",  # TGMCians
@@ -130,7 +130,8 @@ class GlobalVars:
                                               "310756",  # Ms Yvette
                                               "262399",  # Jeffrey Bosboom
                                               "242209",  # JAL
-                                              "280883"],  # ByteCommander 
+                                              "280883",  # ByteCommander 
+                                              "302251"],  # kos
                         socvr_room_id: [
                             "1849664",  # Undo
                             "2581872",  # hichris123


### PR DESCRIPTION
I would like to propose adding 
- myself ([ByteCommander](http://stackexchange.com/users/5612515/byte-commander?tab=accounts)) to the list of privileged users in CCHQ and Tavern
- [kos](http://stackexchange.com/users/5423050/kos?tab=accounts) to the list of privileged users in the Tavern.

Both applications are combined as @ferrybig requested in the Ask Ubuntu General Room. (near [this chat message](http://chat.stackexchange.com/transcript/message/28311310#28311310))