### PR TITLE
Migrate Smokey user IDs to config

### DIFF
--- a/config.ci
+++ b/config.ci
@@ -8,6 +8,12 @@ location=Continuous Integration. If you're seeing this, create a config file wit
 # Set metasmoke_key if Smokey isn't running on the same machine (localhost)
 # that metasmoke is
 # metasmoke_key=gibberish_here
+ 
+# Set Smokey user IDs
+# Leave as default values for the normal smokey user
+charcoal_id=120914
+meta_tavern_id=266345
+socvr_id=3735529
 
 # Set GitHub keys
 # github_username=username@domain.com

--- a/config.sample
+++ b/config.sample
@@ -9,6 +9,12 @@ location=location_here
 # that metasmoke is
 # metasmoke_key=gibberish_here
 
+# Set Smokey user IDs
+# Leave as default values for the normal smokey user
+charcoal_id=120914
+meta_tavern_id=266345
+socvr_id=3735529
+
 # Set GitHub keys
 # github_username=username@domain.com
 # github_password=p@55w0rd

--- a/globalvars.py
+++ b/globalvars.py
@@ -245,6 +245,16 @@ class GlobalVars:
 
     code_privileged_users = None
 
+    try:
+        smokeDetector_user_id = {charcoal_room_id: config.get("Config", "charcoal_id"),
+                                 meta_tavern_room_id: config.get("Config", "meta_tavern_id"),
+                                 socvr_room_id: config.get("Config", "socvr_id")}
+    except ConfigParser.NoOptionError:
+        smokeDetector_user_id = {charcoal_room_id: "120914",
+                                 meta_tavern_room_id: "266345",
+                                 socvr_room_id: "3735529"}
+        print "No SmokeDetector user IDs found, using default values"
+
     smokeDetector_user_id = {charcoal_room_id: "120914", meta_tavern_room_id: "266345",
                              socvr_room_id: "3735529"}
 

--- a/globalvars.py
+++ b/globalvars.py
@@ -239,24 +239,11 @@ class GlobalVars:
             "4875631",  # FrankerZ
             "2958086",  # Compass
             "499214",   # JanDvorak
-            "5647260"  # Andrew L.
+            "5647260"   # Andrew L.
         ]
     }
 
     code_privileged_users = None
-
-    try:
-        smokeDetector_user_id = {charcoal_room_id: config.get("Config", "charcoal_id"),
-                                 meta_tavern_room_id: config.get("Config", "meta_tavern_id"),
-                                 socvr_room_id: config.get("Config", "socvr_id")}
-    except ConfigParser.NoOptionError:
-        smokeDetector_user_id = {charcoal_room_id: "120914",
-                                 meta_tavern_room_id: "266345",
-                                 socvr_room_id: "3735529"}
-        print "No SmokeDetector user IDs found, using default values"
-
-    smokeDetector_user_id = {charcoal_room_id: "120914", meta_tavern_room_id: "266345",
-                             socvr_room_id: "3735529"}
 
     censored_committer_names = {"3f4ed0f38df010ce300dba362fa63a62": "Undo1"}
 
@@ -306,6 +293,16 @@ class GlobalVars:
 
     location = config.get("Config", "location")
     print location
+
+    try:
+        smokeDetector_user_id = {charcoal_room_id: config.get("Config", "charcoal_id"),
+                                 meta_tavern_room_id: config.get("Config", "meta_tavern_id"),
+                                 socvr_room_id: config.get("Config", "socvr_id")}
+    except ConfigParser.NoOptionError:
+        smokeDetector_user_id = {charcoal_room_id: "120914",
+                                 meta_tavern_room_id: "266345",
+                                 socvr_room_id: "3735529"}
+        print "No SmokeDetector user IDs found, using default values"
 
     metasmoke_ws = None
 


### PR DESCRIPTION
If I want to run Smokey under my own account (or a sock), I need to change the user IDs [here](https://github.com/Charcoal-SE/SmokeDetector/blob/master/globalvars.py#L248). However, if I do that, I can no longer pull from this repository via chat without fixing merge conflicts every time, as `globalvars.py` is version controlled.

There are three possible ways to deal with this:
 - Edit the upstream repository to use my user ID, however that would break the official bot (bad idea)
 - Continue to put up with the merge conflicts
 - Transfer user IDs to the config file, which is not version controlled. This is what I have done for this PR.

I have gone ahead and set up this change in a new branch, so it is ready to go if everyone agrees with me. But I will leave it to @ArtOfCode- to merge the PR, so that he can update the config files on his two smokey setups to make this work.