### PR TITLE
bad_keywors.txt: Remove obsolete long phrases

### DIFF
--- a/bad_keywords.txt
+++ b/bad_keywords.txt
@@ -144,10 +144,6 @@ putlocker
 vimax
 (contact|call) us today
 call \d{3}-\d{4}-\d{4}
-I knew I wanted to get him alone, but I couldn.t be obvious about it. So, I came up with a plan. I waited
-Yeah! I had some liquid courage. I figured I would give it a shot. The worst he could say was no! Plus the semester
-friends that I came to UCU  a virgin and the first day I lost my virginity in a shower with two girls
-As I am carrying my personal effects to my room, I spot this girl, probably another fresher, sex hungry as I am
 Thierno(_| )?M.(_| )Sow
 maxtropin
 geniux


### PR DESCRIPTION
I could find no evidence of these phrases in the collected evidence.  Maybe they never worked, or maybe they are just obsolete.  Either way, they don't seem to defend their place in the current blacklist.