### PR TITLE
Infer missed IDs from previous API calls

### DIFF
--- a/bodyfetcher.py
+++ b/bodyfetcher.py
@@ -132,7 +132,7 @@ class BodyFetcher:
 
         if site in self.previous_max_ids and max(new_post_ids) > self.previous_max_ids[site]:
             previous_max_id = self.previous_max_ids[site]
-            intermediate_posts = range(previous_max_id, max(new_post_ids))
+            intermediate_posts = range(previous_max_id + 1, max(new_post_ids))
 
             # We don't want to go over the 100-post API cutoff, so take the last
             # (100-len(new_post_ids)) from intermediate_posts

--- a/bodyfetcher.py
+++ b/bodyfetcher.py
@@ -12,6 +12,7 @@ import requests
 # noinspection PyClassHasNoInit,PyBroadException
 class BodyFetcher:
     queue = {}
+    previous_max_ids = {}
 
     special_cases = {
         "math.stackexchange.com": 15,
@@ -62,6 +63,7 @@ class BodyFetcher:
 
     api_data_lock = threading.Lock()
     queue_modify_lock = threading.Lock()
+    max_ids_modify_lock = threading.Lock()
 
     def add_to_queue(self, post, should_check_site=False):
         mse_sandbox_id = 3122
@@ -122,9 +124,35 @@ class BodyFetcher:
             return
 
         self.queue_modify_lock.acquire()
-        posts = self.queue.pop(site)
+        new_post_ids = self.queue.pop(site)
         store_bodyfetcher_queue()
         self.queue_modify_lock.release()
+
+        self.max_ids_modify_lock.acquire()
+
+        if site in self.previous_max_ids:
+            previous_max_id = self.previous_max_ids[site]
+            intermediate_posts = range(previous_max_id, max(new_post_ids))
+
+            # We don't want to go over the 100-post API cutoff, so take the last
+            # (100-len(new_post_ids)) from intermediate_posts
+
+            intermediate_posts = intermediate_posts[(len(new_post_ids) - 100):]
+
+            # new_post_ids could contain edited posts, so merge it back in
+            combined = intermediate_posts + new_post_ids
+
+            # Could be duplicates, so uniquify
+            posts = list(set(combined))
+        else:
+            posts = new_post_ids
+
+        self.previous_max_ids[site] = max(new_post_ids)
+        self.max_ids_modify_lock.release()
+
+        print("New IDs / Hybrid Intermediate IDs:")
+        print(new_post_ids)
+        print(posts)
 
         question_modifier = ""
         pagesize_modifier = ""

--- a/bodyfetcher.py
+++ b/bodyfetcher.py
@@ -153,8 +153,8 @@ class BodyFetcher:
         self.max_ids_modify_lock.release()
 
         print("New IDs / Hybrid Intermediate IDs:")
-        print(new_post_ids)
-        print(posts)
+        print(sorted(new_post_ids))
+        print(sorted(posts))
 
         question_modifier = ""
         pagesize_modifier = ""

--- a/bodyfetcher.py
+++ b/bodyfetcher.py
@@ -130,7 +130,7 @@ class BodyFetcher:
 
         self.max_ids_modify_lock.acquire()
 
-        if site in self.previous_max_ids:
+        if site in self.previous_max_ids and max(new_post_ids) > self.previous_max_ids[site]:
             previous_max_id = self.previous_max_ids[site]
             intermediate_posts = range(previous_max_id, max(new_post_ids))
 
@@ -147,7 +147,9 @@ class BodyFetcher:
         else:
             posts = new_post_ids
 
-        self.previous_max_ids[site] = max(new_post_ids)
+        if max(new_post_ids) > self.previous_max_ids[site]:
+            self.previous_max_ids[site] = max(new_post_ids)
+
         self.max_ids_modify_lock.release()
 
         print("New IDs / Hybrid Intermediate IDs:")

--- a/bodyfetcher.py
+++ b/bodyfetcher.py
@@ -147,7 +147,10 @@ class BodyFetcher:
         else:
             posts = new_post_ids
 
-        if max(new_post_ids) > self.previous_max_ids[site]:
+        try:
+            if max(new_post_ids) > self.previous_max_ids[site]:
+                self.previous_max_ids[site] = max(new_post_ids)
+        except KeyError:
             self.previous_max_ids[site] = max(new_post_ids)
 
         self.max_ids_modify_lock.release()

--- a/bodyfetcher.py
+++ b/bodyfetcher.py
@@ -155,7 +155,7 @@ class BodyFetcher:
 
         self.max_ids_modify_lock.release()
 
-        print("New IDs / Hybrid Intermediate IDs:")
+        print("New IDs / Hybrid Intermediate IDs for {0}:".format(site))
         print(sorted(new_post_ids))
         print(sorted(posts))
 

--- a/bodyfetcher.py
+++ b/bodyfetcher.py
@@ -1,5 +1,5 @@
 from spamhandling import handle_spam, check_if_spam
-from datahandling import add_or_update_api_data, clear_api_data, store_bodyfetcher_queue
+from datahandling import add_or_update_api_data, clear_api_data, store_bodyfetcher_queue, store_bodyfetcher_max_ids
 from globalvars import GlobalVars
 from operator import itemgetter
 from datetime import datetime
@@ -148,8 +148,10 @@ class BodyFetcher:
         try:
             if max(new_post_ids) > self.previous_max_ids[site]:
                 self.previous_max_ids[site] = max(new_post_ids)
+                store_bodyfetcher_max_ids()
         except KeyError:
             self.previous_max_ids[site] = max(new_post_ids)
+            store_bodyfetcher_max_ids()
 
         self.max_ids_modify_lock.release()
 

--- a/datahandling.py
+++ b/datahandling.py
@@ -60,6 +60,14 @@ def load_files():
             os.remove("bodyfetcherQueue.txt")
             raise
 
+    if os.path.isfile("bodyfetcherMaxIds.txt"):
+        try:
+            with open("bodyfetcherMaxIds.txt", "rb") as f:
+                GlobalVars.bodyfetcher.previous_max_ids = pickle.load(f)
+        except EOFError:
+            os.remove("bodyfetcherMaxIds.txt")
+            raise
+
 
 def filter_auto_ignored_posts():
     today_date = datetime.today()
@@ -265,6 +273,11 @@ def clear_api_data():
 def store_bodyfetcher_queue():
     with open("bodyfetcherQueue.txt", "wb") as f:
         pickle.dump(GlobalVars.bodyfetcher.queue, f, protocol=pickle.HIGHEST_PROTOCOL)
+
+
+def store_bodyfetcher_max_ids():
+    with open("bodyfetcherMaxIds.txt", "wb") as f:
+        pickle.dump(GlobalVars.bodyfetcher.previous_max_ids, f, protocol=pickle.HIGHEST_PROTOCOL)
 
 
 # methods that help avoiding reposting alerts:


### PR DESCRIPTION
Don't merge yet, but feedback is welcome.

See http://chat.stackexchange.com/transcript/message/35339676#35339676 for context. Here's the theory:

 1. When we make an API call, for example, for post IDs `[1,2,3,4]`, we store the *highest* ID (`4`)
 2. When *another* API call for that site is triggered (for `[7,8,9,10]`), we:
    1. take the highest ID from the new batch (`10`), 
    2. compute all IDs between the previous highest ID (`4`) and the new highest (`10`) = `[5,6,7,8,9,10`]
    3. Merge with the requested IDs (`[7..10]`) as they may contain an edited post (imagine if `0` was a valid ID and requested) and uniqueify

The idea is that if we make an API call for `[1,2,3]`, then one for `[5,6,7]`, we *probably* intended to get `4` too but the websocket didn't give it to us for whatever reason. 

Thoughts?