### PR TITLE
Add checks to misleading link filter

### DIFF
--- a/findspam.py
+++ b/findspam.py
@@ -187,7 +187,13 @@ def misleading_link(s, site):   # misleading links like [https://github.com/Char
                 text_host != link_host and
                 link_host != 'rads.stackoverflow.com' and
                 "www." + text_host != link_host and
-                "www." + link_host != text_host):
+                "www." + link_host != text_host and
+                "." in text_host and
+                "." in link_host and
+                not " " in text_host.strip() and
+                not " " in link_host.strip() and
+                not "//http" in text_host and
+                not "//http" in link_host):
             return True, "Misleading link text *{}* to *{}*".format(text, link)
 
     return False, ""

--- a/findspam.py
+++ b/findspam.py
@@ -190,10 +190,10 @@ def misleading_link(s, site):   # misleading links like [https://github.com/Char
                 "www." + link_host != text_host and
                 "." in text_host and
                 "." in link_host and
-                not " " in text_host.strip() and
-                not " " in link_host.strip() and
-                not "//http" in text_host and
-                not "//http" in link_host):
+                " " not in text_host.strip() and
+                " " not in link_host.strip() and
+                "//http" not in text_host and
+                "//http" not in link_host):
             return True, "Misleading link text *{}* to *{}*".format(text, link)
 
     return False, ""


### PR DESCRIPTION
I added checks to the misleading link filter so that it will not report posts unless both the link and the link text:
- Contain a period.
- Do not contain a space that is not leading or trailing.
- Do not contain things like "http://https://."