### PR TITLE
findspam.py: add Pune to city_list

### DIFF
--- a/findspam.py
+++ b/findspam.py
@@ -544,10 +544,14 @@ class FindSpam:
         r"celebritynetworth"
     ]
     city_list = [
-        "Agra", "Amritsar", "Bangalore", "Bhopal", "Chandigarh", "Chennai", "Coimbatore", "Delhi", "Dubai", "Durgapur",
-        "Ghaziabad", "Hyderabad", "Jaipur", "Jalandhar", "Kolkata", "Ludhiana", "Mumbai", "Madurai", "Patna",
-        "Portland", "Rajkot", "Surat", "Telangana", "Udaipur", "Uttarakhand", "India", "Pakistan", "Noida",
+        "Agra", "Amritsar", "Bangalore", "Bhopal", "Chandigarh",
+        "Chennai", "Coimbatore", "Delhi", "Dubai", "Durgapur",
+        "Ghaziabad", "Hyderabad", "Jaipur", "Jalandhar", "Kolkata",
+        "Ludhiana", "Mumbai", "Madurai", "Patna", "Portland",
+        "Rajkot", "Surat", "Telangana", "Udaipur", "Uttarakhand",
+        "Noida", "Pune",
         # yes, these aren't cities but...
+        "India", "Pakistan",
     ]
     rules = [
         # Sites in sites[] will be excluded if 'all' == True.  Whitelisted if 'all' == False.


### PR DESCRIPTION
Pune is a large city in India which frequently occurs in spam
(Metasmoke stats are currently 32 TP / 5 FP / 1 NAA).

http://chat.stackexchange.com/transcript/11540?m=36640159#36640159