### PR TITLE
Add (?#review) comments to preemptive listings

### DIFF
--- a/bad_keywords.txt
+++ b/bad_keywords.txt
@@ -363,6 +363,6 @@ neuro\Wxr
 test\Wshred
 phallyx
 nuvapelle
-jullen(?#review)
+jullen
 nos\Wex(?#review)
 platinum\Wbeaute

--- a/bad_keywords.txt
+++ b/bad_keywords.txt
@@ -358,12 +358,12 @@ testx\Wcore
 lumidaire
 embova
 core\Wskincare
-leallure
+leallure(?#review)
 neuro\Wxr
 test\Wshred
 phallyx
 nuvapelle
 
-jullen
-nos\Wex
+jullen(?#review)
+nos\Wex(?#review)
 platinum\Wbeaute

--- a/bad_keywords.txt
+++ b/bad_keywords.txt
@@ -358,7 +358,7 @@ testx\Wcore
 lumidaire
 embova
 core\Wskincare
-leallure(?#review)
+leallure
 neuro\Wxr
 test\Wshred
 phallyx

--- a/bad_keywords.txt
+++ b/bad_keywords.txt
@@ -371,3 +371,4 @@ body\Wblast
 dermessence
 
 avalure
+nevi(?#review)

--- a/bad_keywords.txt
+++ b/bad_keywords.txt
@@ -366,3 +366,4 @@ nuvapelle
 jullen
 nos\Wex(?#review)
 platinum\Wbeaute
+illujen(?#review)


### PR DESCRIPTION
For documentation, add a regex comment (which does not affect the matching behavior; it just gets quietly ignored) on recently added phrases which should be reviewed in a few days.

If we agree that this is a good idea, this should be codified and documented properly.

I tried to initiate a discussion at http://chat.stackexchange.com/transcript/message/36827286#36827286 but I have not seen any responses yet.  Also previously http://chat.stackexchange.com/transcript/message/36802878#36802878

> that was a solid 24/24 TP rate but I'm thinking we should simply blacklist on first sight when it's clear from context that it's yet another head on the Indian pharma spam hydra

I tagged the ones I added preemptively http://chat.stackexchange.com/search?q=preemptive&user=&room=11540 but this is obviously less than ideal.