### PR TITLE
We are using 💩 to feedback naa in chat

### DIFF
--- a/chatcommunicate.py
+++ b/chatcommunicate.py
@@ -29,7 +29,7 @@ command_aliases = {
     "vand": "tp-",
     "v": "tp-",
     "n": "naa-",
-    u"\U0001F4A9": "tp-",
+    u"\U0001F4A9": "naa-",
 }
 
 


### PR DESCRIPTION
Due to AIM and MS, we are using 💩 to feedback naa in chat, while it is currently tp-. This swaps that.

See [here](https://chat.stackexchange.com/transcript/message/37460309#37460309) for one example