### PR TITLE
Better-handle invalid GH replies when creating pull requests

### DIFF
--- a/gitmanager.py
+++ b/gitmanager.py
@@ -86,7 +86,7 @@ class GitManager:
                     return (False, "Something is wrong with the GH credentials, tell someone to check the GH credentials.")
                 else:
                     # Capture any other invalid response cases.
-                    return (False, "A bad or invalid response was received from GH, please check the error logs for more information.")
+                    return (False, "A bad or invalid reply was received from GH, the message was: %s" % response.json()['message'])
 
         git.checkout(current_commit)  # Return to old commit to await CI. This will make Smokey think it's in reverted mode if it restarts
 

--- a/gitmanager.py
+++ b/gitmanager.py
@@ -77,7 +77,16 @@ class GitManager:
                        "base": "master"}
             response = requests.post("https://api.github.com/repos/Charcoal-SE/SmokeDetector/pulls", auth=HTTPBasicAuth(GlobalVars.github_username, GlobalVars.github_password), data=json.dumps(payload))
             print(response.json())
-            return (True, "You don't have code privileges, but I've [created a pull request for you]({0}).".format(response.json()["html_url"]))
+            try:
+                return (True, "You don't have code privileges, but I've [created a pull request for you]({0}).".format(response.json()["html_url"]))
+            except KeyError:
+                # Error capture/checking for any "invalid" GH reply without an 'html_url' item, which will throw a KeyError.
+                if "Bad credentials" in str(response.json()['message']):
+                    # Capture the case when GH credentials are bad or invalid
+                    return (False, "Something is wrong with the GH credentials, tell someone to check the GH credentials.")
+                else:
+                    # Capture any other invalid response cases.
+                    return (False, "A bad or invalid response was received from GH, please check the error logs for more information.")
 
         git.checkout(current_commit)  # Return to old commit to await CI. This will make Smokey think it's in reverted mode if it restarts
 


### PR DESCRIPTION
We have a case here which we ran into today, where an attempt to create a pull request was returning an "Bad credentials" response from GitHub, without the `html_url` key in the JSON reply.  This was throwing a `KeyError` type error without any useful error output.

This change here attempts to capture such invalid replies, and throw a more useful error message as its return value, rather than just flat out crash and burn.