### PR TITLE
Remove breast enlargement phrase from bad keywords

### DIFF
--- a/bad_keywords.txt
+++ b/bad_keywords.txt
@@ -65,7 +65,7 @@ bbwdesire
 rsorder
 Shopping ?Cart ?Elite
 Easy ?Data ?Feed
-breasts? enlargement
+breasts?\Wenlargement
 best (hotel|property) management
 eduCBA
 Solid[ -]?SEO[ -]?Tools

--- a/bad_keywords.txt
+++ b/bad_keywords.txt
@@ -65,7 +65,6 @@ bbwdesire
 rsorder
 Shopping ?Cart ?Elite
 Easy ?Data ?Feed
-breasts?\Wenlargement
 best (hotel|property) management
 eduCBA
 Solid[ -]?SEO[ -]?Tools


### PR DESCRIPTION
<del>Refactor "breasts? enlargement" to also work with e.g. a dash between the keywords,
as commonly seen e.g. in URLs.</del>