### PR TITLE
bad_keywords.txt: Remove a couple

### DIFF
--- a/bad_keywords.txt
+++ b/bad_keywords.txt
@@ -246,7 +246,6 @@ brick\Wmuscle
 vividermix
 dsn\Wpre\Wworkout
 (?<=\+)15402277725
-growth\Wformula
 kerotin
 newbioti(x|cs)
 max\Wsynapse
@@ -254,5 +253,4 @@ platinum\Wxt
 renovie
 cactinea
 provillus
-textomenix
 testomenix


### PR DESCRIPTION
"textomenix" was a typo; proper "testomenix" remains.

"growth formula" may have been too aggressive; removing due to FP risk.