### PR TITLE
findspam.py: New reason "Bad pattern in URL"

### DIFF
--- a/findspam.py
+++ b/findspam.py
@@ -277,7 +277,7 @@ def bad_link_text(s, site, *args):   # suspicious text of a hyperlink
 # noinspection PyUnusedLocal,PyMissingTypeHints
 def bad_pattern_in_url(s, site, *args):
     patterns = [
-        r'[^"]*-reviews(?:-(?:canada|(?:and|or)-scam))?/?',
+        r'[^"]*-reviews?(?:-(?:canada|(?:and|or)-scam))?/?',
     ]
     matches = regex.compile(
         r'<a href="(?P<frag>{0})"|<a href="[^"]*"(?:\s+"[^"]*")*>(?P<frag>{0})</a>'.format(

--- a/findspam.py
+++ b/findspam.py
@@ -275,19 +275,17 @@ def bad_link_text(s, site, *args):   # suspicious text of a hyperlink
 
 
 # noinspection PyUnusedLocal,PyMissingTypeHints
-def bad_fragment_in_link(s, site, *args):
-    fragments = [
+def bad_pattern_in_url(s, site, *args):
+    patterns = [
         r'[^"]*-reviews(?:-(?:canada|(?:and|or)-scam))?/?',
     ]
-    bad_frag = regex.compile(
+    matches = regex.compile(
         r'<a href="(?P<frag>{0})"|<a href="[^"]*"(?:\s+"[^"]*")*>(?P<frag>{0})</a>'.format(
-            '|'.join(fragments)), regex.UNICODE).findall(s)
-    if bad_frag:
-        log('warn', 'is true {0!r}'.format(bad_frag))
+            '|'.join(patterns)), regex.UNICODE).findall(s)
+    if matches:
         return True, u"Bad fragment in link {}".format(
-            ", ".join(["".join(match) for match in bad_frag]))
+            ", ".join(["".join(match) for match in matches]))
     else:
-        log('warn', 'is false {0!r}, post {1!r}'.format(bad_frag, s))
         return False, ""
 
 
@@ -708,8 +706,8 @@ class FindSpam:
          'sites': [], 'reason': 'bad keyword in link text in {}', 'title': False, 'body': True, 'username': False,
          'stripcodeblocks': True, 'body_summary': False, 'max_rep': 1, 'max_score': 0},
         # Bad fragment in link
