### PR TITLE
Replacing spaces in the MS search link with '+' instead of '%20'

### DIFF
--- a/gitmanager.py
+++ b/gitmanager.py
@@ -72,7 +72,7 @@ class GitManager:
             list_of_domains = ""
 
             for domain in range(len(items_to_blacklist)):
-                list_of_domains += "\n - {0} - [MS search](https://metasmoke.erwaysoftware.com/search?utf8=%E2%9C%93&body_is_regex=1&body={1})".format(items_to_blacklist[domain], items_to_blacklist[domain].replace(" ", "%20"))
+                list_of_domains += "\n - {0} - [MS search](https://metasmoke.erwaysoftware.com/search?utf8=%E2%9C%93&body_is_regex=1&body={1})".format(items_to_blacklist[domain], items_to_blacklist[domain].replace(" ", "+"))
 
             payload = {"title": "{0}: Blacklist {1}".format(username, ", ".join(items_to_blacklist)),
                        "body": "[{0}]({1}) requests the blacklist of the following {2}(s): \n{3}\n<!-- METASMOKE-BLACKLIST {4} -->".format(username, chat_profile_link, blacklist, list_of_domains, "|".join(items_to_blacklist)),


### PR DESCRIPTION
Apparently, bad keywords with spaces in [between were breaking links on github](https://github.com/Charcoal-SE/SmokeDetector/pull/369#issue-196215314). @angussidney made [a commit](https://github.com/Charcoal-SE/SmokeDetector/commit/cf72e1088d97f15aa3f900b6725a0dc157fb75db) to fix that.

Here is the markdown of the example link after angus's change:

    https://metasmoke.erwaysoftware.com/search?utf8=%E2%9C%93&body_is_regex=1&body=muscle%20supplement

The `%20` up there represents a space. If you notice, there is only one `%20`, and that is after the `?`.

The space can also be represented by `+`, which I've tested and it works. [As per this answer on StackOverflow](http://stackoverflow.com/a/29948396/5735775), to represent spaces, `%20` should be used before the `?` and `+` should be used after the `?`. Right now, the only place the space is occurring is after the `?` and thus I've changed the code to replace spaces by a `+`.



