### PR TITLE
Blacklisted "molvi ji"

### DIFF
--- a/bad_keywords.txt
+++ b/bad_keywords.txt
@@ -1,4 +1,4 @@
-baba ji
+(baba|molvi) ji
 fifa.{0,20}coins?
 fifabay
 Long ?Path ?Tool


### PR DESCRIPTION
I just noticed that there are spam posts containing the string `molvi ji` as well as `baba ji` (case insensitive).

[Exhibits](https://metasmoke.erwaysoftware.com/reason/67)