### PR TITLE
+ 'more info'

### DIFF
--- a/findspam.py
+++ b/findspam.py
@@ -242,7 +242,7 @@ class FindSpam:
         "male enhancement supplements", "alpha levo", "digital marketing course", "stark trading system",
         "bring back lost lover", "service proposal essay", "enetdocumentation", "okaygoods", "bojiter",
         "dr ?eziza", "(spell(home)?|temple|classes)@gmail\\.com", "viagra", "cialis", "slotobit",
-        "putlocker", "vimax", "(contact|call) us today", "call \\d{3}-\\d{4}-\\d{4}",
+        "putlocker", "vimax", "(contact|call) us today", "call \\d{3}-\\d{4}-\\d{4}", "more info\s?>+"
     ]
     bad_keywords_nwb = [
         u"ಌ", "vashi?k[ae]r[ae]n", "babyli(ss|cious)", "garcinia", "cambogia", "acai ?berr",  # "nwb" == "no word boundary"


### PR DESCRIPTION
Lots of recent spam posts end with "more info>>>[some link](http://example.com)". 
E.g. https://metasmoke.erwaysoftware.com/post/36840