### PR TITLE
Measure post queue timings

### DIFF
--- a/bodyfetcher.py
+++ b/bodyfetcher.py
@@ -1,6 +1,6 @@
 from spamhandling import handle_spam, check_if_spam
-from datahandling import add_or_update_api_data, clear_api_data, store_bodyfetcher_queue, store_bodyfetcher_max_ids,
-                         store_queue_timings
+from datahandling import (add_or_update_api_data, clear_api_data, store_bodyfetcher_queue, store_bodyfetcher_max_ids,
+                          store_queue_timings)
 from globalvars import GlobalVars
 from operator import itemgetter
 from datetime import datetime

--- a/bodyfetcher.py
+++ b/bodyfetcher.py
@@ -1,5 +1,6 @@
 from spamhandling import handle_spam, check_if_spam
-from datahandling import add_or_update_api_data, clear_api_data, store_bodyfetcher_queue, store_bodyfetcher_max_ids
+from datahandling import add_or_update_api_data, clear_api_data, store_bodyfetcher_queue, store_bodyfetcher_max_ids,
+                         store_queue_timings
 from globalvars import GlobalVars
 from operator import itemgetter
 from datetime import datetime
@@ -14,6 +15,7 @@ from classes import Post
 class BodyFetcher:
     queue = {}
     previous_max_ids = {}
+    queue_timings = {}
 
     special_cases = {
         "math.stackexchange.com": 15,
@@ -65,6 +67,7 @@ class BodyFetcher:
     api_data_lock = threading.Lock()
     queue_modify_lock = threading.Lock()
     max_ids_modify_lock = threading.Lock()
+    queue_timing_modify_lock = threading.Lock()
 
     def add_to_queue(self, post, should_check_site=False):
         mse_sandbox_id = 3122
@@ -81,10 +84,10 @@ class BodyFetcher:
         if post_id == mse_sandbox_id and site_base == "meta.stackexchange.com":
             return  # don't check meta sandbox, it's full of weird posts
         self.queue_modify_lock.acquire()
-        if site_base in self.queue:
-            self.queue[site_base].append(post_id)
-        else:
-            self.queue[site_base] = [post_id]
+        if site_base not in self.queue:
+            self.queue[site_base] = {}
+
+        self.queue[site_base][post_id] = datetime.utcnow()
         self.queue_modify_lock.release()
 
         if should_check_site:
@@ -123,10 +126,26 @@ class BodyFetcher:
             return
 
         self.queue_modify_lock.acquire()
-        new_post_ids = self.queue.pop(site)
+        new_posts = self.queue.pop(site)
         store_bodyfetcher_queue()
         self.queue_modify_lock.release()
 
+        new_post_ids = [k for k, v in new_posts.iteritems()]
+
+        self.queue_timing_modify_lock.acquire()
+        post_add_times = [v for k, v in new_posts.iteritems()]
+        pop_time = datetime.utcnow()
+
+        for add_time in post_add_times:
+            seconds_in_queue = (pop_time - add_time).total_seconds()
+            if site in self.queue_timings:
+                self.queue_timings[site].append(seconds_in_queue)
+            else:
+                self.queue_timings[site] = [seconds_in_queue]
+
+        store_queue_timings()
+
+        self.queue_timing_modify_lock.release()
         self.max_ids_modify_lock.acquire()
 
         if site in self.previous_max_ids and max(new_post_ids) > self.previous_max_ids[site]:

--- a/bodyfetcher.py
+++ b/bodyfetcher.py
@@ -87,7 +87,7 @@ class BodyFetcher:
         if site_base not in self.queue:
             self.queue[site_base] = {}
 
-        self.queue[site_base][post_id] = datetime.utcnow()
+        self.queue[site_base][str(post_id)] = datetime.utcnow()
         self.queue_modify_lock.release()
 
         if should_check_site:
@@ -130,7 +130,7 @@ class BodyFetcher:
         store_bodyfetcher_queue()
         self.queue_modify_lock.release()
 
-        new_post_ids = [k for k, v in new_posts.iteritems()]
+        new_post_ids = [int(k) for k, v in new_posts.iteritems()]
 
         self.queue_timing_modify_lock.acquire()
         post_add_times = [v for k, v in new_posts.iteritems()]

--- a/datahandling.py
+++ b/datahandling.py
@@ -289,6 +289,7 @@ def store_bodyfetcher_max_ids():
     with open("bodyfetcherMaxIds.p", "wb") as f:
         pickle.dump(GlobalVars.bodyfetcher.previous_max_ids, f, protocol=pickle.HIGHEST_PROTOCOL)
 
+
 def store_queue_timings():
     with open("bodyfetcherQueueTimings.p", "wb") as f:
         pickle.dump(GlobalVars.bodyfetcher.queue_timings, f, protocol=pickle.HIGHEST_PROTOCOL)

--- a/datahandling.py
+++ b/datahandling.py
@@ -69,6 +69,14 @@ def load_files():
             os.remove("bodyfetcherMaxIds.p")
             raise
 
+    if os.path.isfile("bodyfetcherQueueTimings.p"):
+        try:
+            with open("bodyfetcherQueueTimings.p", "rb") as f:
+                GlobalVars.bodyfetcher.queue_timings = pickle.load(f)
+        except EOFError:
+            os.remove("bodyfetcherQueueTimings.p")
+            raise
+
 
 def filter_auto_ignored_posts():
     today_date = datetime.today()

--- a/datahandling.py
+++ b/datahandling.py
@@ -289,6 +289,10 @@ def store_bodyfetcher_max_ids():
     with open("bodyfetcherMaxIds.p", "wb") as f:
         pickle.dump(GlobalVars.bodyfetcher.previous_max_ids, f, protocol=pickle.HIGHEST_PROTOCOL)
 
+def store_queue_timings():
+    with open("bodyfetcherQueueTimings.p", "wb") as f:
+        pickle.dump(GlobalVars.bodyfetcher.queue_timings, f, protocol=pickle.HIGHEST_PROTOCOL)
+
 
 # methods that help avoiding reposting alerts:
 

--- a/queue_timings.py
+++ b/queue_timings.py
@@ -1,0 +1,27 @@
+# queue_timings.py
+# Analysis script for bodyfetcher queue timings. Call from the command line using Python 3.
+
+import os.path
+import cPickle as pickle
+
+
+def main():
+    if os.path.isfile("bodyfetcherQueueTimings.p"):
+        try:
+            with open("bodyfetcherQueueTimings.p", "rb") as f:
+                queue_data = pickle.load(f)
+        except EOFError:
+            print("Hit EOFError while reading file. Smokey handles this by deleting the file.")
+            resp = input("Delete? (y/n)").lower()
+            if resp == "y":
+                os.remove("bodyfetcherQueueTimings.p")
+
+        for site, times in queue_data:
+            print("{0}: min {1}, max {2}, avg {3}".format(site, min(times), max(times), sum(times) / len(times)))
+
+    else:
+        print("bodyfetcherQueueTimings.p doesn't exist. No data to analyse.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This should measure how long a post has been in the bodyfetcher queue at the point that the API call for its site is made. It stores the timings locally in `bodyfetcherQueueTimings.p` so that stats can be analysed. Also created a Python script to do that analysis.

PR'd so I can get a code review, and cc @Undo1 since he was talking about doing this.