### PR TITLE
Use \W instead of hyphen for T-Complex

### DIFF
--- a/bad_keywords.txt
+++ b/bad_keywords.txt
@@ -97,7 +97,7 @@ Whizz Systems?
 intellux
 viooz
 smartican
-T-complex
+t\Wcomplex
 фальшивы(е|х) (деньги|денег|купюры?)
 raging lion
 (love|miracle).*spell ?casters?


### PR DESCRIPTION
This matches "T Complex" instead of just T-Complex.