### PR TITLE
Indian pharma spammers

### DIFF
--- a/blacklisted_websites.txt
+++ b/blacklisted_websites.txt
@@ -1153,3 +1153,4 @@ megacleanseradvice\.com
 worldmuscleking\.com
 gomusclebuilding\.com
 musclegainfast\.com
+healthygcpro\.com

--- a/blacklisted_websites.txt
+++ b/blacklisted_websites.txt
@@ -1148,3 +1148,4 @@ researchomatic\.com
 nutritionfit\.org
 oralhealthplus\.com
 supplementlab\.org
+supplementstest\.org

--- a/blacklisted_websites.txt
+++ b/blacklisted_websites.txt
@@ -1146,3 +1146,4 @@ freecustomwritings\.com
 cyberservices\.com
 researchomatic\.com
 nutritionfit\.org
+oralhealthplus\.com

--- a/blacklisted_websites.txt
+++ b/blacklisted_websites.txt
@@ -1151,3 +1151,4 @@ supplementlab\.org
 supplementstest\.org
 megacleanseradvice\.com
 worldmuscleking\.com
+gomusclebuilding\.com

--- a/blacklisted_websites.txt
+++ b/blacklisted_websites.txt
@@ -1152,3 +1152,4 @@ supplementstest\.org
 megacleanseradvice\.com
 worldmuscleking\.com
 gomusclebuilding\.com
+musclegainfast\.com

--- a/blacklisted_websites.txt
+++ b/blacklisted_websites.txt
@@ -1149,3 +1149,4 @@ nutritionfit\.org
 oralhealthplus\.com
 supplementlab\.org
 supplementstest\.org
+megacleanseradvice\.com

--- a/blacklisted_websites.txt
+++ b/blacklisted_websites.txt
@@ -1147,3 +1147,4 @@ cyberservices\.com
 researchomatic\.com
 nutritionfit\.org
 oralhealthplus\.com
+supplementlab\.org

--- a/blacklisted_websites.txt
+++ b/blacklisted_websites.txt
@@ -1155,3 +1155,4 @@ gomusclebuilding\.com
 musclegainfast\.com
 healthygcpro\.com
 dietplanusa\.com
+hikehealth\.com

--- a/blacklisted_websites.txt
+++ b/blacklisted_websites.txt
@@ -1145,3 +1145,4 @@ eye7\.in
 freecustomwritings\.com
 cyberservices\.com
 researchomatic\.com
+nutritionfit\.org

--- a/blacklisted_websites.txt
+++ b/blacklisted_websites.txt
@@ -1154,3 +1154,4 @@ worldmuscleking\.com
 gomusclebuilding\.com
 musclegainfast\.com
 healthygcpro\.com
+dietplanusa\.com

--- a/blacklisted_websites.txt
+++ b/blacklisted_websites.txt
@@ -1150,3 +1150,4 @@ oralhealthplus\.com
 supplementlab\.org
 supplementstest\.org
 megacleanseradvice\.com
+worldmuscleking\.com

--- a/blacklisted_websites.txt
+++ b/blacklisted_websites.txt
@@ -1156,3 +1156,4 @@ musclegainfast\.com
 healthygcpro\.com
 dietplanusa\.com
 hikehealth\.com
+supplementsguide\.org

--- a/watched_keywords.txt
+++ b/watched_keywords.txt
@@ -167,7 +167,6 @@
 1496262181	Mithrandir	termsbux\.com
 1496290923	tripleee	vitalieskincaretry\.com
 1496291174	tripleee	trendingwidgets\.com
-1496291413	tripleee	worldmuscleking\.com
 1496292124	tripleee	2347011164459
 1496295263	tripleee	musclesupplement\.org
 1496299953	tripleee	smallboss\.com

--- a/watched_keywords.txt
+++ b/watched_keywords.txt
@@ -150,7 +150,6 @@
 1496214106	tripleee	supplements4us\.com
 1496220521	tripleee	top10casinoreviews\.com
 1496222056	tripleee	ufmgc\.org
-1496222565	tripleee	supplementlab\.org
 1496222764	tripleee	healthyapplechat\.com
 1496222941	tripleee	mobilenationz
 1496223133	tripleee	cracklogins


### PR DESCRIPTION
This adds a number of recurring spam domains to the blacklisted web site list.

Each domain is a separate commit, with brief statistics in the commit message.

Every one has at least one Metasmoke hit with a weight below our default autoflagging threshold.