### PR TITLE
Test blacklist integrity duplicates

### DIFF
--- a/test/test_blacklist_integrity.py
+++ b/test/test_blacklist_integrity.py
@@ -2,12 +2,19 @@
 
 from glob import glob
 
-for bl_file in glob('bad_*.txt') + glob('blacklisted_*.txt'):
-    with open(bl_file, 'r') as lines:
-        for lineno, line in enumerate(lines, 1):
-            if line.endswith('\r\n'):
-                raise(ValueError('{0}:{1}:DOS line ending'.format(bl_file, lineno)))
-            if not line.endswith('\n'):
-                raise(ValueError('{0}:{1}:No newline'.format(bl_file, lineno)))
-            if line == '\n':
-                raise(ValueError('{0}:{1}:Empty line'.format(bl_file, lineno)))
+
+def test_blacklist_integrity():
+    for bl_file in glob('bad_*.txt') + glob('blacklisted_*.txt'):
+        with open(bl_file, 'r') as lines:
+            seen = dict()
+            for lineno, line in enumerate(lines, 1):
+                if line.endswith('\r\n'):
+                    raise(ValueError('{0}:{1}:DOS line ending'.format(bl_file, lineno)))
+                if not line.endswith('\n'):
+                    raise(ValueError('{0}:{1}:No newline'.format(bl_file, lineno)))
+                if line == '\n':
+                    raise(ValueError('{0}:{1}:Empty line'.format(bl_file, lineno)))
+                if line in seen:
+                    raise(ValueError('{0}:{1}:Duplicate entry {2} (also on line {3})'.format(
+                        bl_file, lineno, line.rstrip('\n'), seen[line])))
+                seen[line] = lineno


### PR DESCRIPTION
Run a check against duplicates entries as well while we are already scanning the blacklists.

Incidentally, also refactor to put the function inside a `test_blacklist_integrity()` function so it works like the other `test/*.py` scripts.