### PR TITLE
Remove "Nike" bad keyword from Findspam.py

### DIFF
--- a/findspam.py
+++ b/findspam.py
@@ -302,9 +302,6 @@ class FindSpam:
         # The big list of bad keywords, for titles and posts
         {'regex': ur"(?is)\b({})\b|{}".format("|".join(bad_keywords), "|".join(bad_keywords_nwb)), 'all': True,
          'sites': [], 'reason': "bad keyword in {}", 'title': True, 'body': True, 'username': True, 'stripcodeblocks': False, 'body_summary': True, 'max_rep': 4, 'max_score': 1},
-        # baba and nike are restricted to the beginning of posts: many false positives otherwise
-        {'regex': ur"(?is)^.{0,200}\bnike ", 'all': True,
-         'sites': [], 'reason': "bad keyword in {}", 'title': True, 'body': True, 'username': False, 'stripcodeblocks': False, 'body_summary': True, 'max_rep': 11, 'max_score': 0},
         # gratis at the beginning of post, SoftwareRecs is exempt
         {'regex': ur"(?is)^.{0,200}\bgratis\b$", 'all': True,
          'sites': ['softwarerecs.stackexchange.com'], 'reason': "bad keyword in {}", 'title': True, 'body': True, 'username': False, 'stripcodeblocks': False, 'body_summary': True, 'max_rep': 11, 'max_score': 0},


### PR DESCRIPTION
Disastrous Track record recently: https://metasmoke.erwaysoftware.com/search?utf8=%E2%9C%93&title=&body=Nike&username=&why=&site=&feedback=&reason=&user_rep_direction=%3E%3D&user_reputation=0&commit=Search