### PR TITLE
+5 new websites to blacklist

### DIFF
--- a/findspam.py
+++ b/findspam.py
@@ -433,7 +433,8 @@ class FindSpam:
         "trickspaid\\.com", "bulksmsclub\\.com", "redbubble\\.com", "joomag\\.com", "bigclasses\\.com",
         "ladybirdco\\.com", "magehit\\.com", "colors34.com", "ultimatewowguide\\.com", "fiverr\\.com/\\w+",
         "shaperich\\.com", "ugccoaching\\.com", "androidpluspc\\.com", "learnit\\.technology", "mastersite\\.com\\.ua",
-        "jobstelangana\\.in", "readyscript\\.ru", "unlock-bootloaderb\\.xyz", "romrootandroid\\.xyz",
+        "jobstelangana\\.in", "readyscript\\.ru", "unlock-bootloaderb\\.xyz", "romrootandroid\\.xyz", "drozforskolin\\.org",
+        "supplementsadvisor\\.org", "pokercheatcenter\\.com", "intelligentadvices\\.com", "yoursbetterhealthsolutions\\.com",
     ]
     # Patterns: the top three lines are the most straightforward, matching any site with this string in domain name
     pattern_websites = [


### PR DESCRIPTION
All of these have been recently used for spamming:

supplementsadvisor.org -> https://metasmoke.erwaysoftware.com/post/37616
pokercheatcenter.com -> https://metasmoke.erwaysoftware.com/post/37614
intelligentadvices.com -> https://metasmoke.erwaysoftware.com/post/37620
yoursbetterhealthsolutions.com  -> https://metasmoke.erwaysoftware.com/post/37621
drozforskolin.org  -> https://metasmoke.erwaysoftware.com/post/37618