### PR TITLE
Don’t trigger “Linked punctuation in answer” if the text is `><>`

### DIFF
--- a/findspam.py
+++ b/findspam.py
@@ -850,7 +850,7 @@ class FindSpam:
          'sites': [], 'reason': 'one-character link in {}', 'title': False, 'body': True, 'username': False,
          'stripcodeblocks': True, 'body_summary': False, 'max_rep': 11, 'max_score': 1},
         # Link text consists of punctuation, answers only
-        {'regex': r'(?iu)rel="nofollow( noreferrer)?">\W+</a>', 'all': True,
+        {'regex': r'(?iu)rel="nofollow( noreferrer)?">(?!><>)\W+</a>', 'all': True,
          'sites': [], 'reason': 'linked punctuation in {}', 'title': False, 'body': True, 'username': False,
          'stripcodeblocks': True, 'body_summary': False, 'questions': False, 'max_rep': 11, 'max_score': 1},
         # URL in title, some sites are exempt


### PR DESCRIPTION
@​quartata:
> [**↰**](https://chat.stackexchange.com/transcript/11540?m=37549828#37549828) @​SmokeDetector Oh jeez, is that going to trip on every ><> answer <sup>[source](https://chat.stackexchange.com/transcript/message/37550380#37550380)</sup>  
> That's not good, ><> is a very common esolang <sup>[source](https://chat.stackexchange.com/transcript/message/37550383#37550383)</sup>