### PR TITLE
don't depend on GlobalVars

### DIFF
--- a/classes/Post.py
+++ b/classes/Post.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 import json
-from globalvars import GlobalVars
+from helpers import log
 import html
 from typing import AnyStr, Union
 
@@ -70,8 +70,7 @@ class Post:
         try:
             data = json.loads(text_data)
         except ValueError:
-            GlobalVars.charcoal_hq.send_message(u"Encountered ValueError parsing the following:\n{0}".format(json_data),
-                                                False)
+            log('error', u"Encountered ValueError parsing the following:\n{0}".format(json_data))
             return
 
         if "ownerUrl" not in data:
@@ -156,6 +155,9 @@ class Post:
                             # Go to next subkey
                             continue
                     continue  # Go to next key because we're done processing the 'owner' key.
+
+                if data[element] is None:
+                    continue
 
                 # Other keys
                 self[varmap] = data[element]


### PR DESCRIPTION
Instead, depend on helpers.log() for reporting parsing problems.

This makes the error less visible, but avoids the potential risks of using an exception (see discussion on [PR#668](/Charcoal-SE/SmokeDetector/pull/668), which this supersedes).

Also coincidentally fix the `api_response=` handling so that a `None` value will not override a default (notably, passing Metasmoke results with `"score": null` would fail further down in the code when you attempt to manipulate them).