### PR TITLE
gitmanager.py: add a critical section with a lock

### DIFF
--- a/gitmanager.py
+++ b/gitmanager.py
@@ -7,6 +7,7 @@ import requests
 import time
 import json
 import regex
+from threading import Lock
 if 'windows' in str(platform.platform()).lower():
     # noinspection PyPep8Naming
     from classes import Git as git
@@ -16,8 +17,11 @@ else:
 
 # noinspection PyRedundantParentheses,PyClassHasNoInit,PyBroadException
 class GitManager:
-    @staticmethod
-    def add_to_blacklist(**kwargs):
+
+    gitmanager_lock = Lock()
+
+    @classmethod
+    def add_to_blacklist(cls, **kwargs):
         blacklist = kwargs.get("blacklist", "")
         item_to_blacklist = kwargs.get("item_to_blacklist", "")
         username = kwargs.get("username", "")
@@ -60,104 +64,110 @@ class GitManager:
             # if we don't address it here.
             return (False, "Invalid blacklist type specified, something has broken badly!")
 
-        git.checkout("master")
         try:
-            git.pull()
-        except:
-            pass
-
-        # Check that we're up-to-date with origin (GitHub)
-        git.remote.update()
-        if 'windows' in platform.platform().lower():
-            if git.rev_parse("refs/remotes/origin/master").strip() != git.rev_parse("master").strip():
-                return (False, "HEAD isn't at tip of origin's master branch")
-        else:
-            if git("rev-parse", "refs/remotes/origin/master").strip() != git("rev-parse", "master").strip():
-                return (False, "HEAD isn't at tip of origin's master branch")
-
-        # Check that blacklisted_websites.txt isn't modified locally. That could get ugly fast
-        if blacklist_file_name in git.status():  # Also ugly
-            return (False, "{0} is modified locally. This is probably bad.".format(blacklist_file_name))
-
-        # Prevent duplicates
-        if blacklist_file_name in ['watched_keywords.txt']:
-            item_regex = regex.compile(
-                r'\t\L<item>$', item=[item_to_blacklist.split('\t', 2)[2]])
-        else:
-            item_regex = regex.compile(r'^\L<item>$', item=[item_to_blacklist])
-        with open(blacklist_file_name, "r") as blacklist_file:
-            for lineno, line in enumerate(blacklist_file, 1):
-                if item_regex.search(line):
-                    return (False, '{0} already blacklisted on {1} line {2}'.format(
-                        item_to_blacklist, blacklist_file_name, lineno))
-
-        # Add item to file
-        with open(blacklist_file_name, "a+") as blacklist_file:
-            last_character = blacklist_file.read()[-1:]
-            if last_character not in ["", "\n"]:
-                blacklist_file.write("\n")
-            blacklist_file.write(item_to_blacklist + "\n")
-
-        # Checkout a new branch (for PRs for non-code-privileged people)
-        branch = "auto-blacklist-{0}".format(str(time.time()))
-        git.checkout("-b", branch)
-
-        # Clear HEAD just in case
-        git.reset("HEAD")
-
-        git.add(blacklist_file_name)
-        git.commit("--author='SmokeDetector <smokey@erwaysoftware.com>'",
-                   "-m", u"Auto blacklist of {0} by {1} --autopull".format(item_to_blacklist, username))
-
-        if code_permissions:
+            cls.gitmanager_lock.acquire()
             git.checkout("master")
-            git.merge(branch)
-            git.push("origin", "master")
-            git.branch('-D', branch)  # Delete the branch in the local git tree since we're done with it.
-        else:
-            git.push("origin", branch)
-            git.checkout("master")
-
-            if GlobalVars.github_username is None or GlobalVars.github_password is None:
-                return (False, "Tell someone to set a GH password")
-
-            payload = {"title": u"{0}: Blacklist {1}".format(username, item_to_blacklist),
-                       "body": u"[{0}]({1}) requests the blacklist of the {2} {3}. See the Metasmoke search [here]"
-                               "(https://metasmoke.erwaysoftware.com/search?utf8=%E2%9C%93{4}{5})\n"
-                               u"<!-- METASMOKE-BLACKLIST-{6} {3} -->".format(username, chat_profile_link, blacklist,
-                                                                              item_to_blacklist, ms_search_option,
-                                                                              item_to_blacklist.replace(" ", "+"),
-                                                                              blacklist.upper()),
-                       "head": branch,
-                       "base": "master"}
-            response = requests.post("https://api.github.com/repos/Charcoal-SE/SmokeDetector/pulls",
-                                     auth=HTTPBasicAuth(GlobalVars.github_username, GlobalVars.github_password),
-                                     data=json.dumps(payload))
-            log('debug', response.json())
             try:
