### PR TITLE
bad_keywords.txt: Blacklist novellus alone

### DIFF
--- a/bad_keywords.txt
+++ b/bad_keywords.txt
@@ -343,7 +343,7 @@ hacker@
 nuvitaskin
 femme\W?youth
 priamax
-Novellus Skin
+novellus
 patriot\Wpower\Wgreens
 ultraderm
 colodetox


### PR DESCRIPTION
"Novellus Skin" was blacklisted, but "Novellus" occurs in recent spam
with a lot of other suffixes, too.