### PR TITLE
remove misleading link filter

### DIFF
--- a/findspam.py
+++ b/findspam.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 import regex
 import phonenumbers
-from urlparse import urlparse
 
 
 def has_repeated_words(s, site):

--- a/findspam.py
+++ b/findspam.py
@@ -175,30 +175,6 @@ def bad_link_text(s, site):   # suspicious text of a hyperlink
     return False, ""
 
 
-def misleading_link(s, site):   # misleading links like [https://github.com/Charcoal-SE/SmokeDetector](https://spam.com)
-    links = regex.compile(ur'<a href="([^"]*)" rel="nofollow(?: noreferrer)?">\s*([^<\s]*)(?=\s*</a>)', regex.UNICODE).findall(s)
-    for (link, text) in links:
-        if '.' not in text:
-            continue        # skip link text that doesn't contain a period
-
-        link_host = urlparse(link).netloc
-        text_host = urlparse(text).netloc
-        if (text_host != '' and
-                text_host != link_host and
-                link_host != 'rads.stackoverflow.com' and
-                "www." + text_host != link_host and
-                "www." + link_host != text_host and
-                "." in text_host and
-                "." in link_host and
-                " " not in text_host.strip() and
-                " " not in link_host.strip() and
-                "//http" not in text_host and
-                "//http" not in link_host):
-            return True, "Misleading link text *{}* to *{}*".format(text, link)
-
-    return False, ""
-
-
 def is_offensive_post(s, site):
     if s is None or len(s) == 0:
         return False, ""
@@ -443,9 +419,6 @@ class FindSpam:
         # Link text consists of punctuation, answers only
         {'regex': ur'(?iu)rel="nofollow( noreferrer)?">\W</a>', 'all': True,
          'sites': [], 'reason': 'linked punctuation in {}', 'title': False, 'body': True, 'username': False, 'stripcodeblocks': True, 'body_summary': False, 'questions': False, 'max_rep': 11, 'max_score': 1},
-        # Link text is misleading (like [https://github.com/Charcoal-SE/SmokeDetector](https://spam.com))
-        {'method': misleading_link, 'all': True,
-         'sites': [], 'reason': 'misleading link in {}', 'title': False, 'body': True, 'username': False, 'stripcodeblocks': True, 'body_summary': False, 'max_rep': 11, 'max_score': 1},
         # URL in title, some sites are exempt
         {'regex': ur"(?i)https?://(?!(www\.)?(example|domain)\.(com|net|org))[a-zA-Z0-9_.-]+\.[a-zA-Z]{2,4}|\w{3,}\.(com|net)\b.*\w{3,}\.(com|net)\b", 'all': True,
          'sites': ["stackoverflow.com", "pt.stackoverflow.com", "ru.stackoverflow.com", "es.stackoverflow.com", "ja.stackoverflow.com", "superuser.com", "askubuntu.com", "serverfault.com", "unix.stackexchange.com", "webmasters.stackexchange.com"], 'reason': "URL in title", 'title': True, 'body': False, 'username': False, 'stripcodeblocks': False, 'body_summary': False, 'max_rep': 11, 'max_score': 0},


### PR DESCRIPTION
The misleading link filter I wrote is really bad at finding spam (almost all false positives), so I added it to FireAlarm and will remove it from Smokey.