### PR TITLE
findspam.py: Tighten regex for deeply nested blockquotes

### DIFF
--- a/findspam.py
+++ b/findspam.py
@@ -471,7 +471,7 @@ class FindSpam:
         # Academia image by low-rep user
         {'regex': ur'\<img src="[^"]+"(?: alt="[^"]+")?>', 'all': False, 'sites': ['academia.stackexchange.com'], 'reason': 'image by low-rep user', 'title': False, 'body': True, 'username': False, 'body_summary': False, 'stripcodeblocks': True, 'max_rep': 1, 'max_score': 0},
         # Nested blockquotes
-        {'regex': ur'<blockquote>\s*<blockquote>\s*<blockquote>\s*<blockquote>', 'all': True, 'sites': [], 'reason': 'deeply nested blockquotes', 'title': False, 'body': True, 'username': False, 'body_summary': False, 'stripcodeblocks': True, 'max_rep': 1, 'max_score': 0},
+        {'regex': ur'(?:<blockquote>\s*){8}', 'all': True, 'sites': [], 'reason': 'deeply nested blockquotes', 'title': False, 'body': True, 'username': False, 'body_summary': False, 'stripcodeblocks': True, 'max_rep': 1, 'max_score': 0},
 
         #
         # Category: other


### PR DESCRIPTION
Require eight or more levels in order for the rule to trigger.

FP fix for PR#377 which ended up generating quite a number of false positives.

Based on (incomplete) spam evidence, the pattern we are looking for is a *substantial* level of nesting, definitely more than the four levels the rule would originally match.

("Incomplete" because I cannot figure out how to search for this in Metasmoke, even with the regex option, and the samples I have saved for my own testing are too few and don't include false positives.)