### PR TITLE
Added 000webhost.com

### DIFF
--- a/findspam.py
+++ b/findspam.py
@@ -444,7 +444,7 @@ class FindSpam:
         "makehimmine\\.com\\.au", "shopicheck\\.com", "hivimoore\\.com", "blogmium\\.com", "soundmagic\\.us",
         "onlinecorrection\\.com", "dragracerv3game\\.com", "bananakong\\.net", "himzakaz\\.net", "dropcrack\\.com",
         "raybiztech\\.com", "cegonsoft\\.com", "technomaniya\\.com", "instantassignmenthelp\\.com\\.au", "huintech\\.com",
-        "dramaonline\\.pk", "gamingustaad\\.com",
+        "dramaonline\\.pk", "gamingustaad\\.com", " 000webhost\\.com",
     ]
     # Patterns: the top three lines are the most straightforward, matching any site with this string in domain name
     pattern_websites = [


### PR DESCRIPTION
See https://metasmoke.erwaysoftware.com/post/41397

Note: [this Metasmoke search](https://metasmoke.erwaysoftware.com/search?utf8=%E2%9C%93&title=&body=000webhost&username=&why=&site=&feedback=&reason=&user_rep_direction=%3E%3D&user_reputation=0&commit=Search) returns mixed results. See [chat](http://chat.stackexchange.com/transcript/message/32527710#32527710).