### PR TITLE
findspam.py: what_is_this_pharma_title()

### DIFF
--- a/findspam.py
+++ b/findspam.py
@@ -211,11 +211,9 @@ def pattern_product_name(s, site, *args):
 
 
 # noinspection PyUnusedLocal,PyMissingTypeHints
-def bad_pattern_in_title(s, site, *args):   # title "what is this Xxxx?"
-    matches = regex.compile(r'^(what is this (?:[A-Z]|http://)').findall(s):
-    if matches:
-        return True, u'Bad pattern in title {}'.format(
-            ", ".join(["".join(match) for match in matches]))
+def what_is_this_pharma_title(s, site, *args):   # title "what is this Xxxx?"
+    if regex.compile(r'^what is this (?:[A-Z]|http://)').match(s):
+        return True, u'Title starts with "what is this"'
     else:
         return False, ""
 
@@ -595,11 +593,9 @@ class FindSpam:
         {'method': pattern_product_name, 'all': True, 'sites': [], 'reason': "pattern-matching product name in {}",
          'title': True, 'body': True, 'username': False, 'stripcodeblocks': True, 'body_summary': True,
          'answers': False, 'max_rep': 4, 'max_score': 1},
-        # Bad pattern in title
-        {'method': bad_pattern_in_title, 'all': True, 'sites': [],
-         'reason': 'Title starts with "what is this"',
-         'title': True, 'body': False, 'username': False,
-         'stripcodeblocks': False, 'body_summary': False,
+        # "What is this" - pharma title
+        {'method': what_is_this_pharma_title, 'all': True, 'sites': [], 'reason': 'Pattern-matching title',
+         'title': True, 'body': False, 'username': False, 'stripcodeblocks': False, 'body_summary': False,
          'answers': False, 'max_rep': 1, 'max_score': 1},
         # gratis at the beginning of post, SoftwareRecs is exempt
         {'regex': r"(?is)^.{0,200}\bgratis\b$", 'all': True,

--- a/findspam.py
+++ b/findspam.py
@@ -211,9 +211,11 @@ def pattern_product_name(s, site, *args):
 
 
 # noinspection PyUnusedLocal,PyMissingTypeHints
-def what_is_this_pharma_title(s, site, *args):   # title "what is this Xxxx?"
-    if regex.compile(r'^what is this (?:[A-Z]|http://)').match(s):
-        return True, u'Title starts with "what is this"'
+def bad_pattern_in_title(s, site, *args):   # title "what is this Xxxx?"
+    matches = regex.compile(r'^(what is this (?:[A-Z]|http://)').findall(s):
+    if matches:
+        return True, u'Bad pattern in title {}'.format(
+            ", ".join(["".join(match) for match in matches]))
     else:
         return False, ""
 
@@ -593,8 +595,8 @@ class FindSpam:
         {'method': pattern_product_name, 'all': True, 'sites': [], 'reason': "pattern-matching product name in {}",
          'title': True, 'body': True, 'username': False, 'stripcodeblocks': True, 'body_summary': True,
          'answers': False, 'max_rep': 4, 'max_score': 1},
-        # Title is "what is this Xxx?"
-        {'method': what_is_this_pharma_title, 'all': True, 'sites': [],
+        # Bad pattern in title
+        {'method': bad_pattern_in_title, 'all': True, 'sites': [],
          'reason': 'Title starts with "what is this"',
          'title': True, 'body': False, 'username': False,
          'stripcodeblocks': False, 'body_summary': False,

--- a/findspam.py
+++ b/findspam.py
@@ -211,6 +211,14 @@ def pattern_product_name(s, site, *args):
 
 
 # noinspection PyUnusedLocal,PyMissingTypeHints
+def what_is_this_pharma_title(s, site, *args):   # title "what is this Xxxx?"
+    if regex.compile(r'^what is this (?:[A-Z]|http://)').match(s):
+        return True, u'Title starts with "what is this"'
+    else:
+        return False, ""
+
+
+# noinspection PyUnusedLocal,PyMissingTypeHints
 def keyword_email(s, site, *args):   # a keyword and an email in the same post
     if regex.compile("<pre>|<code>").search(s) and site == "stackoverflow.com":  # Avoid false positives on SO
         return False, ""
@@ -585,6 +593,12 @@ class FindSpam:
         {'method': pattern_product_name, 'all': True, 'sites': [], 'reason': "pattern-matching product name in {}",
          'title': True, 'body': True, 'username': False, 'stripcodeblocks': True, 'body_summary': True,
          'answers': False, 'max_rep': 4, 'max_score': 1},
+        # Title is "what is this Xxx?"
+        {'method': what_is_this_pharma_title, 'all': True, 'sites': [],
+         'reason': 'Title starts with "what is this"',
+         'title': True, 'body': False, 'username': False,
+         'stripcodeblocks': False, 'body_summary': False,
+         'answers': False, 'max_rep': 1, 'max_score': 1},
         # gratis at the beginning of post, SoftwareRecs is exempt
         {'regex': r"(?is)^.{0,200}\bgratis\b$", 'all': True,
          'sites': ['softwarerecs.stackexchange.com'], 'reason': "bad keyword in {}", 'title': True, 'body': True,


### PR DESCRIPTION
Idiosyncratic title formatting, starting with lowercase "what is this".

Metasmoke results are approximate because it doesn't support case-significant searching. 
 I get 101/114 TP rate with this, but the actual result is closer to 90/90 (however with some low-hanging fruit being missed by the rule): https://metasmoke.erwaysoftware.com/search?body=&body_is_regex=1&commit=Search&feedback=&reason=&site=&title=%5Ewhat+is+this+%28%5BA-Z%5D%7Chttp%3A%2F%2F%29&title_is_regex=1&user_rep_direction=%3E%3D&user_reputation=0&username=&utf8=%E2%9C%93&why=