### PR TITLE
Extend richestcelebrities pattern

### DIFF
--- a/blacklisted_websites.txt
+++ b/blacklisted_websites.txt
@@ -933,7 +933,7 @@ nextuae\.com
 bongdalu\.com
 cateringroz\.com
 xaddition\.net
-richestcelebrities\.org
+richestcelebrities
 technoblink\.com
 assignmentsolver\.co
 theacademicpapers\.co


### PR DESCRIPTION
We have seen .bio and .wiki as well as .org -- simply blacklist anything with this base.