### PR TITLE
Try and better handle logon failures and "Invalid Literal"

### DIFF
--- a/ws.py
+++ b/ws.py
@@ -98,30 +98,33 @@ load_files()
 filter_auto_ignored_posts()
 
 # chat.stackexchange.com logon/wrapper
-while True:
+for chatlogoncount in range(1,10):
     try:
         GlobalVars.wrap.login(username, password)
         GlobalVars.smokeDetector_user_id[GlobalVars.charcoal_room_id] = str(GlobalVars.wrap.get_me().id)
         break  # If we didn't error out horribly, we can be done with this loop
     except ValueError:
+        time.sleep(1)
         continue  # If we did error, we need to try this again.
 
 # chat.meta.stackexchange.com logon/wrapper
-while True:
+for metalogoncount in range(1,10):
     try:
         GlobalVars.wrapm.login(username, password)
         GlobalVars.smokeDetector_user_id[GlobalVars.meta_tavern_room_id] = str(GlobalVars.wrapm.get_me().id)
         break  # If we didn't error out horribly, we can be done with this loop
     except ValueError:
+        time.sleep(1)
         continue  # If we did error, we need to try this again.
 
 # chat.stackoverflow.com logon/wrapper
-while True:
+for sologoncount in range(1,10):
     try:
         GlobalVars.wrapso.login(username, password)
         GlobalVars.smokeDetector_user_id[GlobalVars.socvr_room_id] = str(GlobalVars.wrapso.get_me().id)
         break  # If we didn't error out horribly, we can be done with this loop
     except ValueError:
+        time.sleep(1)
         continue  # If we did error, we need to try this again.
 
 GlobalVars.s = "[ " + GlobalVars.chatmessage_prefix + " ] " \

--- a/ws.py
+++ b/ws.py
@@ -98,7 +98,9 @@ load_files()
 filter_auto_ignored_posts()
 
 # chat.stackexchange.com logon/wrapper
-for chatlogoncount in range(1,10):
+chatlogoncount = 0
+for cl in range(1,10):
+    chatlogoncount += 1
     try:
         GlobalVars.wrap.login(username, password)
         GlobalVars.smokeDetector_user_id[GlobalVars.charcoal_room_id] = str(GlobalVars.wrap.get_me().id)
@@ -106,9 +108,13 @@ for chatlogoncount in range(1,10):
     except ValueError:
         time.sleep(1)
         continue  # If we did error, we need to try this again.
+if chatlogoncount >= 10:  # Handle "too many logon attempts" case to prevent infinite looping
+    raise RuntimeError("Could not get Chat.SE logon.")
 
 # chat.meta.stackexchange.com logon/wrapper
-for metalogoncount in range(1,10):
+metalogoncount = 0
+for cml in range(1,10):
+    metalogoncount += 1
     try:
         GlobalVars.wrapm.login(username, password)
         GlobalVars.smokeDetector_user_id[GlobalVars.meta_tavern_room_id] = str(GlobalVars.wrapm.get_me().id)
@@ -116,9 +122,13 @@ for metalogoncount in range(1,10):
     except ValueError:
         time.sleep(1)
         continue  # If we did error, we need to try this again.
+if metalogoncount >= 10:  # Handle "too many logon attempts" case to prevent infinite looping
+        raise RuntimeError("Could not get Chat.Meta.SE logon.")
 
 # chat.stackoverflow.com logon/wrapper
-for sologoncount in range(1,10):
+sologoncount = 0
+for sol in range(1,10):
+    sologoncount += 1
     try:
         GlobalVars.wrapso.login(username, password)
         GlobalVars.smokeDetector_user_id[GlobalVars.socvr_room_id] = str(GlobalVars.wrapso.get_me().id)
@@ -126,6 +136,8 @@ for sologoncount in range(1,10):
     except ValueError:
         time.sleep(1)
         continue  # If we did error, we need to try this again.
+if sologoncount >= 10:  # Handle "too many logon attempts" case to prevent infinite looping
+    raise RuntimeError("Could not get Chat.SO logon.")
 
 GlobalVars.s = "[ " + GlobalVars.chatmessage_prefix + " ] " \
                "SmokeDetector started at [rev " +\

