### PR TITLE
fornatgaex\.com duplicate removed

### DIFF
--- a/blacklisted_websites.txt
+++ b/blacklisted_websites.txt
@@ -805,7 +805,6 @@ guideusermanual\.com
 avisfrance\.org
 customertollfreehelplinenumber\.in
 customeronlineinfo\.in
-fornatgaex\.com
 eyeluminoushelps\.com
 skinshining\.com
 minimilitiahack\.com


### PR DESCRIPTION
We already have fornatgaex in the blacklist, so the \.com is redundant.