### PR TITLE
Fix formatting of watched_keywords.txt lines 205 and 206

### DIFF
--- a/watched_keywords.txt
+++ b/watched_keywords.txt
@@ -202,8 +202,8 @@
 1496921326	Glorfindel	alphonsacollege\.com
 1496927422	Mithrandir	surejob\.in
 1496949638	Ferrybig	hyderabadfairy
-1497086954	Glorfindel	imperialindiatourpackages\.com 
-1497086954	Glorfindel  viajesindiarajasthan\.com
+1497086954	Glorfindel	imperialindiatourpackages\.com
+1497086954	Glorfindel	viajesindiarajasthan\.com
 1497093760	Glorfindel	canbeyvinc\.com
 1497104718	Glorfindel	powerengineers\.in
 1497177636	Glorfindel	Tony Awards \d+ Live


### PR DESCRIPTION
A couple of lines in `watched_keywords.txt` had broken formatting; line 205 had a trailing space (I'm not sure if it's a big deal or not, but I removed it), and line 206 had two spaces instead of a tab (which caused an error message when loading the keywords).