### PR TITLE
This implements username like website; adjusts method calls to accept *args

### DIFF
--- a/findspam.py
+++ b/findspam.py
@@ -282,9 +282,7 @@ def has_eltima(s, site, *args):
 # noinspection PyUnusedLocal
 def username_similar_website(s, site, *args):
     username = args[0]
-    print "Username:", username
     sim_result = perform_similarity_checks(s, username)
-    print "Sim result:", sim_result
     if sim_result >= SIMILAR_THRESHOLD:
         return True, u"Username similar to website"
     else:
@@ -301,7 +299,6 @@ def perform_similarity_checks(post, name):
     # Fix stupid spammer tricks
     for p in COMMON_MALFORMED_PROTOCOLS:
         post = post.replace(p[0], p[1])
-    print "Post:", post
     # Find links in post
     found_links = regex.findall(URL_REGEX, post)
 
@@ -334,7 +331,6 @@ def perform_similarity_checks(post, name):
                 return max(t1, t2, t3, t4)
     else:
         return 0
-        #print "ERROR PARSING STRING: ", post
     return max(t1, t2, t3, t4)
 
 
@@ -356,8 +352,6 @@ def get_domain(s):
         except tld.exceptions.TldDomainNotFound as e:
             # Assume bad TLD and try one last fall back, just strip the trailing TLD and leading subdomain
             parsed_uri = urlparse(s)
-            # print "Exception within Exception result:", parsed_uri
-            # print parsed_uri.path.split(".")
             if len(parsed_uri.path.split(".")) >= 3:
                 domain = parsed_uri.path.split(".")[1]
             else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ pep8-naming
 regex==2015.11.22
 termcolor
 sh
+tld

--- a/test/test_regexes.py
+++ b/test/test_regexes.py
@@ -70,14 +70,19 @@ import pytest
     ('Title here', '<img src="http://example.com/11111111111.jpg" alt="my image">', '', 'stackoverflow.com', False, False),
     ('Title here', '<img src="http://example.com/11111111111111.jpg" alt="my image" />', '', 'stackoverflow.com', False, False),
     ('Title here', '<a href="http://example.com/11111111111111.html">page</a>', '', 'stackoverflow.com', False, False),
-    ('Error: 2147467259', '', '', 'stackoverflow.com', False, False)
+    ('Error: 2147467259', '', '', 'stackoverflow.com', False, False),
+    ('Max limit on number of concurrent ajax request', """<p>Php java script boring yaaarrr <a href="http://www.price-buy.com/" rel="nofollow noreferrer">Price-Buy.com</a> </p>""", 'Price Buy', 'stackoverflow.com', True, True),
+    ('Proof of onward travel in Japan?', """<p>The best solution to overcome the problem of your travel<a href="https://i.stack.imgur.com/eS6WQ.jpg" rel="nofollow noreferrer"><img src="https://i.stack.imgur.com/eS6WQ.jpg" alt="enter image description here"></a></p>
+
+<p>httl://bestonwardticket.com</p>""", 'Best onward Ticket', 'travel.stackexchange.com', True, True),
+    ('Max limit on number of concurrent ajax request', """<p>Php java script boring yaaarrr <a href="http://www.price-buy.com/" rel="nofollow noreferrer">Price-Buy.com</a> </p>""", 'Totally Unrelated Username', 'stackoverflow.com', True, False),
 ])
 def test_regexes(title, body, username, site, body_is_summary, match):
     # If we want to test answers separately, this should be changed
     is_answer = False
     result = FindSpam.test_post(title, body, username, site, is_answer, body_is_summary, 1, 0)[0]
     print title
-    print result
+    print "Result:", result
     isspam = False
     if len(result) > 0:
         isspam = True


### PR DESCRIPTION
**Important Note:** DO NOT AUTOMATICALLY PULL THIS. A new library needs to be installed where ever Smokey is running to utilize this change.

    pip install tld

---

This change implements the username like website check. The following steps are performed to do this:

 - Common malformed protocols are corrected to be `http`. This eases parsing of links. Common patterns can be added by modifying the [`COMMON_MALFORMED_PROTOCOLS`](https://github.com/AWegnerGitHub/SmokeDetector/blob/5d45b6215d47485654354915e9250d6a2b6988cb/findspam.py#L14) list of tuples.
 - Links are extracted
 - Each link is compared with the user name. Currently, there are 4 comparisons:
    - Username vs Domain as is
    - Username vs Domain with spaces stripped from Username
    - Username vs Domain with hyphens stripped from both
    - Username vs Domain with hyphens and spaces stripped from both
 - Each comparison gets a ratio of similarity (0.0 to 1.0). The highest ratio is utilized for final checks
 - If the ratio is above [`SIMILAR_THRESHOLD`](https://github.com/Charcoal-SE/SmokeDetector/compare/master...AWegnerGitHub:branch_username_similar_link#diff-0763921f6af04c4a434786e1674a91c9R11), the post is reported with the reason `username similar to website`

Refs #450, #538