### PR TITLE
findspam.py: fix safflower FPs

### DIFF
--- a/findspam.py
+++ b/findspam.py
@@ -274,7 +274,7 @@ class FindSpam:
         "(?:design|development|compan(y|ies)|training|courses?|automation).{0,8}\\L<city>",
         u"Ｃ[Ｏ|0]Ｍ", "ecoflex", "no2factor", "no2blast", "sunergetic", "capilux", "sante ?avis",
         "enduros", "dianabol", "ICQ#?\d{4}-?\d{5}", "3073598075", "lumieres", "viarex", "revimax",
-        "celluria", "viatropin", "(meg|test)adrox", "nordic ?loan ?firm", "safflower",
+        "celluria", "viatropin", "(meg|test)adrox", "nordic ?loan ?firm", "safflower\Woil",
         "(essay|resume|article|dissertation|thesis) ?writing ?service", "satta ?matka", "b.?o.?j.?i.?t.?e.?r"
     ]
 


### PR DESCRIPTION
Just "safflower" gets 4 FPs currently; extending to "safflower\Woil" fixed 3 of them.