### PR TITLE
Run git.config safely

### DIFF
--- a/gitmanager.py
+++ b/gitmanager.py
@@ -17,10 +17,10 @@ class GitManager:
         code_permissions = kwargs.get("code_permissions", False)
 
         # Make sure git credentials are set up
-        if git.config("--global", "--get", "user.name", _ok_code=[0,1]) == "":
+        if git.config("--global", "--get", "user.name", _ok_code=[0, 1]) == "":
             return (False, "Tell someone to run `git config --global user.name \"SmokeDetector\"`")
 
-        if git.config("--global", "--get", "user.email", _ok_code=[0,1]) == "":
+        if git.config("--global", "--get", "user.email", _ok_code=[0, 1]) == "":
             return (False, "Tell someone to run `git config --global user.email \"smokey@erwaysoftware.com\"`")
 
         if blacklist == "":

--- a/gitmanager.py
+++ b/gitmanager.py
@@ -17,10 +17,10 @@ class GitManager:
         code_permissions = kwargs.get("code_permissions", False)
 
         # Make sure git credentials are set up
-        if git.config("--global", "--get", "user.name") == "":
+        if git.config("--global", "--get", "user.name", _ok_code=[0,1]) == "":
             return (False, "Tell someone to run `git config --global user.name \"SmokeDetector\"`")
 
-        if git.config("--global", "--get", "user.name") == "":
+        if git.config("--global", "--get", "user.email", _ok_code=[0,1]) == "":
             return (False, "Tell someone to run `git config --global user.email \"smokey@erwaysoftware.com\"`")
 
         if blacklist == "":


### PR DESCRIPTION
Ignore exit code 1 when checking whether global user.name and user.email
are set or not.  Also, fix copy/paste error in user.email check.