### PR TITLE
+ etrove.com.sg

### DIFF
--- a/findspam.py
+++ b/findspam.py
@@ -317,7 +317,7 @@ class FindSpam:
         "arabic(soft)?downloads?\\.com", "braindumpsvalid", "cardsbymellc\\.com",
         "couchsurfing\\.com", "sukere\\.com", "elsner\\.com", "latestphonespec\\.com",
         "gta5codes\\.fr", "pcsoftpro\\.com", "addium\\.info", "graspui\\.com",
-        "fallclassicrun\\.com", "forgrams\\.com", "windowiso\\.com",
+        "fallclassicrun\\.com", "forgrams\\.com", "windowiso\\.com", "etrove\\.com\\.sg",
         "cloudinsights\\.net", "xtremenitro", "surfmegeek",
         "(premium|priceless)-inkjet\\.com", "meatspin", "techappzone\\.com",
         "clusterlinks\\.com", "kizi1000\\.in", "weightruinations\\.com",


### PR DESCRIPTION
Added `etrove.com.sg` to the blacklist. See [this](https://metasmoke.erwaysoftware.com/post/36092) post which was not detected.