### PR TITLE
blacklisted_websites.txt: remove fiverr

### DIFF
--- a/blacklisted_websites.txt
+++ b/blacklisted_websites.txt
@@ -631,7 +631,6 @@ bigclasses\.com
 ladybirdco\.com
 colors34.com
 ultimatewowguide\.com
-fiverr\.com/\w+
 shaperich\.com
 ugccoaching\.com
 androidpluspc\.com


### PR DESCRIPTION
fiverr\.com/w+ had 20 TPs out of 28, which isn't too great, and not a very frequent pattern anyway.

http://chat.stackexchange.com/transcript/message/34749585#34749585