### PR TITLE
findspam.py: allow multiple characters in punc-only link

### DIFF
--- a/findspam.py
+++ b/findspam.py
@@ -808,7 +808,7 @@ class FindSpam:
          'sites': [], 'reason': 'one-character link in {}', 'title': False, 'body': True, 'username': False,
          'stripcodeblocks': True, 'body_summary': False, 'max_rep': 11, 'max_score': 1},
         # Link text consists of punctuation, answers only
-        {'regex': r'(?iu)rel="nofollow( noreferrer)?">\W</a>', 'all': True,
+        {'regex': r'(?iu)rel="nofollow( noreferrer)?">\W+</a>', 'all': True,
          'sites': [], 'reason': 'linked punctuation in {}', 'title': False, 'body': True, 'username': False,
          'stripcodeblocks': True, 'body_summary': False, 'questions': False, 'max_rep': 11, 'max_score': 1},
         # URL in title, some sites are exempt


### PR DESCRIPTION
Case in point: https://metasmoke.erwaysoftware.com/post/66842