### PR TITLE
Remove "standby" from runtime arguments when 'pull' is called

### DIFF
--- a/nocrash.py
+++ b/nocrash.py
@@ -41,7 +41,7 @@ while stoprunning is False:
     # print "[NoCrash] Switch to Standby? %s" % switch_to_standby
 
     if count == 0:
-        if switch_to_standby or ("standby" in sys.argv):
+        if switch_to_standby or ("standby" in persistent_arguments):
             switch_to_standby = False  # Necessary for the while loop
             command = 'python ws.py standby'.split()
         else:
@@ -66,8 +66,8 @@ while stoprunning is False:
         git.submodule('update')
         count = 0
         crashcount = 0
-        if "standby" in sys.argv:
-            sys.argv.remove("standby")
+        if "standby" in persistent_arguments:
+            persistent_arguments.remove("standby")
 
     elif ecode == 4:
         # print "[NoCrash] Crashed."

--- a/nocrash.py
+++ b/nocrash.py
@@ -66,6 +66,8 @@ while stoprunning is False:
         git.submodule('update')
         count = 0
         crashcount = 0
+        if "standby" in sys.argv:
+            sys.argv.remove("standby")
 
     elif ecode == 4:
         # print "[NoCrash] Crashed."


### PR DESCRIPTION
This is to avoid a failover tug of war whenever `!!/pull` is used.  If we passed `standby` into `nocrash.py`, we should remove `standby` from the `persistent_arguments` variable, so that we don't autolaunch into Standby every time.  This way we're almost guaranteed to have at least one instance of Smokey in 'active' mode.

This required a couple additional changes.  We now check `persistent_arguments` instead of `sys.argv` for determining if we 'standby' launch.  We then add an `if` statement to 'remove' `standby` from the persistent args if we've quit with code 3 (the "pull" command code).  This way we don't 'restart' in standby mode in such cases, even if we don't intend for that to happen.