### PR TITLE
Quick and dirty solution for blacklist patterns that would have spaces

### DIFF
--- a/chatcommands.py
+++ b/chatcommands.py
@@ -265,12 +265,12 @@ def command_blacklist_website(message_parts, ev_user_name, ev_room, ev_user_id, 
     """
 
     chat_user_profile_link = "http://chat.{host}/users/{id}".format(host=wrap2.host, id=str(ev_user_id))
-    for item in message_parts[1:]:
-        # noinspection PyProtectedMember
-        try:
-            regex.compile(item)
-        except regex._regex_core.error:
-            return Response(command_status=False, message="An invalid website pattern was found in the item(s) being blacklisted.")
+    website_pattern = " ".join(message_parts[1:])
+    # noinspection PyProtectedMember
+    try:
+        regex.compile(website_pattern)
+    except regex._regex_core.error:
+        return Response(command_status=False, message="An invalid website pattern was provided, not blacklisting.")
     result = GitManager.add_to_blacklist(
         blacklist="website",
         items_to_blacklist=message_parts[1:],
@@ -292,12 +292,12 @@ def command_blacklist_keyword(message_parts, ev_user_name, ev_room, ev_user_id, 
     """
 
     chat_user_profile_link = "http://chat.{host}/users/{id}".format(host=wrap2.host, id=str(ev_user_id))
-    for item in message_parts[1:]:
-        # noinspection PyProtectedMember
-        try:
-            regex.compile(item)
-        except regex._regex_core.error:
-            return Response(command_status=False, message="An invalid keyword pattern was found in the item(s) being blacklisted.")
+    keyword_pattern = " ".join(message_parts[1:])
+    # noinspection PyProtectedMember
+    try:
+        regex.compile(keyword_pattern)
+    except regex._regex_core.error:
+        return Response(command_status=False, message="An invalid keyword pattern was provided, not blacklisting.")
     result = GitManager.add_to_blacklist(
         blacklist="keyword",
         items_to_blacklist=message_parts[1:],
@@ -319,12 +319,12 @@ def command_blacklist_username(message_parts, ev_user_name, ev_room, ev_user_id,
     """
 
     chat_user_profile_link = "http://chat.{host}/users/{id}".format(host=wrap2.host, id=str(ev_user_id))
-    for item in message_parts[1:]:
-        # noinspection PyProtectedMember
-        try:
-            regex.compile(item)
-        except regex._regex_core.error:
-            return Response(command_status=False, message="An invalid username pattern was found in the item(s) being blacklisted.")
+    username_pattern = " ".join(message_parts[1:])
+    # noinspection PyProtectedMember
+    try:
+        regex.compile(username_pattern)
+    except regex._regex_core.error:
+        return Response(command_status=False, message="An invalid username pattern was provided, not blacklisting.")
     result = GitManager.add_to_blacklist(
         blacklist="username",
         items_to_blacklist=message_parts[1:],


### PR DESCRIPTION
Currently, we split on spaces.  For the blacklist commands, we are going to join multiple message parts with spaces, under the assumption that only one pattern is actually provided at a time.  Also, we need to include a merge from Master into this branch, because I made a mistake of not updating the Master branch first.  (My bad!)