### PR TITLE
bad_keywords.txt: fix word boundary from PR#427

### DIFF
--- a/bad_keywords.txt
+++ b/bad_keywords.txt
@@ -180,7 +180,7 @@ genbrain
 teeth lightening
 alpha\Wprime
 alpha\Wforce\Wtesto
-xtest\W(muscle|revie)
+xtest\W(muscle|reviews?)
 inteligen
 natural\Wslim\Wlife
 test\Wx\W360


### PR DESCRIPTION
Based on discussion with Glorfindel, capturing a single mistake is probably less important than covering a recurring pattern, so lose the single mistake and cover half a dozen or so samples from Metasmoke instead.

http://chat.stackexchange.com/transcript/message/34648436#34648436