### PR TITLE
gitmanager.py: empty line fix for Python 3

### DIFF
--- a/gitmanager.py
+++ b/gitmanager.py
@@ -77,7 +77,7 @@ class GitManager:
         # Add item to file
         with open(blacklist_file_name, "a+") as blacklist_file:
             last_character = blacklist_file.read()[-1:]
-            if last_character != "\n":
+            if last_character not in ["", "\n"]:
                 blacklist_file.write("\n")
             blacklist_file.write(item_to_blacklist + "\n")
 


### PR DESCRIPTION
read() on a file opened with 'a+' mode yields an empty string.
Accommodate by looking for either that or '\n' at the end.

Regression; see also [PR#658](https://github.com/Charcoal-SE/SmokeDetector/pull/658) which fixes recent symptoms.