### PR TITLE
Add click2trial.com to blacklist

### DIFF
--- a/blacklisted_websites.txt
+++ b/blacklisted_websites.txt
@@ -914,3 +914,4 @@ sysinfotools\.com
 easytechtools\.com
 www\.pokemonomegarubyandalphasapphiredownload\.com
 alphagenixsweden\.com
+click2trial\.com


### PR DESCRIPTION
[Metasmoke Search](https://metasmoke.erwaysoftware.com/search?utf8=%E2%9C%93&title=&body_is_regex=1&body=click2trial&username=&why=&site=&feedback=&reason=&user_rep_direction=%3E%3D&user_reputation=0&commit=Search) - been used in 7 spam posts over the last couple of weeks now