### PR TITLE
Add API request retry logic.

### DIFF
--- a/bodyfetcher.py
+++ b/bodyfetcher.py
@@ -162,6 +162,7 @@ class BodyFetcher:
                 self.queue[site].append()
             else:
                 self.queue[site] = [posts]
+            self.queue_modify_lock.release()
             return
 
         self.api_data_lock.acquire()

--- a/bodyfetcher.py
+++ b/bodyfetcher.py
@@ -161,7 +161,7 @@ class BodyFetcher:
             if site in self.queue:
                 self.queue[site].append()
             else:
-                self.queue[site] = [posts]
+                self.queue[site] = posts
             self.queue_modify_lock.release()
             return
 

--- a/bodyfetcher.py
+++ b/bodyfetcher.py
@@ -155,7 +155,14 @@ class BodyFetcher:
             time_request_made = datetime.strftime(datetime.now(), '%H:%M:%S')
             response = requests.get(url, timeout=20).json()
         except (requests.exceptions.Timeout, requests.ConnectionError, Exception):
-            return  # could add some retrying logic here, but eh.
+            # Any failure in the request being made (timeout or otherwise) should be added back to
+            # the queue.
+            self.queue_modify_lock.acquire()
+            if site in self.queue:
+                self.queue[site].append()
+            else:
+                self.queue[site] = [posts]
+            return
 
         self.api_data_lock.acquire()
         add_or_update_api_data(site)

--- a/bodyfetcher.py
+++ b/bodyfetcher.py
@@ -159,7 +159,7 @@ class BodyFetcher:
             # the queue.
             self.queue_modify_lock.acquire()
             if site in self.queue:
-                self.queue[site].append()
+                self.queue[site].extend(posts)
             else:
                 self.queue[site] = posts
             self.queue_modify_lock.release()


### PR DESCRIPTION
This is the first attempt at the logic, so it'll need reverted if it stops working on timeouts.

This would put any posts as part of that timeout/failure in the request back into the queue.