-                git.checkout("deploy")  # Return to deploy, pending the accept of the PR in Master.
+                git.pull()
+            except:
+                pass
+
+            # Check that we're up-to-date with origin (GitHub)
+            git.remote.update()
+            if 'windows' in platform.platform().lower():
+                if git.rev_parse("refs/remotes/origin/master").strip() != git.rev_parse("master").strip():
+                    return (False, "HEAD isn't at tip of origin's master branch")
+            else:
+                if git("rev-parse", "refs/remotes/origin/master").strip() != git("rev-parse", "master").strip():
+                    return (False, "HEAD isn't at tip of origin's master branch")
+
+            # Check that blacklisted_websites.txt isn't modified locally. That could get ugly fast
+            if blacklist_file_name in git.status():  # Also ugly
+                return (False, "{0} is modified locally. This is probably bad.".format(blacklist_file_name))
+
+            # Prevent duplicates
+            if blacklist_file_name in ['watched_keywords.txt']:
+                item_regex = regex.compile(
+                    r'\t\L<item>$', item=[item_to_blacklist.split('\t', 2)[2]])
+            else:
+                item_regex = regex.compile(r'^\L<item>$', item=[item_to_blacklist])
+            with open(blacklist_file_name, "r") as blacklist_file:
+                for lineno, line in enumerate(blacklist_file, 1):
+                    if item_regex.search(line):
+                        return (False, '{0} already blacklisted on {1} line {2}'.format(
+                            item_to_blacklist, blacklist_file_name, lineno))
+
+            # Add item to file
+            with open(blacklist_file_name, "a+") as blacklist_file:
+                last_character = blacklist_file.read()[-1:]
+                if last_character not in ["", "\n"]:
+                    blacklist_file.write("\n")
+                blacklist_file.write(item_to_blacklist + "\n")
+
+            # Checkout a new branch (for PRs for non-code-privileged people)
+            branch = "auto-blacklist-{0}".format(str(time.time()))
+            git.checkout("-b", branch)
+
+            # Clear HEAD just in case
+            git.reset("HEAD")
+
+            git.add(blacklist_file_name)
+            git.commit("--author='SmokeDetector <smokey@erwaysoftware.com>'",
+                       "-m", u"Auto blacklist of {0} by {1} --autopull".format(item_to_blacklist, username))
+
+            if code_permissions:
+                git.checkout("master")
+                git.merge(branch)
+                git.push("origin", "master")
                 git.branch('-D', branch)  # Delete the branch in the local git tree since we're done with it.
-                return (True, "You don't have code privileges, but I've [created a pull request for you]({0}).".format(
-                    response.json()["html_url"]))
-            except KeyError:
-                git.checkout("deploy")  # Return to deploy
+            else:
+                git.push("origin", branch)
+                git.checkout("master")
 
-                # Delete the branch in the local git tree, we'll create it again if the
-                # command is run again. This way, we keep things a little more clean in
-                # the local git tree
-                git.branch('-D', branch)
+                if GlobalVars.github_username is None or GlobalVars.github_password is None:
+                    return (False, "Tell someone to set a GH password")
 
-                # Error capture/checking for any "invalid" GH reply without an 'html_url' item,
-                # which will throw a KeyError.
-                if "bad credentials" in str(response.json()['message']).lower():
-                    # Capture the case when GH credentials are bad or invalid
-                    return (False, "Something is wrong with the GH credentials, tell someone to check them.")
-                else:
-                    # Capture any other invalid response cases.
-                    return (False, "A bad or invalid reply was received from GH, the message was: %s" %
-                            response.json()['message'])
+                payload = {"title": u"{0}: Blacklist {1}".format(username, item_to_blacklist),
+                           "body": u"[{0}]({1}) requests the blacklist of the {2} {3}. See the Metasmoke search [here]"
+                                   "(https://metasmoke.erwaysoftware.com/search?utf8=%E2%9C%93{4}{5})\n"
+                                   u"<!-- METASMOKE-BLACKLIST-{6} {3} -->".format(
+                                       username, chat_profile_link, blacklist,
+                                       item_to_blacklist, ms_search_option,
+                                       item_to_blacklist.replace(" ", "+"),
+                                       blacklist.upper()),
+                           "head": branch,
+                           "base": "master"}
+                response = requests.post("https://api.github.com/repos/Charcoal-SE/SmokeDetector/pulls",
+                                         auth=HTTPBasicAuth(GlobalVars.github_username, GlobalVars.github_password),
+                                         data=json.dumps(payload))
+                log('debug', response.json())
+                try:
+                    git.checkout("deploy")  # Return to deploy, pending the accept of the PR in Master.
+                    git.branch('-D', branch)  # Delete the branch in the local git tree since we're done with it.
+                    return (True,
+                            "You don't have code privileges, but I've [created a pull request for you]({0}).".format(
+                                response.json()["html_url"]))
+                except KeyError:
+                    git.checkout("deploy")  # Return to deploy
 
-        git.checkout("deploy")  # Return to deploy to await CI.
+                    # Delete the branch in the local git tree, we'll create it again if the
+                    # command is run again. This way, we keep things a little more clean in
+                    # the local git tree
+                    git.branch('-D', branch)
+
+                    # Error capture/checking for any "invalid" GH reply without an 'html_url' item,
+                    # which will throw a KeyError.
+                    if "bad credentials" in str(response.json()['message']).lower():
+                        # Capture the case when GH credentials are bad or invalid
+                        return (False, "Something is wrong with the GH credentials, tell someone to check them.")
+                    else:
+                        # Capture any other invalid response cases.
+                        return (False, "A bad or invalid reply was received from GH, the message was: %s" %
+                                response.json()['message'])
+
+            git.checkout("deploy")  # Return to deploy to await CI.
+        finally:
+            cls.gitmanager_lock.release()
 
         return (True, "Blacklisted {0}".format(item_to_blacklist))
 


### PR DESCRIPTION
This way, only one blacklisting request can be in progress at any time.  Further requests will simply block on attempting to acquire the lock, and thus wait nicely in queue.

Fixes #679