### PR TITLE
gitmanager.py: don't force or require --global git config

### DIFF
--- a/gitmanager.py
+++ b/gitmanager.py
@@ -27,11 +27,11 @@ class GitManager:
         code_permissions = kwargs.get("code_permissions", False)
 
         # Make sure git credentials are set up
-        if git.config("--global", "--get", "user.name", _ok_code=[0, 1]) == "":
-            return (False, "Tell someone to run `git config --global user.name \"SmokeDetector\"`")
+        if git.config("--get", "user.name", _ok_code=[0, 1]) == "":
+            return (False, "Tell someone to run `git config user.name \"SmokeDetector\"`")
 
-        if git.config("--global", "--get", "user.email", _ok_code=[0, 1]) == "":
-            return (False, "Tell someone to run `git config --global user.email \"smokey@erwaysoftware.com\"`")
+        if git.config("--get", "user.email", _ok_code=[0, 1]) == "":
+            return (False, "Tell someone to run `git config user.email \"smokey@erwaysoftware.com\"`")
 
         if blacklist == "":
             # If we broke the code, and this isn't assigned, error out before doing anything, but do


### PR DESCRIPTION
SmokeDetector should not care whether this setting is global or not,
as long as the value is correct in the current working directory.

Forcing it to be set globally hampers work on private check-outs and
makes some tests very hard to write.