### PR TITLE
allow "www" in the misleading link filter

### DIFF
--- a/findspam.py
+++ b/findspam.py
@@ -183,8 +183,12 @@ def misleading_link(s, site):   # misleading links like [https://github.com/Char
 
         link_host = urlparse(link).netloc
         text_host = urlparse(text).netloc
-        if text_host != '' and text_host != link_host and link_host != 'rads.stackoverflow.com':
-            return True, "Misleading link text *{}* to *{}*".format(text, link)
+        if (text_host != '' and
+            text_host != link_host and
+            link_host != 'rads.stackoverflow.com' and
+            "www." + text_host != link_host and
+            "www." + link_host != text_host):
+                return True, "Misleading link text *{}* to *{}*".format(text, link)
 
     return False, ""
 

--- a/findspam.py
+++ b/findspam.py
@@ -184,10 +184,10 @@ def misleading_link(s, site):   # misleading links like [https://github.com/Char
         link_host = urlparse(link).netloc
         text_host = urlparse(text).netloc
         if (text_host != '' and
-            text_host != link_host and
-            link_host != 'rads.stackoverflow.com' and
-            "www." + text_host != link_host and
-            "www." + link_host != text_host):
+                text_host != link_host and
+                link_host != 'rads.stackoverflow.com' and
+                "www." + text_host != link_host and
+                "www." + link_host != text_host):
             return True, "Misleading link text *{}* to *{}*".format(text, link)
 
     return False, ""

--- a/findspam.py
+++ b/findspam.py
@@ -188,7 +188,7 @@ def misleading_link(s, site):   # misleading links like [https://github.com/Char
             link_host != 'rads.stackoverflow.com' and
             "www." + text_host != link_host and
             "www." + link_host != text_host):
-                return True, "Misleading link text *{}* to *{}*".format(text, link)
+            return True, "Misleading link text *{}* to *{}*".format(text, link)
 
     return False, ""
 


### PR DESCRIPTION
The misleading link filter caught a post because that post linked to `http://example.com` but with the link text `http://www.example.com`.  I added a check for that in `misleading_link`.

Hopefully I can pass `flake8` this time...