### PR TITLE
bad_keywords:txt: Fix plussed phone numbers

### DIFF
--- a/bad_keywords.txt
+++ b/bad_keywords.txt
@@ -240,7 +240,9 @@ raw\Wpower\Wxl
 pantothen
 argireline
 brick\Wmuscle
-\+234\d{8,14}
+# documentation: the plus is skipped by the word boundary condition in the code
+# so we can't match that directly, but we can say "if we just skipped a plus sign"
+(?<=\+)234\d{8,14}
 vividermix
 dsn\Wpre\Wworkout
-\+15402277725
+(?<=\+)15402277725


### PR DESCRIPTION
These were not working, because the leading plus is consumed by the word boundary condition in the code, so we can't match that directly, but we can say "if we just skipped a plus sign" with a lookbehind.

I included a couple of comments in the text file which are simply never going to match anything; but down the line, we might want to add code to skip comments in the file, or just remove these lines.