### PR TITLE
Add yet another regex for catching wingding

### DIFF
--- a/bad_keywords.txt
+++ b/bad_keywords.txt
@@ -165,3 +165,4 @@ muscle supplement
 maxatin
 paravex
 testabolan
+ANG kimoc.?hi


### PR DESCRIPTION
More specifically, I decided to take care of a long-overlooked pattern in the gibberish posted by [wingding](https://metasmoke.erwaysoftware.com/search?utf8=%E2%9C%93&title=&body=&username_is_regex=1&username=w.ng.%3Fd.ng&why=&site=&feedback=&reason=&user_rep_direction=%3E%3D&user_reputation=0&commit=Search) by adding `ANG kimoc.?hi`, a regex that has [19 hits with a 100% TP rate](https://metasmoke.erwaysoftware.com/search?utf8=%E2%9C%93&title=&body_is_regex=1&body=ANG+kimoc.%3Fhi&username=&why=&site=&feedback=&reason=&user_rep_direction=%3E%3D&user_reputation=0&commit=Search), to the list of bad keywords.