### PR TITLE
Added whitespace-only link rule

### DIFF
--- a/findspam.py
+++ b/findspam.py
@@ -897,6 +897,10 @@ class FindSpam:
         {'method': mostly_dots, 'all': True, 'sites': ['codegolf.stackexchange.com'],
          'reason': 'mostly dots in {}', 'title': True, 'body': True, 'username': False, 'body_summary': False,
          'stripcodeblocks': True, 'max_rep': 50, 'max_score': 0},
+        # Whitespace-only link
+        {'regex': ur'<a href=".*?">\p{Zs}+?</a>', 'all': True, 'sites': [],
+         'reason': 'whitespace-only link in {}', 'title': False, 'body': True, 'username': False, 'body_summary': False,
+         'stripcodeblocks': True, 'max_rep': 50, 'max_score': 0},
 
         #
         # Category: other


### PR DESCRIPTION
This will probably be fixed soon, but currently "invisible" links can be made using whitespace. This should catch those (and catch any fancy Unicode whitespace).