### PR TITLE
Decorator fix to return response

### DIFF
--- a/chatcommands.py
+++ b/chatcommands.py
@@ -31,7 +31,9 @@ def check_permissions(function):
             kwargs['wrap2'] = wrap2
             return function(*args, **kwargs)
         else:
-            return False
+            return Response(command_status=False,
+                            message="Permission Denied. See [the Privileges wiki page](" + GlobalVars.bot_repository +
+                                    "/wiki/Privileges) for information on what privileges are and what is expected.")
 
     return run_command
 

--- a/chatcommunicate.py
+++ b/chatcommunicate.py
@@ -132,12 +132,13 @@ def watcher(ev, wrap2):
                                          message_id=message_id)
                 if result.command_status and result.message:
                     reply += result.message + os.linesep
-                if result.message is None:
-                    reply += "<processed without return value>" + os.linesep
-                    amount_none += 1
                 if result.command_status is False:
                     reply += "<unrecognized command>" + os.linesep
                     amount_unrecognized += 1
+                if result.message is None and result.command_status is not False:
+                    reply += "<processed without return value>" + os.linesep
+                    amount_none += 1
+
             else:
                 reply += "<skipped>" + os.linesep
                 amount_skipped += 1

--- a/chatcommunicate.py
+++ b/chatcommunicate.py
@@ -209,7 +209,7 @@ def handle_commands(content_lower, message_parts, ev_room, ev_room_name, ev_user
             'wrap2': wrap2,
         }
         if second_part_lower not in subcmds:
-            return Response(command_status=False, message=None) # Unrecognized subcommand
+            return Response(command_status=False, message=None)  # Unrecognized subcommand
 
         return subcmds[second_part_lower](**subcommand_parameters)
 

--- a/chatcommunicate.py
+++ b/chatcommunicate.py
@@ -208,8 +208,10 @@ def handle_commands(content_lower, message_parts, ev_room, ev_room_name, ev_user
             'second_part_lower': second_part_lower,
             'wrap2': wrap2,
         }
-        if second_part_lower in subcmds:
-            return subcmds[second_part_lower](**subcommand_parameters)
+        if second_part_lower not in subcmds:
+            return Response(command_status=False, message=None) # Unrecognized subcommand
+
+        return subcmds[second_part_lower](**subcommand_parameters)
 
     # Process additional commands
     command_parameters = {

--- a/test/test_chatcommunicate.py
+++ b/test/test_chatcommunicate.py
@@ -182,6 +182,13 @@ def test_privileged_users():
     assert reply_value == "No, you are not a privileged user. See [the Privileges wiki page](//github.com/Charcoal-SE/SmokeDetector/wiki/Privileges) for information on what privileges are and what is expected."
 
 
+def test_unprivileged_denial():
+    event = mock_event("!!/rmwlu http://meta.stackexchange.com/users/237685/hichris123", 1, 11540, "Charcoal HQ", -5, u"Some bot")
+    watcher(event, client.Client())
+    assert reply_value == "Permission Denied. See [the Privileges wiki page](" + GlobalVars.bot_repository +\
+                          "/wiki/Privileges) for information on what privileges are and what is expected."
+
+
 def test_test_command():
     event = mock_event("!!/test", 1, 11540, "Charcoal HQ", 59776, u"Doorknob 冰")
     watcher(event, client.Client())


### PR DESCRIPTION
This changes the decorator from returning a boolean to instead return a Response tuple when a user doesn't have permission to run a command. This change also fixes the subcommands failing if an unknown command is passed

Also included is a unittest to detect the decorator failure in the future