### PR TITLE
Removed 'faasoft' from blacklisted websites

### DIFF
--- a/blacklisted_websites.txt
+++ b/blacklisted_websites.txt
@@ -60,7 +60,6 @@ trustessaywriting
 thesispaperwriters
 homeworkhelponline
 trustmyessay
-faasoft
 besttvshows
 mytechlabs
 Housecarbike\.com


### PR DESCRIPTION
I saw that there were only [five hits](https://metasmoke.erwaysoftware.com/search?utf8=%E2%9C%93&title=&body=faasoft&username=&why=&site=&feedback=&reason=&user_rep_direction=%3E%3D&user_reputation=0&commit=Search) for "faasoft" and they were all false positives, but there isn't any command to remove a blacklisted site, so I figure this was the best way to do it. ¯\_(ツ)_/¯