### PR TITLE
findspam.py: Update link inside nested blockquotes

### DIFF
--- a/findspam.py
+++ b/findspam.py
@@ -466,8 +466,8 @@ class FindSpam:
         {'regex': ur"(?i)\b\<a href=\".{0,25}\.xyz\"( rel=\"nofollow( noreferrer)?\")?\>.{0,15}google.{0,15}\<\/a\>\b", 'all': True, 'sites': [], 'reason': 'non-Google "google search" link in {}', 'title': False, 'body': True, 'username': False, 'body_summary': False, 'stripcodeblocks': True, 'max_rep': 1, 'max_score': 0},
         # Academia image by low-rep user
         {'regex': ur'\<img src="[^"]+"(?: alt="[^"]+")?>', 'all': False, 'sites': ['academia.stackexchange.com'], 'reason': 'image by low-rep user', 'title': False, 'body': True, 'username': False, 'body_summary': False, 'stripcodeblocks': True, 'max_rep': 1, 'max_score': 0},
-        # Nested blockquotes
-        {'regex': ur'(?:<blockquote>\s*){8}', 'all': True, 'sites': [], 'reason': 'deeply nested blockquotes', 'title': False, 'body': True, 'username': False, 'body_summary': False, 'stripcodeblocks': True, 'max_rep': 1, 'max_score': 0},
+        # Link inside nested blockquotes
+        {'regex': ur'(?:<blockquote>\s*){6}<p><a href="([^<>]+)"[^<>]*>\1</a>\s*</p>\s*</blockquote>', 'all': True, 'sites': [], 'reason': 'link inside deeply nested blockquotes', 'title': False, 'body': True, 'username': False, 'body_summary': False, 'stripcodeblocks': True, 'max_rep': 1, 'max_score': 0},
 
         #
         # Category: other


### PR DESCRIPTION
Experimentation reveals six nested blockquotes or more are all TP.  Add the requirement to have a link alone inside the blockquotes.

This updates the rule introduced in PR#377 and tweaked in PR#416.

I have updated the rule description, I hope that's acceptable.  This no longer looks merely for nested blockquotes, so the old description would be misleading (but I'm wondering whether this will make Metasmoke regard this as a new heuristic).