### PR TITLE
Use the 'full' user link in Smokey reports

### DIFF
--- a/parsing.py
+++ b/parsing.py
@@ -190,7 +190,7 @@ def user_url_to_shortlink(url):
     user_id_and_site = get_user_from_url(url)
     if user_id_and_site is None:
         return url
-    return "http://{}/u/{}".format(user_id_and_site[1], user_id_and_site[0])
+    return "http://{}/users/{}".format(user_id_and_site[1], user_id_and_site[0])
 
 
 # noinspection PyMissingTypeHints

--- a/test/test_parsing.py
+++ b/test/test_parsing.py
@@ -41,7 +41,7 @@ with open("test/data_test_parsing.txt", "r", encoding="utf-8") as f:
     ('http://writers.stackexchange.com/questions/1/%2f%2f', url_to_shortlink, 'http://writers.stackexchange.com/questions/1'),
     ('http://writers.stackexchange.com/questions/1/%2f%2f/2#2', url_to_shortlink, 'http://writers.stackexchange.com/a/2'),
     ('http://mathoverflow.net/q/1', url_to_shortlink, 'http://mathoverflow.net/questions/1'),
-    ('http://stackoverflow.com/users/1234/abcd', user_url_to_shortlink, 'http://stackoverflow.com/u/1234'),
+    ('http://stackoverflow.com/users/1234/abcd', user_url_to_shortlink, 'http://stackoverflow.com/users/1234'),
     ('http://stackexchange.com', to_protocol_relative, '//stackexchange.com'),
     ('https://stackexchange.com', to_protocol_relative, '//stackexchange.com'),
     ('//stackexchange.com', to_protocol_relative, '//stackexchange.com'),


### PR DESCRIPTION
Use the full link as suggested [here](https://meta.stackexchange.com/questions/297554/can-u-userid-redirect-to-users-userid-even-for-deleted-users-for-moderato#comment965491_297554) to prevent redirection problems when the user is deleted.