### PR TITLE
Delete auto-blacklist branches in local tree (#505)

### DIFF
--- a/gitmanager.py
+++ b/gitmanager.py
@@ -85,6 +85,7 @@ class GitManager:
             git.checkout("master")
             git.merge(branch)
             git.push()
+            git.branch('-D', branch)  # Delete the branch in the local git tree since we're done with it.
         else:
             git.push("origin", branch)
             git.checkout("master")
@@ -107,9 +108,14 @@ class GitManager:
             print(response.json())
             try:
                 git.checkout("deploy")  # Return to deploy, pending the accept of the PR in Master.
+                git.branch('-D', branch)  # Delete the branch in the local git tree since we're done with it.
                 return (True, "You don't have code privileges, but I've [created a pull request for you]({0}).".format(
                     response.json()["html_url"]))
             except KeyError:
+                git.branch('-D', branch)  # Delete the branch in the local git tree, we'll create it again if the
+                                          # command is run again. This way, we keep things a little more clean in
+                                          # the local git tree
+
                 # Error capture/checking for any "invalid" GH reply without an 'html_url' item,
                 # which will throw a KeyError.
                 if "bad credentials" in str(response.json()['message']).lower():

--- a/gitmanager.py
+++ b/gitmanager.py
@@ -112,6 +112,8 @@ class GitManager:
                 return (True, "You don't have code privileges, but I've [created a pull request for you]({0}).".format(
                     response.json()["html_url"]))
             except KeyError:
+                git.checkout("deploy")  # Return to deploy
+
                 # Delete the branch in the local git tree, we'll create it again if the
                 # command is run again. This way, we keep things a little more clean in
                 # the local git tree

--- a/gitmanager.py
+++ b/gitmanager.py
@@ -112,9 +112,10 @@ class GitManager:
                 return (True, "You don't have code privileges, but I've [created a pull request for you]({0}).".format(
                     response.json()["html_url"]))
             except KeyError:
-                git.branch('-D', branch)  # Delete the branch in the local git tree, we'll create it again if the
-                                          # command is run again. This way, we keep things a little more clean in
-                                          # the local git tree
+                # Delete the branch in the local git tree, we'll create it again if the
+                # command is run again. This way, we keep things a little more clean in
+                # the local git tree
+                git.branch('-D', branch)
 
                 # Error capture/checking for any "invalid" GH reply without an 'html_url' item,
                 # which will throw a KeyError.


### PR DESCRIPTION
Refer to #505.

This code change would add code which will automatically delete the created auto-blacklist branch in the local tree after we are done with it - either when the merge was done and pushed automatically by SmokeDetector (for code priv. users) or once the branch is pushed up to GitHub and a Pull Request made.

Note this branch deletion only affects the `.git` folder where the SmokeDetector runs.  This leaves the rest of the branches intact on GitHub, but cleans up the local git tree a little.

I also discovered an issue here with when we handle git push/pull request errors in gitmanager when creating the pull requests, where it might not switch back to the "Deploy" branch, so let's forcibly go back to the branch.