### PR TITLE
blacklisted_websites.txt: typo fix

### DIFF
--- a/blacklisted_websites.txt
+++ b/blacklisted_websites.txt
@@ -981,5 +981,4 @@ skinliftsup\.com
 supplementplatform\.com
 skincaresfreetrial\.com
 powerupmale\.com
-wealthcare24by7\.org
 healthcare24by7\.org


### PR DESCRIPTION
Commit d492454398d1ae9d1079bb3b47875521c4b46405 was a typo.