### PR TITLE
add_to_blacklist(): explicitly push to master

### DIFF
--- a/gitmanager.py
+++ b/gitmanager.py
@@ -93,7 +93,7 @@ class GitManager:
         if code_permissions:
             git.checkout("master")
             git.merge(branch)
-            git.push("master")
+            git.push("origin", "master")
             git.branch('-D', branch)  # Delete the branch in the local git tree since we're done with it.
         else:
             git.push("origin", branch)

--- a/gitmanager.py
+++ b/gitmanager.py
@@ -93,7 +93,7 @@ class GitManager:
         if code_permissions:
             git.checkout("master")
             git.merge(branch)
-            git.push()
+            git.push("master")
             git.branch('-D', branch)  # Delete the branch in the local git tree since we're done with it.
         else:
             git.push("origin", branch)


### PR DESCRIPTION
This attempts to work around the "git push.default simple" symptom.

See also http://stackoverflow.com/questions/21772279/why-is-pushing-to-matching-the-default-in-git/21772695#21772695

Example transcript:
http://chat.stackexchange.com/transcript/message/36096835#36096835