### PR TITLE
Temporarily disabled the recovery message system

### DIFF
--- a/ws.py
+++ b/ws.py
@@ -202,7 +202,8 @@ while True:
             os._exit(4)
         ws = websocket.create_connection("ws://qa.sockets.stackexchange.com/")
         ws.send("155-questions-active")
-        # GlobalVars.charcoal_hq.send_message("Recovered from `" + exception_only + "`")
+        if exception_only != "WebSocketConnectionClosedException: Connection is already closed."
+            GlobalVars.charcoal_hq.send_message("Recovered from `" + exception_only + "`")
 
 now = datetime.utcnow()
 delta = UtcDate.startup_utc_date - now

--- a/ws.py
+++ b/ws.py
@@ -202,7 +202,7 @@ while True:
             os._exit(4)
         ws = websocket.create_connection("ws://qa.sockets.stackexchange.com/")
         ws.send("155-questions-active")
-        #GlobalVars.charcoal_hq.send_message("Recovered from `" + exception_only + "`")
+        # GlobalVars.charcoal_hq.send_message("Recovered from `" + exception_only + "`")
 
 now = datetime.utcnow()
 delta = UtcDate.startup_utc_date - now

--- a/ws.py
+++ b/ws.py
@@ -202,7 +202,7 @@ while True:
             os._exit(4)
         ws = websocket.create_connection("ws://qa.sockets.stackexchange.com/")
         ws.send("155-questions-active")
-        if exception_only != "WebSocketConnectionClosedException: Connection is already closed."
+        if exception_only != "WebSocketConnectionClosedException: Connection is already closed.":
             GlobalVars.charcoal_hq.send_message("Recovered from `" + exception_only + "`")
 
 now = datetime.utcnow()

--- a/ws.py
+++ b/ws.py
@@ -202,7 +202,7 @@ while True:
             os._exit(4)
         ws = websocket.create_connection("ws://qa.sockets.stackexchange.com/")
         ws.send("155-questions-active")
-        GlobalVars.charcoal_hq.send_message("Recovered from `" + exception_only + "`")
+        #GlobalVars.charcoal_hq.send_message("Recovered from `" + exception_only + "`")
 
 now = datetime.utcnow()
 delta = UtcDate.startup_utc_date - now


### PR DESCRIPTION
Something with websockets is broken and until that can be fixed, I propose disabling the error reporter because [it spams Charcoal HQ](http://chat.stackexchange.com/transcript/message/33551921#33551921).