### PR TITLE
Added zenpromo.com

### DIFF
--- a/findspam.py
+++ b/findspam.py
@@ -449,7 +449,7 @@ class FindSpam:
         "onlinecorrection\\.com", "dragracerv3game\\.com", "bananakong\\.net", "himzakaz\\.net", "dropcrack\\.com",
         "raybiztech\\.com", "cegonsoft\\.com", "technomaniya\\.com", "instantassignmenthelp\\.com\\.au", "huintech\\.com",
         "dramaonline\\.pk", "gamingustaad\\.com", "carding-wutransfer\\.com", "nulife\\.co\\.in", "fixmyprinter\\.com",
-        "iseepassword\\.com", "samedaypros\\.com",
+        "iseepassword\\.com", "samedaypros\\.com", "zen-promo\\.com",
     ]
     # Patterns: the top three lines are the most straightforward, matching any site with this string in domain name
     pattern_websites = [


### PR DESCRIPTION
See [Metasmoke search](https://metasmoke.erwaysoftware.com/search?utf8=%E2%9C%93&title=&body=zen-promo&username=&why=&site=&feedback=&reason=&user_rep_direction=%3E%3D&user_reputation=0&commit=Search). Could only be caught manually.