### PR TITLE
Removing match for vpnranks.com

### DIFF
--- a/blacklisted_websites.txt
+++ b/blacklisted_websites.txt
@@ -210,7 +210,7 @@ wasel(pro)?\.com
 i-spire\.(com|net)
 sandangku\.com
 iwasl\.com
-vpn(faqs|answers|ranks|4games)\.com
+vpn(faqs|answers|4games)\.com
 airmore\.com
 showmore\.com
 unblockingtwitter\.com


### PR DESCRIPTION
Today's hit for vpnranks.com was a FP.  The site hasn't had any other hits for 8 months.
The older hits were marked TP, but were more or less decent answers.

Discussion about removing the rule with Glorfindel, here:
http://chat.stackexchange.com/transcript/message/35572084#35572084