### PR TITLE
expanded tooth product regexes

### DIFF
--- a/bad_keywords.txt
+++ b/bad_keywords.txt
@@ -159,7 +159,8 @@ Youth Serum
 explosive muscle
 zyntix
 genbrain
-(teeth|tooth)\W(lightening|whitening)
+(teeth|tooth)\W(lighten|whiten|brighten|shin)(er|ing)?
+(lighten|whiten|brighten|shin)(e|er|ing|ed)?\W(teeth|tooth|kit)
 xtest\W(muscle|reviews?)
 inteligen
 natural\W?slim\W?life


### PR DESCRIPTION
- expanded teeth/tooth {thing} regex from 75tp/0fp --> 93tp/0fp. now catches brightening/shining, and -ing/-er suffixes (or no suffix at all)
- added a regex that puts the adjective/verb first, and detects whitening kits, etc. 34tp/0fp.