### PR TITLE
Reconnect a dead Metasmoke websocket

### DIFF
--- a/metasmoke.py
+++ b/metasmoke.py
@@ -28,8 +28,7 @@ class Metasmoke:
                                       "identifier": "{\"channel\":\"SmokeDetectorChannel\","
                                       "\"key\":\"" + GlobalVars.metasmoke_key + "\"}"})
                 GlobalVars.metasmoke_ws.send(payload)
-                
-                
+
                 GlobalVars.metasmoke_ws.settimeout(10)
 
                 has_succeded = True
@@ -56,7 +55,6 @@ class Metasmoke:
                     break
                 else:
                     time.sleep(10)
-
 
     @staticmethod
     def handle_websocket_data(data):

--- a/metasmoke.py
+++ b/metasmoke.py
@@ -60,8 +60,6 @@ class Metasmoke:
 
     @staticmethod
     def handle_websocket_data(data):
-        last_recieved = time.gmtime()
-        
         if "message" not in data:
             return
 
@@ -122,7 +120,6 @@ class Metasmoke:
 
                     # noinspection PyUnboundLocalVariable
                     GlobalVars.charcoal_hq.send_message(s)
-
 
     @staticmethod
     def send_stats_on_post(title, link, reasons, body, username, user_link, why, owner_rep,


### PR DESCRIPTION
Right now, when the Metasmoke websocket dies, SmokeDetector logs a message to the console and stops listening.  

I changed it (by stumbling along with the help of Undo) so that, if a MS connection has previously succeeded, it attempts to reconnect after 10 seconds.  

I also set a timeout so it will reconnect if it stops receiving heartbeats.