### PR TITLE
+ 'death reckoning calculate'

### DIFF
--- a/findspam.py
+++ b/findspam.py
@@ -208,7 +208,7 @@ class FindSpam:
         "kolcak", "Zapyo", "we (offer|give out) (loans|funds|funding)",
         "molvi", "judi bola", "ituBola.com", "lost lover'?s?",
         "rejuvenated skin", "ProBrain", "restore[ -]?samsung[ -]?data",
-        "LifeForce", "swtor2credits", "me2.do",
+        "LifeForce", "swtor2credits", "me2.do", "death reckoning calculate",
         "bam2u", "Neuro(3X|flexyn|fuse|luma|plex)", "TesteroneXL", "Nitroxin",
         "Bowtrol", "Slim ?Genix", "Cleanse EFX", "Alpha ?(Rush|Fuel)",
         "Blackline Elite", "TestCore Pro", "blank(ed)? ?ATM\\b( card)?", "ATM Machine Vault",


### PR DESCRIPTION
A particular user has been spamming maths.se with a post advertising this book. It normally goes like the following: 

> There is  a book death reckoning calculate..... I think.but if you want same precision as a ten digits calculator do for 1 

See:

 - https://metasmoke.erwaysoftware.com/post/36105
 - https://metasmoke.erwaysoftware.com/post/36108
 - https://metasmoke.erwaysoftware.com/post/36107
 - https://metasmoke.erwaysoftware.com/post/36106

I added the words 'death reckoning calculate' to the blacklist of words