### PR TITLE
Reduces multiple if statements to a single dictionary check for command aliases

### DIFF
--- a/chatcommunicate.py
+++ b/chatcommunicate.py
@@ -21,6 +21,17 @@ from ChatExchange.chatexchange.messages import Message
 
 add_latest_message_lock = Lock()
 
+command_aliases = {
+    "f": "fp-",
+    "notspam": "fp-",
+    "k": "tpu-",
+    "spam": "tpu-",
+    "rude": "tpu-",
+    "abuse": "tpu-",
+    "abusive": "tpu-",
+    "offensive": "tpu-",
+    "n": "naa",
+}
 
 def post_message_in_room(room_id_str, msg, length_check=True):
     if room_id_str == GlobalVars.charcoal_room_id:
@@ -170,12 +181,8 @@ def watcher(ev, wrap2):
 def handle_commands(content_lower, message_parts, ev_room, ev_room_name, ev_user_id, ev_user_name, wrap2, content, message_id):
     message_url = "//chat.{host}/transcript/message/{id}#{id}".format(host=wrap2.host, id=message_id)
     second_part_lower = "" if len(message_parts) < 2 else message_parts[1].lower()
-    if second_part_lower in ["f", "notspam"]:
-        second_part_lower = "fp-"
-    if second_part_lower in ["k", "spam", "rude", "abuse", "abusive", "offensive"]:
-        second_part_lower = "tpu-"
-    if second_part_lower == "n":
-        second_part_lower = "naa-"
+    if command_aliases.get(second_part_lower):
+        second_part_lower = command_aliases.get(second_part_lower)
     if re.compile("^:[0-9]{4,}$").search(message_parts[0]):
         msg_id = int(message_parts[0][1:])
         msg = wrap2.get_message(msg_id)

--- a/chatcommunicate.py
+++ b/chatcommunicate.py
@@ -33,6 +33,7 @@ command_aliases = {
     "n": "naa",
 }
 
+
 def post_message_in_room(room_id_str, msg, length_check=True):
     if room_id_str == GlobalVars.charcoal_room_id:
         GlobalVars.charcoal_hq.send_message(msg, length_check)


### PR DESCRIPTION
This removed multiple `if` checks in `handle_commands` to a check of a dictionary for appropriate substitutions. 

The new dictionary - `command_aliases` - holds the expected command as a key and the substitution in the value.

Currently the entire dictionary looks like this:

```
command_aliases = {
    "f": "fp-",
    "notspam": "fp-",
    "k": "tpu-",
    "spam": "tpu-",
    "rude": "tpu-",
    "abuse": "tpu-",
    "abusive": "tpu-",
    "offensive": "tpu-",
    "n": "naa",
}
```

If no key exists, the single `if` check prevents substituting a `NoneType`. 