### PR TITLE
Adding offersreviews.org to blacklist after 7 TPs and no detection

### DIFF
--- a/blacklisted_websites.txt
+++ b/blacklisted_websites.txt
@@ -726,3 +726,4 @@ kikguru\.com
 disruptivei\.com
 wufoo\.com
 pureways\.ca
+offersreviews\.org


### PR DESCRIPTION
https://metasmoke.erwaysoftware.com/search?utf8=%E2%9C%93&title=&body=offersreviews.org&username=&why=&site=&feedback=&reason=&user_rep_direction=%3E%3D&user_reputation=0&commit=Search