### PR TITLE
+ graspui.com

### DIFF
--- a/findspam.py
+++ b/findspam.py
@@ -316,7 +316,7 @@ class FindSpam:
         "unblockingtwitter\\.com", "openingblockedsite\\.com", "credenceresearch\\.com",
         "arabic(soft)?downloads?\\.com", "braindumpsvalid", "cardsbymellc\\.com",
         "couchsurfing\\.com", "sukere\\.com", "elsner\\.com", "latestphonespec\\.com",
-        "gta5codes\\.fr", "pcsoftpro\\.com", "addium\\.info",
+        "gta5codes\\.fr", "pcsoftpro\\.com", "addium\\.info", "graspui\\.com",
         "fallclassicrun\\.com", "forgrams\\.com", "windowiso\\.com",
         "cloudinsights\\.net", "xtremenitro", "surfmegeek",
         "(premium|priceless)-inkjet\\.com", "meatspin", "techappzone\\.com",


### PR DESCRIPTION
Added `graspui.com` to the blacklist.

See [this](https://metasmoke.erwaysoftware.com/search?utf8=%E2%9C%93&title=&body=graspui.com&username=&why=&site=&feedback=&reason=&user_rep_direction=%3E%3D&user_reputation=0&commit=Search)