### PR TITLE
Detect misleading link text

### DIFF
--- a/findspam.py
+++ b/findspam.py
@@ -177,17 +177,14 @@ def bad_link_text(s, site):   # suspicious text of a hyperlink
 
 def misleading_link(s, site):   # misleading links like [https://github.com/Charcoal-SE/SmokeDetector](https://spam.com)
     links = regex.compile(ur'<a href="([^"]*)" rel="nofollow(?: noreferrer)?">\s*([^<\s]*)(?=\s*</a>)', regex.UNICODE).findall(s)
-
     for (link, text) in links:
-        if '.' not in text: 
+        if '.' not in text:
             continue        # skip link text that doesn't contain a period
 
         linkHost = urlparse(link).netloc
         textHost = urlparse(text).netloc
-
         if textHost != '' and textHost != linkHost:
             return True, "Misleading link text *{}* to *{}*".format(text, link)
-
 
     return False, ""
 

--- a/findspam.py
+++ b/findspam.py
@@ -175,17 +175,20 @@ def bad_link_text(s, site):   # suspicious text of a hyperlink
     return False, ""
 
 
-def misleading_link(s, site): # misleading links like [https://github.com/Charcoal-SE/SmokeDetector](https://spam.com)
+def misleading_link(s, site):   # misleading links like [https://github.com/Charcoal-SE/SmokeDetector](https://spam.com)
     links = regex.compile(ur'<a href="([^"]*)" rel="nofollow(?: noreferrer)?">\s*([^<\s]*)(?=\s*</a>)', regex.UNICODE).findall(s)
-    
+
     for (link, text) in links:
-        if '.' not in text: continue        # skip link text that doesn't contain a period
+        if '.' not in text: 
+            continue        # skip link text that doesn't contain a period
+
         linkHost = urlparse(link).netloc
         textHost = urlparse(text).netloc
-        
+
         if textHost != '' and textHost != linkHost:
             return True, "Misleading link text *{}* to *{}*".format(text, link)
-        
+
+
     return False, ""
 
 

--- a/findspam.py
+++ b/findspam.py
@@ -174,6 +174,20 @@ def bad_link_text(s, site):   # suspicious text of a hyperlink
     return False, ""
 
 
+def misleading_link(s, site): # misleading links like [https://github.com/Charcoal-SE/SmokeDetector](https://spam.com)
+    links = regex.compile(ur'<a href="([^"]*)" rel="nofollow(?: noreferrer)?">\s*([^<\s]*)(?=\s*</a>)', regex.UNICODE).findall(s)
+    
+    for (link, text) in links:
+        if '.' not in text: continue        # skip link text that doesn't contain a period
+        linkHost = urlparse(link).netloc
+        textHost = urlparse(text).netloc
+        
+        if textHost != '' and textHost != linkHost:
+            return True, "Misleading link text *{}* to *{}*".format(text, link)
+        
+    return False, ""
+
+
 def is_offensive_post(s, site):
     if s is None or len(s) == 0:
         return False, ""
@@ -414,6 +428,9 @@ class FindSpam:
         # Link text consists of punctuation, answers only
         {'regex': ur'(?iu)rel="nofollow( noreferrer)?">\W</a>', 'all': True,
          'sites': [], 'reason': 'linked punctuation in {}', 'title': False, 'body': True, 'username': False, 'stripcodeblocks': True, 'body_summary': False, 'questions': False, 'max_rep': 11, 'max_score': 1},
+        # Link text is misleading (like [https://github.com/Charcoal-SE/SmokeDetector](https://spam.com))
+        {'method': misleading_link, 'all': True,
+         'sites': [], 'reason': 'misleading link in {}', 'title': False, 'body': True, 'username': False, 'stripcodeblocks': True, 'body_summary': False, 'max_rep': 11, 'max_score': 1},
         # URL in title, some sites are exempt
         {'regex': ur"(?i)https?://(?!(www\.)?(example|domain)\.(com|net|org))[a-zA-Z0-9_.-]+\.[a-zA-Z]{2,4}|\w{3,}\.(com|net)\b.*\w{3,}\.(com|net)\b", 'all': True,
          'sites': ["stackoverflow.com", "pt.stackoverflow.com", "ru.stackoverflow.com", "es.stackoverflow.com", "ja.stackoverflow.com", "superuser.com", "askubuntu.com", "serverfault.com", "unix.stackexchange.com", "webmasters.stackexchange.com"], 'reason': "URL in title", 'title': True, 'body': False, 'username': False, 'stripcodeblocks': False, 'body_summary': False, 'max_rep': 11, 'max_score': 0},

--- a/findspam.py
+++ b/findspam.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import regex
 import phonenumbers
+from urlparse import urlparse
 
 
 def has_repeated_words(s, site):


### PR DESCRIPTION
Check for misleading link text which appears to go to one site but instead links to another, for example [https://github.com/Charcoal-SE/SmokeDetector](https://www.youtube.com/watch?v=dQw4w9WgXcQ).

I'm not a regular expression expert and this is my first time contributing anything like this to Smokey, so please review the code before merging -- I might have made a big mistake.