### PR TITLE
Update bad keywords

### DIFF
--- a/bad_keywords.txt
+++ b/bad_keywords.txt
@@ -116,7 +116,7 @@ Push Money App
 Volive( Solutions)?
 Herbalife
 Accumass
-purple rhino male enhancement
+purple\Wrhino
 Dating Coaching
 (dietary|muscle)\Wsupplements?
 digital marketing course

--- a/bad_keywords.txt
+++ b/bad_keywords.txt
@@ -372,6 +372,6 @@ avalure
 allumiere
 male\Wenhancement
 tl900\Wheadlamp
-zytek
+zytek(xl)?
 biodermrx
 amore\Wskin


### PR DESCRIPTION
Allow "zytekxl" as well as "zytek".

Remove "male enhancement" (which is now separately blacklisted anyway) from "purple rhino" phrase and allow punctuation as well as space between the words (commonly, in URLs, it is instead a dash).  This captures five additional samples in the current Metasmoke database, two of which had a score only sligthtly over 190.

Details in individual commit messages.