### PR TITLE
More test cases

### DIFF
--- a/spamhandling.py
+++ b/spamhandling.py
@@ -151,7 +151,7 @@ def handle_spam(post, reasons, why):
                         if len(chq_msg_pings) <= 500 else chq_msg[0:500]
                     try:
                         GlobalVars.charcoal_hq.send_message(msg_to_send)
-                    except AttributeError: # In our Test Suite
+                    except AttributeError:  # In our Test Suite
                         pass
                 if not should_reasons_prevent_tavern_posting(reasons) \
                         and post.post_site not in GlobalVars.non_tavern_sites \
@@ -184,7 +184,7 @@ def handle_spam(post, reasons, why):
                         if len(socvr_msg_pings) <= 500 else socvr_msg[0:500]
                     try:
                         GlobalVars.socvr.send_message(msg_to_send)
-                    except AttributeError: # In test Suite
+                    except AttributeError:  # In test Suite
                         pass
 
             for specialroom in GlobalVars.specialrooms:

--- a/spamhandling.py
+++ b/spamhandling.py
@@ -149,7 +149,10 @@ def handle_spam(post, reasons, why):
                     chq_msg_pings_ms = prefix_ms + datahandling.append_pings(s, chq_pings)
                     msg_to_send = chq_msg_pings_ms if len(chq_msg_pings_ms) <= 500 else chq_msg_pings \
                         if len(chq_msg_pings) <= 500 else chq_msg[0:500]
-                    GlobalVars.charcoal_hq.send_message(msg_to_send)
+                    try:
+                        GlobalVars.charcoal_hq.send_message(msg_to_send)
+                    except AttributeError: # In our Test Suite
+                        pass
                 if not should_reasons_prevent_tavern_posting(reasons) \
                         and post.post_site not in GlobalVars.non_tavern_sites \
                         and time.time() >= GlobalVars.blockedTime[GlobalVars.meta_tavern_room_id]:
@@ -179,7 +182,10 @@ def handle_spam(post, reasons, why):
                     socvr_msg_pings_ms = prefix_ms + datahandling.append_pings(s, socvr_pings)
                     msg_to_send = socvr_msg_pings_ms if len(socvr_msg_pings_ms) <= 500 else socvr_msg_pings \
                         if len(socvr_msg_pings) <= 500 else socvr_msg[0:500]
-                    GlobalVars.socvr.send_message(msg_to_send)
+                    try:
+                        GlobalVars.socvr.send_message(msg_to_send)
+                    except AttributeError: # In test Suite
+                        pass
 
             for specialroom in GlobalVars.specialrooms:
                 sites = specialroom["sites"]

--- a/test/test_chatcommunicate.py
+++ b/test/test_chatcommunicate.py
@@ -307,10 +307,24 @@ def test_messages_not_sent():
 
 
 # noinspection PyMissingTypeHints
-def test_manual_report():
+def test_manual_report(capfd):
     event = mock_event("!!/report http://stackoverflow.com/questions/1000", 1, 11540, "Charcoal HQ", 59776, u"Doorknob 冰")
     watcher(event, client.Client())
     assert reply_value == "Post 1: Could not find data for this post in the API. It may already have been deleted."
+
+    # Test batch reporting
+    event = mock_event("!!/report http://stackoverflow.com/a/1732454 http://stackoverflow.com/q/14405063/189134", 1, 11540, "Charcoal HQ", 59776, u"Doorknob 冰")
+    watcher(event, client.Client())
+    assert reply_value == ''
+
+    # Remove blacklisted users from above reports
+    event = mock_event("!!/rmblu http://stackoverflow.com/users/18936", 1, 11540, "Charcoal HQ", 59776, u"Doorknob 冰")
+    watcher(event, client.Client())
+    event = mock_event("!!/rmblu http://stackoverflow.com/users/1715740", 1, 11540, "Charcoal HQ", 59776, u"Doorknob 冰")
+    watcher(event, client.Client())
+
+    os.remove("whyData.p")
+    os.remove("blacklistedUsers.p")
 
 
 @pytest.mark.skipif(os.path.isfile("blacklistedUsers.p"),

--- a/test/test_spamhandling.py
+++ b/test/test_spamhandling.py
@@ -5,7 +5,7 @@ from parsing import get_user_from_url
 import pytest
 import os
 import json
-from classes import Post
+from classes import Post, PostParseError
 
 
 test_data_inputs = []
@@ -69,6 +69,10 @@ def test_check_if_spam(title, body, username, site, match):
 def test_check_if_spam_json(data, match):
     is_spam, reason, _ = check_if_spam_json(data)
     assert match == is_spam
+
+    # Check that a malformed post isn't reported as spam
+    is_spam, reason, _ = check_if_spam_json(None)
+    assert not is_spam
 
 
 @pytest.mark.skipif(os.path.isfile("blacklistedUsers.p"),

--- a/test/test_spamhandling.py
+++ b/test/test_spamhandling.py
@@ -5,7 +5,7 @@ from parsing import get_user_from_url
 import pytest
 import os
 import json
-from classes import Post, PostParseError
+from classes import Post
 
 
 test_data_inputs = []


### PR DESCRIPTION
This adds additional test cases and adds a patch in `handle_spam` so that it can correctly determine if it is in the test suite. This is done because `handle_spam` doesn't return the standard `Response` object in all cases, and instead prints directly to the chatrooms.