### PR TITLE
Get rid of the anchors in wingding's username regex

### DIFF
--- a/blacklisted_usernames.txt
+++ b/blacklisted_usernames.txt
@@ -4,7 +4,7 @@ tejveer ?iq
 ser?vice pemanas?
 \bnigg[aeu][rh]?
 \b(fuck(er|ing)?|penis)\b
-^w.ng.?d.ng$
+w.ng.?d.ng
 dlqudals
 ^[a-z ]+juri(?:n|na|ns|sa|ya|yam|ym)$
 ^[a-z]+jiibond$

--- a/blacklisted_usernames.txt
+++ b/blacklisted_usernames.txt
@@ -4,7 +4,7 @@ tejveer ?iq
 ser?vice pemanas?
 \bnigg[aeu][rh]?
 \b(fuck(er|ing)?|penis)\b
-*{,3}w.ng.?d.ng*{,3}
+^\w{0,3}w.ng.?d.ng\w{0,3}$
 dlqudals
 ^[a-z ]+juri(?:n|na|ns|sa|ya|yam|ym)$
 ^[a-z]+jiibond$

--- a/blacklisted_usernames.txt
+++ b/blacklisted_usernames.txt
@@ -4,7 +4,7 @@ tejveer ?iq
 ser?vice pemanas?
 \bnigg[aeu][rh]?
 \b(fuck(er|ing)?|penis)\b
-w.ng.?d.ng
+*{,3}w.ng.?d.ng*{,3}
 dlqudals
 ^[a-z ]+juri(?:n|na|ns|sa|ya|yam|ym)$
 ^[a-z]+jiibond$


### PR DESCRIPTION
The name of the "user" who posted https://metasmoke.erwaysoftware.com/post/56146 explains why I made this commit better than I could.