### PR TITLE
Add special-case handler for Math.SE on 'has few characters'

### DIFF
--- a/findspam.py
+++ b/findspam.py
@@ -25,7 +25,7 @@ def has_few_characters(s, site):
     s = regex.sub("</?p>", "", s).rstrip()    # remove HTML paragraph tags from posts
     uniques = len(set(list(s)))
     if (len(s) >= 30 and uniques <= 6) or (len(s) >= 100 and uniques <= 15):    # reduce if false reports appear
-        if uniques > 5 and site == "math.stackoverflow.com":
+        if (uniques <= 15) and (uniques >= 5) and site == "math.stackoverflow.com":
             # Special case for Math.SE: Uniques case may trigger false-positives.
             return False, ""
         return True, u"Contains {} unique characters".format(uniques)

--- a/findspam.py
+++ b/findspam.py
@@ -25,6 +25,9 @@ def has_few_characters(s, site):
     s = regex.sub("</?p>", "", s).rstrip()    # remove HTML paragraph tags from posts
     uniques = len(set(list(s)))
     if (len(s) >= 30 and uniques <= 6) or (len(s) >= 100 and uniques <= 15):    # reduce if false reports appear
+        if uniques > 5 and site == "math.stackoverflow.com":
+            # Special case for Math.SE: Uniques case may trigger false-positives.
+            return False, ""
         return True, u"Contains {} unique characters".format(uniques)
     return False, ""
 


### PR DESCRIPTION
Math.SE triggers a lot of false positives on this filter.

We should consider special-casing that site so that it has to have 5 or more and 15 or less unique characters for Math.SE.

This is free to be modified as necessary to adjust the threshold, or for a better approach/solution.