### PR TITLE
-raspi.se from LAE of answer

### DIFF
--- a/findspam.py
+++ b/findspam.py
@@ -435,7 +435,7 @@ class FindSpam:
          'sites': ["superuser.com", "askubuntu.com", "drupal.stackexchange.com", "meta.stackexchange.com", "security.stackexchange.com", "patents.stackexchange.com", "money.stackexchange.com", "gaming.stackexchange.com", "arduino.stackexchange.com", "workplace.stackexchange.com"], 'reason': 'link at end of {}', 'title': False, 'body': True, 'username': False, 'stripcodeblocks': False, 'body_summary': False, 'answers': False, 'max_rep': 1, 'max_score': 0},
         # Link at the end of a short answer
         {'regex': ur'(?is)^.{0,350}<a href="https?://(?:(?:www\.)?[\w-]+\.(?:blogspot\.|wordpress\.|co\.)?\w{2,4}/?\w{0,2}/?|(?:plus\.google|www\.facebook)\.com/[\w/]+)"[^<]*</a>(?:</strong>)?\W*</p>\s*$|\[/url\]\W*</p>\s*$', 'all': True,
-         'sites': [], 'reason': 'link at end of {}', 'title': False, 'body': True, 'username': False, 'stripcodeblocks': False, 'body_summary': False, 'questions': False, 'max_rep': 1, 'max_score': 0},
+         'sites': ["raspberrypi.stackexchange.com"], 'reason': 'link at end of {}', 'title': False, 'body': True, 'username': False, 'stripcodeblocks': False, 'body_summary': False, 'questions': False, 'max_rep': 1, 'max_score': 0},
         # Link with "thanks for sharing" or a similar phrase in a short answer
         {'method': keyword_link, 'all': True,
          'sites': [], 'reason': 'bad keyword with a link in {}', 'title': False, 'body': True, 'username': False, 'stripcodeblocks': False, 'body_summary': False, 'questions': False, 'max_rep': 1, 'max_score': 0},


### PR DESCRIPTION
I just made the astonishing discovery that we have a 50% false positive rate on RaspberryPi.SE. I had a look at all of the false positives, and reasoned that an easy way to fix that in the future would be to disable the link at end of answer reason for that site.

The current stats are 4fp/1naa/3tp. See [here](https://metasmoke.erwaysoftware.com/search?utf8=%E2%9C%93&title=&body=&username=&why=&site=164&feedback=&reason=73&user_rep_direction=%3E%3D&user_reputation=0&commit=Search) for more info.  

Your thoughts?

(ignore the CI, it's been failing ever since the new blacklist changes)