### PR TITLE
Make findspam.FindSpam load the blacklisted username regex from a separate file instead of having it hardcoded

### DIFF
--- a/blacklisted_usernames.txt
+++ b/blacklisted_usernames.txt
@@ -1,0 +1,12 @@
+^l(?:ol){2,}$
+^troll$
+tejveer ?iq
+ser?vice pemanas?
+\bnigg[aeu][rh]?
+\b(fuck(er|ing)?|penis)\b
+^w.ng.?d.ng$
+dlqudals
+^[a-z ]+juri(?:n|na|ns|sa|ya|yam|ym)$
+^[a-z]+jiibond$
+Marlin Woods
+xiguai

--- a/findspam.py
+++ b/findspam.py
@@ -227,7 +227,7 @@ class FindSpam:
 
     with open("blacklisted_websites.txt", "r") as f:
         blacklisted_websites = [line.rstrip() for line in f if len(line.rstrip()) > 0]
-        
+
     with open("blacklisted_usernames.txt", "Ur") as f:
         blacklisted_usernames = [line.rstrip() for line in f if len(line.rstrip()) > 0]
 

--- a/findspam.py
+++ b/findspam.py
@@ -228,7 +228,7 @@ class FindSpam:
     with open("blacklisted_websites.txt", "r") as f:
         blacklisted_websites = [line.rstrip() for line in f if len(line.rstrip()) > 0]
         
-    with open("blacklisted_usernames.txt", "ur") as f:
+    with open("blacklisted_usernames.txt", "Ur") as f:
         blacklisted_usernames = [line.rstrip() for line in f if len(line.rstrip()) > 0]
 
     # Patterns: the top three lines are the most straightforward, matching any site with this string in domain name

--- a/findspam.py
+++ b/findspam.py
@@ -227,6 +227,9 @@ class FindSpam:
 
     with open("blacklisted_websites.txt", "r") as f:
         blacklisted_websites = [line.rstrip() for line in f if len(line.rstrip()) > 0]
+        
+    with open("blacklisted_usernames.txt", "ur") as f:
+        blacklisted_usernames = [line.rstrip() for line in f if len(line.rstrip()) > 0]
 
     # Patterns: the top three lines are the most straightforward, matching any site with this string in domain name
     pattern_websites = [
@@ -467,7 +470,7 @@ class FindSpam:
         #
         # Category: other
         # Blacklisted usernames
-        {'regex': ur"(?i)(^l(?:ol){2,}$|^troll$|tejveer ?iq|ser?vice pemanas?|\bnigg[aeu][rh]?|\b(fuck(er|ing)?|penis)\b|^w.ng.?d.ng$|dlqudals|^[a-z ]+juri(?:n|na|ns|sa|ya|yam|ym)$|^[a-z]+jiibond$|Marlin Woods|xiguai)", 'all': True, 'sites': [], 'reason': "blacklisted username", 'title': False, 'body': False, 'username': True, 'stripcodeblocks': False, 'body_summary': False, 'max_rep': 1, 'max_score': 0},
+        {'regex': ur"(?i)({})".format("|".join(blacklisted_usernames)), 'all': True, 'sites': [], 'reason': "blacklisted username", 'title': False, 'body': False, 'username': True, 'stripcodeblocks': False, 'body_summary': False, 'max_rep': 1, 'max_score': 0},
         {'regex': u"(?i)^jeff$", 'all': False, 'sites': ["parenting.stackexchange.com"], 'reason': "blacklisted username", 'title': False, 'body': False, 'username': True, 'stripcodeblocks': False, 'body_summary': False, 'max_rep': 1, 'max_score': 0}
     ]
 


### PR DESCRIPTION
In [this reply](https://github.com/Charcoal-SE/SmokeDetector/issues/305#issuecomment-262158807) to #305, bwDraco suggested that we should implement `!!/blacklist-username` as well as `!!/blacklist-keyword` and `!!/blacklist-website`.

To do that, we have to do the following (assuming we want to keep the format of the username blacklist consistent with the website blacklist and bad keywords):

1. Export the username blacklist to its own text file
2. Make [findspam.FindSpam](https://github.com/Charcoal-SE/SmokeDetector/blob/master/findspam.py#L201) use that text file instead of a hardcoded regex to figure out which usernames are blacklisted
3. Add the `!!/blacklist-username` command

Since 1 and 2 mess with parts that require no interaction with users, I decided to do them and leave the username blacklister to those who actually know Python.