### PR TITLE
Improve the no-word-boundary bad keyword that catches wingding

### DIFF
--- a/findspam.py
+++ b/findspam.py
@@ -247,7 +247,7 @@ class FindSpam:
         u"Ｃ[Ｏ|0]Ｍ", "ecoflex", "no2factor", "no2blast", "sunergetic", "capilux", "sante ?avis",
         "enduros", "dianabol", "ICQ#?\d{4}-?\d{5}", "3073598075", "lumieres", "viarex", "revimax",
         "celluria", "viatropin", "(meg|test)adrox", "nordic ?loan ?firm", "safflower",
-        "(essay|resume|article|dissertation|thesis) ?writing ?service", "satta ?matka", "bojiter"
+        "(essay|resume|article|dissertation|thesis) ?writing ?service", "satta ?matka", "b.?o.?j.?i.?t.?e.?r"
     ]
 
     with open("blacklisted_websites.txt", "r") as f:


### PR DESCRIPTION
[wingding just found out how to circumvent the bad keyword filter.](https://metasmoke.erwaysoftware.com/post/49416) This could be caught by the bad keyword filter if each letter of the regex `bojiter` was separated by a `.?`.

(P.S ignore the merge commit, that was me updating my Smokey fork)