### PR TITLE
Prevent report title from containing ], *, `, or \n

### DIFF
--- a/spamhandling.py
+++ b/spamhandling.py
@@ -110,7 +110,7 @@ def handle_spam(post, reasons, why):
         else:
             sanitized_title = regex.sub('(https?://|\n)', '', post.title)
 
-        sanitized_title = regex.sub('([\]*`])', r'\\$1', sanitized_title).replace('\n', u'\u23CE')
+        sanitized_title = regex.sub(r'([\]*`])', r'\\$1', sanitized_title).replace('\n', u'\u23CE')
 
         prefix = u"[ [SmokeDetector](//goo.gl/eLDYqh) ]"
         if GlobalVars.metasmoke_key:

--- a/spamhandling.py
+++ b/spamhandling.py
@@ -109,8 +109,8 @@ def handle_spam(post, reasons, why):
             sanitized_title = regex.sub('(https?://|\n)', '', post.parent.title)
         else:
             sanitized_title = regex.sub('(https?://|\n)', '', post.title)
-            
-        sanitized_title = regex.sub('([\]*`])', r'\\$1', sanitzed_title).replace('\n', u'\u23CE')
+
+        sanitized_title = regex.sub('([\]*`])', r'\\$1', sanitized_title).replace('\n', u'\u23CE')
 
         prefix = u"[ [SmokeDetector](//goo.gl/eLDYqh) ]"
         if GlobalVars.metasmoke_key:

--- a/spamhandling.py
+++ b/spamhandling.py
@@ -109,6 +109,8 @@ def handle_spam(post, reasons, why):
             sanitized_title = regex.sub('(https?://|\n)', '', post.parent.title)
         else:
             sanitized_title = regex.sub('(https?://|\n)', '', post.title)
+            
+        sanitized_title = regex.sub('([\]*`])', r'\\$1', sanitzed_title).replace('\n', u'\u23CE')
 
         prefix = u"[ [SmokeDetector](//goo.gl/eLDYqh) ]"
         if GlobalVars.metasmoke_key:


### PR DESCRIPTION
This avoids (un)intentional formatting in titles