### PR TITLE
Add the ability to give tea to someone else

### DIFF
--- a/chatcommands.py
+++ b/chatcommands.py
@@ -283,7 +283,12 @@ def command_coffee(ev_user_name, *args, **kwargs):
     :param kwargs: No additional arguments expected
     :return: A string
     """
-    return Response(command_status=True, message=u"*brews coffee for @" + ev_user_name.replace(" ", "") + "*")
+    if message_parts and message_parts[0]:  # list not empty and string not empty
+        # in case they decided to ping the person there, too:
+        giving_to = message_parts[0][1:] if message_parts[0][0] == "@" else  message_parts[0]
+    else:
+        giving_to = ev_user_name.replace(" ", "")
+    return Response(command_status=True, message=u"*brews coffee for @{user}*".format(user=giving_to))
 
 
 def command_lick(*args, **kwargs):

--- a/chatcommands.py
+++ b/chatcommands.py
@@ -294,18 +294,22 @@ def command_lick(*args, **kwargs):
     return Response(command_status=True, message="*licks ice cream cone*")
 
 
-def command_tea(ev_user_name, *args, **kwargs):
+def command_tea(ev_user_name, message_parts, *args, **kwargs):
     """
     Returns a string stating who the tea is for (This is a joke command)
     :param ev_user_name:
     :param kwargs: No additional arguments expected
     :return: A string
     """
+    if message_parts and message_parts[0]:  # list not empty and string not empty
+        giving_to = message_parts[0][1:] if message_parts[0][0] == "@" else  message_parts[0]
+    else:
+        giving_to = ev_user_name.replace(" ", "")
     return Response(command_status=True,
                     message=u"*brews a cup of {choice} tea for @{user}*".format(
-                        choice=random.choice(['earl grey', 'green', 'chamomile',
+                        choice=random.choice(['earl grey', 'green', 'chamomile', 'Southern sweet',
                                               'lemon', 'darjeeling', 'mint', 'jasmine']),
-                        user=ev_user_name.replace(" ", "")))
+                        user=giving_to))
 
 
 def command_wut(*args, **kwargs):


### PR DESCRIPTION
*I'm not totally sure I got the syntax right, though.*

Exactly what the title says: Before, you could only give yourself tea with !!/tea. Now, you can give someone else tea. Also applies to coffee, fancy that. For example, this exchange might happen:

> QPaysTaxes: !!/tea @Olaf
> SmokeDetector: ↳@QPaysTaxes *brews a cup of Southern sweet tea for @Olaf*

Is this needed? No. Does it solve any problem? No. But hey, it's not like it interferes with core functionality, and I'm _pretty_ sure it works. 