### PR TITLE
classes/Post.py: Don't pull in GlobalVars

### DIFF
--- a/bodyfetcher.py
+++ b/bodyfetcher.py
@@ -332,7 +332,11 @@ class BodyFetcher:
                 continue
 
             post['site'] = site
-            post_ = Post(api_response=post)
+            try:
+                post_ = Post(api_response=post)
+            except ValueError:
+                log('error', 'ValueError when parsing post {0!r}'.format(post_))
+                continue
 
             num_scanned += 1
 

--- a/bodyfetcher.py
+++ b/bodyfetcher.py
@@ -9,7 +9,7 @@ import json
 import time
 import threading
 import requests
-from classes import Post
+from classes import Post, PostParseError
 from helpers import log
 from itertools import chain
 
@@ -334,8 +334,9 @@ class BodyFetcher:
             post['site'] = site
             try:
                 post_ = Post(api_response=post)
-            except ValueError:
-                log('error', 'ValueError when parsing post {0!r}'.format(post_))
+            except PostParseError as err:
+                log('error', 'Error {0} when parsing post: {1!r}'.format(
+                    err, post_))
                 continue
 
             num_scanned += 1

--- a/classes/Post.py
+++ b/classes/Post.py
@@ -4,6 +4,13 @@ import html
 from typing import AnyStr, Union
 
 
+class PostParseError(Exception):
+    """
+    Error raised when a JSON entry could not be parsed.
+    """
+    pass
+
+
 class Post:
     _body = ""
     _body_is_summary = False
@@ -33,7 +40,7 @@ class Post:
         elif api_response is not None:
             self._parse_api_post(api_response)
         else:
-            raise ValueError("Must provide either JSON Data or an API Response object for Post object.")
+            raise PostParseError("Must provide either JSON Data or an API Response object for Post object.")
 
         return  # Required for PEP484 compliance
 
@@ -66,8 +73,10 @@ class Post:
         if text_data == "hb":
             return
 
-        # This could throw ValueError which needs to be caught
-        data = json.loads(text_data)
+        try:
+            data = json.loads(text_data)
+        except ValueError as err:
+            raise PostParseError('PostParseError {0}'.format(err))
 
         if "ownerUrl" not in data:
             # owner's account doesn't exist anymore, no need to post it in chat:

--- a/classes/Post.py
+++ b/classes/Post.py
@@ -1,6 +1,5 @@
 # coding=utf-8
 import json
-from globalvars import GlobalVars
 import html
 from typing import AnyStr, Union
 
@@ -67,12 +66,8 @@ class Post:
         if text_data == "hb":
             return
 
-        try:
-            data = json.loads(text_data)
-        except ValueError:
-            GlobalVars.charcoal_hq.send_message(u"Encountered ValueError parsing the following:\n{0}".format(json_data),
-                                                False)
-            return
+        # This could throw ValueError which needs to be caught
+        data = json.loads(text_data)
 
         if "ownerUrl" not in data:
             # owner's account doesn't exist anymore, no need to post it in chat:

--- a/classes/__init__.py
+++ b/classes/__init__.py
@@ -1,3 +1,3 @@
 # coding=utf-8
 # noinspection PyUnresolvedReferences
-from .Post import Post
+from .Post import Post, PostParseError

--- a/spamhandling.py
+++ b/spamhandling.py
@@ -67,7 +67,11 @@ def check_if_spam(post):
 
 # noinspection PyMissingTypeHints
 def check_if_spam_json(json_data):
-    post = classes.Post(json_data=json_data)
+    try:
+        post = classes.Post(json_data=json_data)
+    except ValueError:
+        log('error', 'ValueError when parsing json_data {0!r}'.format(json_data))
+        return False, '', ''
     is_spam, reason, why = check_if_spam(post)
     return is_spam, reason, why
 

--- a/spamhandling.py
+++ b/spamhandling.py
@@ -69,8 +69,9 @@ def check_if_spam(post):
 def check_if_spam_json(json_data):
     try:
         post = classes.Post(json_data=json_data)
-    except ValueError:
-        log('error', 'ValueError when parsing json_data {0!r}'.format(json_data))
+    except classes.PostParseError as err:
+        log('error', 'Parse error {0} when parsing json_data {1!r}'.format(
+            err, json_data))
         return False, '', ''
     is_spam, reason, why = check_if_spam(post)
     return is_spam, reason, why

--- a/test/test_parsing.py
+++ b/test/test_parsing.py
@@ -113,3 +113,15 @@ with open("test/data_test_parsing.txt", "r") as f:
 ])
 def test_parsing(input_data, parse_method, expected):
     assert parse_method(input_data.strip()) == expected
+
+
+# noinspection PyMissingTypeHints
+def test_post_parse_errors():
+    from classes import Post, PostParseError
+    failure = None
+    try:
+        failure = Post()
+        assert 'Post with no initializer did not fail' is False
+    except PostParseError:
+        pass
+    assert failure is None

--- a/test/test_spamhandling.py
+++ b/test/test_spamhandling.py
@@ -7,6 +7,7 @@ import os
 import json
 from classes import Post
 
+
 test_data_inputs = []
 with open("test/data_test_spamhandling.txt", "r") as f:
     # noinspection PyRedeclaration


### PR DESCRIPTION
For modularity, avoid doing anything with globals from this module.

Instead, possibly raise a ValueError for the caller to handle somehow.