### PR TITLE
Added "datagharch.com" to blacklisted Websites

### DIFF
--- a/blacklisted_websites.txt
+++ b/blacklisted_websites.txt
@@ -715,6 +715,7 @@ rumahminimalisok\.com
 ceramicdirectory\.com
 yioplayer\.com
 caracepatmengobatimiomblog\.wordpress\.com
+datagharch\.com
 
 awesomespam\.spammyspam\d.spam
 thisis.aspammydomain\dname\.com


### PR DESCRIPTION
Appeared in 10 confirmed TP reports and is currently not caught by any filter on its own.

https://metasmoke.erwaysoftware.com/search?utf8=%E2%9C%93&title=&body=datagharch&username=&why=&site=&feedback=&reason=&user_rep_direction=%3E%3D&user_reputation=0&commit=Search