### PR TITLE
bad_keywords.txt: Add Nigerian phone number pattern

### DIFF
--- a/bad_keywords.txt
+++ b/bad_keywords.txt
@@ -240,3 +240,4 @@ raw\Wpower\Wxl
 pantothen
 argireline
 brick\Wmuscle
+\+234[0-9]{8,}

--- a/bad_keywords.txt
+++ b/bad_keywords.txt
@@ -240,4 +240,4 @@ raw\Wpower\Wxl
 pantothen
 argireline
 brick\Wmuscle
-\+234[0-9]{8,}
+\+234\d{8,14}


### PR DESCRIPTION
As discussed here: http://chat.stackexchange.com/transcript/message/34997711#34997711

234/235 TP (one NAA): https://metasmoke.erwaysoftware.com/search?body=%28%5E%7C%5B%5EA-Za-z0-9_%5D%29%5C%2B234%5B0-9%5D%7B8%2C%7D%28%24%7C%5B%5EA-Za-z0-9_%5D%29&body_is_regex=1&commit=Search&feedback=&feedback_filter=naa&reason=&site=&title=&user_rep_direction=%3E%3D&user_reputation=0&username=&utf8=%E2%9C%93&why=

The proposal is Glorfindel's but we agreed I would make the PR. This is somewhat more far-reaching than your routine blacklisting request so I think we want to have this reviewed by the authors.