--- a/ws.py
+++ b/ws.py
@@ -105,7 +105,7 @@ for cl in range(1, 10):
         GlobalVars.wrap.login(username, password)
         GlobalVars.smokeDetector_user_id[GlobalVars.charcoal_room_id] = str(GlobalVars.wrap.get_me().id)
         break  # If we didn't error out horribly, we can be done with this loop
-    except ValueError:
+    except (ValueError, AssertionError):
         time.sleep(1)
         continue  # If we did error, we need to try this again.
 if chatlogoncount >= 10:  # Handle "too many logon attempts" case to prevent infinite looping
@@ -119,7 +119,7 @@ for cml in range(1, 10):
         GlobalVars.wrapm.login(username, password)
         GlobalVars.smokeDetector_user_id[GlobalVars.meta_tavern_room_id] = str(GlobalVars.wrapm.get_me().id)
         break  # If we didn't error out horribly, we can be done with this loop
-    except ValueError:
+    except (ValueError, AssertionError):
         time.sleep(1)
         continue  # If we did error, we need to try this again.
 if metalogoncount >= 10:  # Handle "too many logon attempts" case to prevent infinite looping
@@ -133,7 +133,7 @@ for sol in range(1, 10):
         GlobalVars.wrapso.login(username, password)
         GlobalVars.smokeDetector_user_id[GlobalVars.socvr_room_id] = str(GlobalVars.wrapso.get_me().id)
         break  # If we didn't error out horribly, we can be done with this loop
-    except ValueError:
+    except (ValueError, AssertionError):
         time.sleep(1)
         continue  # If we did error, we need to try this again.
 if sologoncount >= 10:  # Handle "too many logon attempts" case to prevent infinite looping

--- a/ws.py
+++ b/ws.py
@@ -100,10 +100,10 @@ filter_auto_ignored_posts()
 while True:
     try:
         GlobalVars.wrap.login(username, password)
-        GlobalVars.wrapm.login(username, password)
-        GlobalVars.wrapso.login(username, password)
         GlobalVars.smokeDetector_user_id[GlobalVars.charcoal_room_id] = str(GlobalVars.wrap.get_me().id)
+        GlobalVars.wrapm.login(username, password)
         GlobalVars.smokeDetector_user_id[GlobalVars.meta_tavern_room_id] = str(GlobalVars.wrapm.get_me().id)
+        GlobalVars.wrapso.login(username, password)
         GlobalVars.smokeDetector_user_id[GlobalVars.socvr_room_id] = str(GlobalVars.wrapso.get_me().id)
         break  # If we've gotten here, we don't need to continue in this loop, so 'break' from it
     except ValueError:

--- a/ws.py
+++ b/ws.py
@@ -99,7 +99,7 @@ filter_auto_ignored_posts()
 
 # chat.stackexchange.com logon/wrapper
 chatlogoncount = 0
-for cl in range(1,10):
+for cl in range(1, 10):
     chatlogoncount += 1
     try:
         GlobalVars.wrap.login(username, password)
@@ -113,7 +113,7 @@ if chatlogoncount >= 10:  # Handle "too many logon attempts" case to prevent inf
 
 # chat.meta.stackexchange.com logon/wrapper
 metalogoncount = 0
-for cml in range(1,10):
+for cml in range(1, 10):
     metalogoncount += 1
     try:
         GlobalVars.wrapm.login(username, password)
@@ -127,7 +127,7 @@ if metalogoncount >= 10:  # Handle "too many logon attempts" case to prevent inf
 
 # chat.stackoverflow.com logon/wrapper
 sologoncount = 0
-for sol in range(1,10):
+for sol in range(1, 10):
     sologoncount += 1
     try:
         GlobalVars.wrapso.login(username, password)

--- a/ws.py
+++ b/ws.py
@@ -97,12 +97,17 @@ GlobalVars.bodyfetcher = BodyFetcher()
 load_files()
 filter_auto_ignored_posts()
 