-        {'method': bad_fragment_in_link, 'all': True, 'sites': [],
-         'reason': 'bad fragment in link {}',
+        {'method': bad_pattern_in_url, 'all': True, 'sites': [],
+         'reason': 'bad pattern in URL {}',
          'title': False, 'body': True, 'username': False,
          'stripcodeblocks': True, 'body_summary': True, 'max_rep': 1, 'max_score': 0},
         # Country-name domains, travel and expats sites are exempt

--- a/findspam.py
+++ b/findspam.py
@@ -275,6 +275,23 @@ def bad_link_text(s, site, *args):   # suspicious text of a hyperlink
 
 
 # noinspection PyUnusedLocal,PyMissingTypeHints
+def bad_fragment_in_link(s, site, *args):
+    fragments = [
+        r'[^"]*-reviews(?:-(?:canada|(?:and|or)-scam))?/?',
+    ]
+    bad_frag = regex.compile(
+        r'<a href="(?P<frag>{0})"|<a href="[^"]*"(?:\s+"[^"]*")*>(?P<frag>{0})</a>'.format(
+            '|'.join(fragments)), regex.UNICODE).findall(s)
+    if bad_frag:
+        log('warn', 'is true {0!r}'.format(bad_frag))
+        return True, u"Bad fragment in link {}".format(
+            ", ".join(["".join(match) for match in bad_frag]))
+    else:
+        log('warn', 'is false {0!r}, post {1!r}'.format(bad_frag, s))
+        return False, ""
+
+
+# noinspection PyUnusedLocal,PyMissingTypeHints
 def is_offensive_post(s, site, *args):
     if s is None or len(s) == 0:
         return False, ""
@@ -690,6 +707,11 @@ class FindSpam:
         {'method': bad_link_text, 'all': True,
          'sites': [], 'reason': 'bad keyword in link text in {}', 'title': False, 'body': True, 'username': False,
          'stripcodeblocks': True, 'body_summary': False, 'max_rep': 1, 'max_score': 0},
+        # Bad fragment in link
+        {'method': bad_fragment_in_link, 'all': True, 'sites': [],
+         'reason': 'bad fragment in link {}',
+         'title': False, 'body': True, 'username': False,
+         'stripcodeblocks': True, 'body_summary': True, 'max_rep': 1, 'max_score': 0},
         # Country-name domains, travel and expats sites are exempt
         {'regex': r"(?i)([\w-]{6}|shop)(australia|brazil|canada|denmark|france|india|mexico|norway|pakistan|"
                   r"spain|sweden)\w{0,4}\.(com|net)", 'all': True,

--- a/test/test_spamhandling.py
+++ b/test/test_spamhandling.py
@@ -33,9 +33,9 @@ with open("test/data_test_spamhandling.txt", "r") as f:
     ('Cannot access http://stackoverflow.com/ with proxy enabled', '', '', 'superuser.com', False),
     ('kkkkkkkkkkkkkkkkkkkkkkkkkkkk', '<p>bbbbbbbbbbbbbbbbbbbbbb</p>', '', 'stackoverflow.com', True),
     ('Enhance SD Male Enhancement Supplements', '', '', '', True),
-    ('Test case for bad fragment rule',
+    ('Test case for bad pattern in URL',
      '<p><a href="http://example.com/bad-reviews-canada/" rel="nofollow noreferrer">Cliquez ici</a></p>', '', '', True),
-    ('Another test case for bad fragment',
+    ('Another test case for bad URL pattern',
      '<p><a href="http://example.net/harmless/">http://example.org/pesky-reviews-and-scam</a></p>', '', '', True),
 ])
 def test_check_if_spam(title, body, username, site, match):

--- a/test/test_spamhandling.py
+++ b/test/test_spamhandling.py
@@ -32,7 +32,11 @@ with open("test/data_test_spamhandling.txt", "r") as f:
     ('Inner workings of muscles', '', '', 'fitness.stackexchange.com', False),
     ('Cannot access http://stackoverflow.com/ with proxy enabled', '', '', 'superuser.com', False),
     ('kkkkkkkkkkkkkkkkkkkkkkkkkkkk', '<p>bbbbbbbbbbbbbbbbbbbbbb</p>', '', 'stackoverflow.com', True),
-    ('Enhance SD Male Enhancement Supplements', '', '', '', True)
+    ('Enhance SD Male Enhancement Supplements', '', '', '', True),
+    ('Test case for bad fragment rule',
+     '<p><a href="http://example.com/bad-reviews-canada/" rel="nofollow noreferrer">Cliquez ici</a></p>', '', '', True),
+    ('Another test case for bad fragment',
+     '<p><a href="http://example.net/harmless/">http://example.org/pesky-reviews-and-scam</a></p>', '', '', True),
 ])
 def test_check_if_spam(title, body, username, site, match):
     # We can't check blacklists/whitelists in tests, so these are set to their default values


### PR DESCRIPTION
For the time being, it specifically matches URLs ending with "-reviews"
(with a couple of oddball variations from old spam).  This is a common
MO for the Indian pharma spammer.  Most of these spams are detected just
fine, but they are mutating brand names etc. incessantly and might one
day succeed in getting past the usual filters.  This is added as just
one more layer of "defense in depth".

It should be relatively easy to see how to add more fragments to the
rule in the future.

There are two new test cases to check both branches of the regex at
the heart of this rule.

Current Metasmoke report for a similar query suggests 3494/3494 TP rate:
https://metasmoke.erwaysoftware.com/search?utf8=%E2%9C%93&title=&body_is_regex=1&body=%28%5E%7C%5B%5EA-Za-z0-9_%5D%29%5BA-Za-z0-9_%5D%2B-reviews%28-%28canada%7C%28and%7Cor%29-scam%29%29%3F%2F%3F%3C%2Fa%3E&username=&why=&site=&feedback=&reason=&user_rep_direction=%3E%3D&user_reputation=0&commit=Search