### PR TITLE
findspam.py: Nested blockquotes

### DIFF
--- a/findspam.py
+++ b/findspam.py
@@ -470,6 +470,8 @@ class FindSpam:
         {'regex': ur"(?i)\b\<a href=\".{0,25}\.xyz\"( rel=\"nofollow( noreferrer)?\")?\>.{0,15}google.{0,15}\<\/a\>\b", 'all': True, 'sites': [], 'reason': 'non-Google "google search" link in {}', 'title': False, 'body': True, 'username': False, 'body_summary': False, 'stripcodeblocks': True, 'max_rep': 1, 'max_score': 0},
         # Academia image by low-rep user
         {'regex': ur'\<img src="[^"]+"(?: alt="[^"]+")?>', 'all': False, 'sites': ['academia.stackexchange.com'], 'reason': 'image by low-rep user', 'title': False, 'body': True, 'username': False, 'body_summary': False, 'stripcodeblocks': True, 'max_rep': 1, 'max_score': 0},
+        # Nested blockquotes
+        {'regex': ur'<blockquote>\s*<blockquote>\s*<blockquote>\s*<blockquote>', 'all': False, 'sites': [], 'reason': 'deeply nested blockquotes', 'title': False, 'body': True, 'username': False, 'body_summary': False, 'stripcodeblocks': True, 'max_rep': 1, 'max_score': 0},
 
         #
         # Category: other


### PR DESCRIPTION
Many of these spams have been detected only by the domain name heuristic, which could fail if they post with a domain name which doesn't contain terms on the blacklist.  To strengthen the filter, add a rule to identify the conspicuous use of nested blockquotes.

Example: https://metasmoke.erwaysoftware.com/post/50594