-GlobalVars.wrap.login(username, password)
-GlobalVars.wrapm.login(username, password)
-GlobalVars.wrapso.login(username, password)
-GlobalVars.smokeDetector_user_id[GlobalVars.charcoal_room_id] = str(GlobalVars.wrap.get_me().id)
-GlobalVars.smokeDetector_user_id[GlobalVars.meta_tavern_room_id] = str(GlobalVars.wrapm.get_me().id)
-GlobalVars.smokeDetector_user_id[GlobalVars.socvr_room_id] = str(GlobalVars.wrapso.get_me().id)
+while True:
+    try:
+        GlobalVars.wrap.login(username, password)
+        GlobalVars.wrapm.login(username, password)
+        GlobalVars.wrapso.login(username, password)
+        GlobalVars.smokeDetector_user_id[GlobalVars.charcoal_room_id] = str(GlobalVars.wrap.get_me().id)
+        GlobalVars.smokeDetector_user_id[GlobalVars.meta_tavern_room_id] = str(GlobalVars.wrapm.get_me().id)
+        GlobalVars.smokeDetector_user_id[GlobalVars.socvr_room_id] = str(GlobalVars.wrapso.get_me().id)
+        break  # If we've gotten here, we don't need to continue in this loop, so 'break' from it
+    except ValueError:
+        continue  # If we've gotten here, we need to continue going through the loop.
 
 GlobalVars.s = "[ " + GlobalVars.chatmessage_prefix + " ] " \
                "SmokeDetector started at [rev " +\

--- a/ws.py
+++ b/ws.py
@@ -97,17 +97,32 @@ GlobalVars.bodyfetcher = BodyFetcher()
 load_files()
 filter_auto_ignored_posts()
 
+# chat.stackexchange.com logon/wrapper
 while True:
     try:
         GlobalVars.wrap.login(username, password)
         GlobalVars.smokeDetector_user_id[GlobalVars.charcoal_room_id] = str(GlobalVars.wrap.get_me().id)
+        break  # If we didn't error out horribly, we can be done with this loop
+    except ValueError:
+        continue  # If we did error, we need to try this again.
+
+# chat.meta.stackexchange.com logon/wrapper
+while True:
+    try:
         GlobalVars.wrapm.login(username, password)
         GlobalVars.smokeDetector_user_id[GlobalVars.meta_tavern_room_id] = str(GlobalVars.wrapm.get_me().id)
+        break  # If we didn't error out horribly, we can be done with this loop
+    except ValueError:
+        continue  # If we did error, we need to try this again.
+
+# chat.stackoverflow.com logon/wrapper
+while True:
+    try:
         GlobalVars.wrapso.login(username, password)
         GlobalVars.smokeDetector_user_id[GlobalVars.socvr_room_id] = str(GlobalVars.wrapso.get_me().id)
-        break  # If we've gotten here, we don't need to continue in this loop, so 'break' from it
+        break  # If we didn't error out horribly, we can be done with this loop
     except ValueError:
-        continue  # If we've gotten here, we need to continue going through the loop.
+        continue  # If we did error, we need to try this again.
 
 GlobalVars.s = "[ " + GlobalVars.chatmessage_prefix + " ] " \
                "SmokeDetector started at [rev " +\


### PR DESCRIPTION
This issue has plagued us in the past.  Logon may randomly fail, and we get an "invalid literal" error when trying to parse a string as an int.  Our first attempt at this capture didn't fix the core issue.

This is a major refactor to the logon process, *but* it will give us a better way of handling things.

Firstly, split the individual logons and value acquisitions into separate little segments of code.

Secondly, put a `for` loop around each segment, and track how many times we've iterated over the logon attempts, waiting 1 second between each failed attempt.  This also limits us to 10 attempts by 'for' loops.  We then try to get the logon data and values that are valid, but when it fails it waits a second, then goes to the next item in the loop and tries again.  The moment we've got a valid logon and we don't get a value error, we can continue on.

Thirdly, if we've tried 10 times and still are failing, die off hard with a "RuntimeError" that will kill and reset the entire Smokey process (via the 'unhandled exception' hook).  There is one such "Die" case for each chat wrapper.  This is a much more painful approach to this, but will better allow us to handle chat death errors on 'invalid literal' and 'attempt' to logon again after waiting a short while.  There's probably better approaches to this, but this should work to evade those invalid literal errors.

This must be reviewed ***before*** being merged, for sanity.