### PR TITLE
Metasmoke: Track 'last ping time', reboot if time > 60 seconds

### DIFF
--- a/globalvars.py
+++ b/globalvars.py
@@ -24,6 +24,7 @@ class GlobalVars:
     meta_tavern_room_id = "89"
     socvr_room_id = "41570"
     blockedTime = {"all": 0, charcoal_room_id: 0, meta_tavern_room_id: 0, socvr_room_id: 0}
+    metasmoke_last_ping_time = None
 
     experimental_reasons = []  # Don't widely report these
     non_socvr_reasons = []    # Don't report to SOCVR

--- a/metasmoke.py
+++ b/metasmoke.py
@@ -164,6 +164,8 @@ class Metasmoke:
             print "Metasmoke location not defined; not reporting"
             return
 
+        metasmoke_key = GlobalVars.metasmoke_key
+
         try:
             payload = {
                 'feedback': {

--- a/metasmoke.py
+++ b/metasmoke.py
@@ -63,7 +63,7 @@ class Metasmoke:
 
         if GlobalVars.metasmoke_last_ping_time < (datetime.datetime.now() - datetime.timedelta(seconds=60)):
             with open('errorlogs.txt', 'a') as errlog:
-                errlog.write("\nWARNING: Last MetaSmoke ping with a response was over 60 seconds ago, "
+                errlog.write("\nWARNING: Last metasmoke ping with a response was over 60 seconds ago, "
                              "forcing SmokeDetector restart to reset all sockets.\n")
             os._exit(10)
         else:

--- a/metasmoke.py
+++ b/metasmoke.py
@@ -62,7 +62,7 @@ class Metasmoke:
         while True:
             if GlobalVars.metasmoke_last_ping_time < (datetime.datetime.now() - datetime.timedelta(seconds=60)):
                 with open('errorlogs.txt', 'a') as errlog:
-                    errlog.write("\nWARNING: Last MetaSmoke ping with a response was over 60 seconds ago, "
+                    errlog.write("\nWARNING: Last metasmoke ping with a response was over 60 seconds ago, "
                                  "forcing SmokeDetector restart to reset all sockets.\n")
                 os._exit(10)
             else:

--- a/metasmoke.py
+++ b/metasmoke.py
@@ -222,7 +222,7 @@ class Metasmoke:
             }
 
             headers = {'content-type': 'application/json'}
-            requests.post(GlobalVars.metasmoke_host + "/status-update.json",  data=json.dumps(payload), headers=headers)
+            requests.post(GlobalVars.metasmoke_host + "/status-update.json", data=json.dumps(payload), headers=headers)
             GlobalVars.metasmoke_last_ping_time = datetime.now()
         except Exception as e:
             print e

--- a/metasmoke.py
+++ b/metasmoke.py
@@ -59,14 +59,15 @@ class Metasmoke:
 
     @staticmethod
     def check_last_pingtime():
-        while True:
-            if GlobalVars.metasmoke_last_ping_time < (datetime.datetime.now() - datetime.timedelta(seconds=60)):
-                with open('errorlogs.txt', 'a') as errlog:
-                    errlog.write("\nWARNING: Last metasmoke ping with a response was over 60 seconds ago, "
-                                 "forcing SmokeDetector restart to reset all sockets.\n")
-                os._exit(10)
-            else:
-                pass  # Do nothing
+        threading.Timer(10, Metasmoke.check_last_pingtime).start()
+
+        if GlobalVars.metasmoke_last_ping_time < (datetime.datetime.now() - datetime.timedelta(seconds=60)):
+            with open('errorlogs.txt', 'a') as errlog:
+                errlog.write("\nWARNING: Last MetaSmoke ping with a response was over 60 seconds ago, "
+                             "forcing SmokeDetector restart to reset all sockets.\n")
+            os._exit(10)
+        else:
+            pass  # Do nothing
 
     @staticmethod
     def handle_websocket_data(data):

--- a/nocrash.sh
+++ b/nocrash.sh
@@ -59,6 +59,11 @@ do
     git checkout deploy
     count=0
     crashcount=0
+   elif [ "$ecode" -eq "10" ]
+   then
+    # Last MS Ping > 30 seconds handler.
+    sleep 5
+    count=0
    else
     sleep 5
     count=$((count+1))

--- a/ws.py
+++ b/ws.py
@@ -19,7 +19,7 @@ from threading import Thread
 import traceback
 from bodyfetcher import BodyFetcher
 from chatcommunicate import watcher, special_room_watcher
-from datetime import datetime
+from datetime import datetime, timedelta
 from utcdate import UtcDate
 from spamhandling import check_if_spam_json
 from globalvars import GlobalVars
@@ -204,6 +204,9 @@ threading.Timer(600, Metasmoke.send_statistics).start()
 metasmoke_ws_t = Thread(name="metasmoke websocket", target=Metasmoke.init_websocket)
 metasmoke_ws_t.start()
 
+metasmoke_ping_tracker = Thread(name="metasmoke last time checker", target=Metasmoke.check_last_pingtime)
+metasmoke_ping_tracker.start()
+
 while True:
     try:
         a = ws.recv()
@@ -217,6 +220,7 @@ while True:
                            target=GlobalVars.bodyfetcher.add_to_queue,
                            args=(a, True if is_spam else None))
                 t.start()
+
     except Exception, e:
         exc_type, exc_obj, exc_tb = sys.exc_info()
         now = datetime.utcnow()

--- a/ws.py
+++ b/ws.py
@@ -204,8 +204,7 @@ threading.Timer(600, Metasmoke.send_statistics).start()
 metasmoke_ws_t = Thread(name="metasmoke websocket", target=Metasmoke.init_websocket)
 metasmoke_ws_t.start()
 
-metasmoke_ping_tracker = Thread(name="metasmoke last time checker", target=Metasmoke.check_last_pingtime)
-metasmoke_ping_tracker.start()
+Metasmoke.check_last_pingtime()  # This will call itself every 10 seconds or so
 
 while True:
     try:

--- a/ws.py
+++ b/ws.py
@@ -19,7 +19,7 @@ from threading import Thread
 import traceback
 from bodyfetcher import BodyFetcher
 from chatcommunicate import watcher, special_room_watcher
-from datetime import datetime, timedelta
+from datetime import datetime
 from utcdate import UtcDate
 from spamhandling import check_if_spam_json
 from globalvars import GlobalVars


### PR DESCRIPTION
**This is not thoroughly tested, and needs review before inclusion!**

We don't currently track the 'last time' a ping from MetaSmoke was processed.  Therefore, we have some odd cases where SmokeDetector will 'die off' and not ping.

By tracking the 'last pinged' time, and check if that time is greater than 60 seconds into the past.  If it is, then die off with exit code '10' and write to the ErrorLogs accordingly, then wait 5 seconds, and restart SmokeDetector with a brand new set of sockets.  The 5 second wait is for 'networking must settle' waits, just in case.

This should allow for 'not pinging' cases to 'try' and recover by a forcible restart to SmokeDetector, and will kill existing sockets and use brand new ones, in case of uncaught network interruptions.