### PR TITLE
Added new form of link following 'arrows'

### DIFF
--- a/findspam.py
+++ b/findspam.py
@@ -590,7 +590,7 @@ class FindSpam:
         {'regex': ur"(?i)(bodybuilding|workout|fitness|diet|perfecthealth|muscle|nutrition|prostate)[\w-]*?\.(com|co\.|net|org|info|in\W)", 'all': True,
          'sites': ["fitness.stackexchange.com", "biology.stackexchange.com", "health.stackexchange.com", "skeptics.stackexchange.com", "bicycles.stackexchange.com"], 'reason': "pattern-matching website in {}", 'title': True, 'body': True, 'username': True, 'stripcodeblocks': False, 'body_summary': True, 'max_rep': 4, 'max_score': 2},
         # Links preceded by arrows >>>
-        {'regex': ur"(?is)(>>>|==\s*>>|====|===>|==>>|(Read More|Click Here) \W{2,20}).{0,20}http(?!://i.stack.imgur.com).{0,200}$", 'all': True,
+        {'regex': ur"(?is)(>>>|==\s*>>|====|===>|==>>|= = =|(Read More|Click Here) \W{2,20}).{0,20}http(?!://i.stack.imgur.com).{0,200}$", 'all': True,
          'sites': [], 'reason': "link following arrow in {}", 'title': True, 'body': True, 'username': True, 'stripcodeblocks': True, 'body_summary': False, 'answers': False, 'max_rep': 11, 'max_score': 0},
         # Link at the end of question, selected sites
         {'method': link_at_end, 'all': False,


### PR DESCRIPTION
See https://metasmoke.erwaysoftware.com/post/38183

The 'link following arrow' reason will now catch stuff like `Read more = = = http://www.spam.com`

Yes, I know, it's techinically *not* an arrow, but it fits the general concept of this reason.