### PR TITLE
Blacklisting serverbasket.com

### DIFF
--- a/blacklisted_websites.txt
+++ b/blacklisted_websites.txt
@@ -729,3 +729,4 @@ long-path-eraser
 capstonehigh\.com
 uflysoft\.com
 sea59\.com
+serverbasket\.com


### PR DESCRIPTION
Used twice in known spam, not currently caught. Last occurence wasn't caught at all.

https://metasmoke.erwaysoftware.com/search?utf8=%E2%9C%93&title=&body=serverbasket.com&username=&why=&site=&feedback=&reason=&user_rep_direction=%3E%3D&user_reputation=0&commit=Search