### PR TITLE
Blacklisting usadrugguide.com

### DIFF
--- a/blacklisted_websites.txt
+++ b/blacklisted_websites.txt
@@ -730,3 +730,4 @@ whizzsystems\.com
 diwaligiftz\.com
 letstrick\.com
 ideaflix\.com
+usadrugguide\.com


### PR DESCRIPTION
Not currently caught as pattern matching, bad keyword or blacklisted website. 

8 tp occurences in the past month: 

https://metasmoke.erwaysoftware.com/search?utf8=%E2%9C%93&title=&body=usadrugguide.com&username=&why=&site=&feedback=&reason=&user_rep_direction=%3E%3D&user_reputation=0&commit=Search