### PR TITLE
Change repo link to description in report prefix

### DIFF
--- a/spamhandling.py
+++ b/spamhandling.py
@@ -117,7 +117,7 @@ def handle_spam(title, body, poster, site, post_url, poster_url, post_id, reason
         title = parsing.escape_special_chars_in_title(title)
         sanitized_title = regex.sub('(https?://|\n)', '', title)
 
-        prefix = u"[ [SmokeDetector](//git.io/vgx7b) ]"
+        prefix = u"[ [SmokeDetector](//goo.gl/eLDYqh) ]"
         if GlobalVars.metasmoke_key:
             prefix_ms = u"[ [SmokeDetector](//git.io/vgx7b) | [MS](//m.erwaysoftware.com/posts/by-url?url=" + \
                         post_url + ") ]"


### PR DESCRIPTION
As per the first point of #488, this replaces the link to the repository with a shortened URL to the 'What's Smokey' section of our website. This would be more useful to newcomers than the repo link, and you can still access the repo via the pinned projects in CHQ.

Note that the prefix for the startup message remains unchanged (still pointing to the repo), as it is more likely that people would like to be linked to the repo then.

https://goo.gl/eLDYqh -> http://charcoal-se.org/#whats-smokey (sadly, git.io only works for Github pages sites under the .github.io domain.)

If there aren't any concerns, I'll merge this tomorrow.