### PR TITLE
Fix leak of api_request_lock

### DIFF
--- a/apigetpost.py
+++ b/apigetpost.py
@@ -30,6 +30,7 @@ def api_get_post(post_url):
         time.sleep(GlobalVars.api_backoff_time - time.time() + 2)
     d = parsing.fetch_post_id_and_site_from_url(post_url)
     if d is None:
+        GlobalVars.api_request_lock.release()
         return None
     post_id, site, post_type = d
     if post_type == "answer":
@@ -46,6 +47,7 @@ def api_get_post(post_url):
         if GlobalVars.api_backoff_time < time.time() + response["backoff"]:
             GlobalVars.api_backoff_time = time.time() + response["backoff"]
     if 'items' not in response or len(response['items']) == 0:
+        GlobalVars.api_request_lock.release()
         return False
     GlobalVars.api_request_lock.release()
 

--- a/bodyfetcher.py
+++ b/bodyfetcher.py
@@ -199,6 +199,7 @@ class BodyFetcher:
             else:
                 self.queue[site] = posts
             self.queue_modify_lock.release()
+            GlobalVars.api_request_lock.release()
             return
 
         self.api_data_lock.acquire()


### PR DESCRIPTION
`api_get_post` has error handling in case it is passed an invalid URL or the API does not return any `items`.  However, this error handling does not release `api_request_lock`, causing a deadlock the next time `api_get_post` is called.  A similar bug occurs in `bodyfetcher.py`.

This bug is *a* cause of `!!/report` breaking, but it may not be *the* cause.