### PR TITLE
Stop versioning config.

### DIFF
--- a/config
+++ b/config
@@ -1,4 +1,0 @@
-[Config]
-location=location_here
-
-metasmoke_host=http://127.0.0.1:3000

--- a/config.sample
+++ b/config.sample
@@ -1,3 +1,4 @@
+# Copy this to a new file named `config`
 [Config]
 location=location_here
 


### PR DESCRIPTION
The `config` file was in `.gitignore` but still under version control.
That could cause unintended adding and commiting a change in `config`,
which, having been merged into master, would lead to merge conflicts
on next pull for everybody who changed their own `config`.

Added an explicit instruction in `config.sample` about copying its
contents to a new `config` file.