### PR TITLE
keyword updates: reduce writing service fp, remove obsoletes

### DIFF
--- a/bad_keywords.txt
+++ b/bad_keywords.txt
@@ -122,7 +122,6 @@ lost lover? back
 service proposal essay
 enetdocumentation
 okaygoods
-dr ?eziza
 (love|miracle).*spell ?casters?
 (spell(home)?|temple|classes)\w*@gmail\.com
 black magic specialist
@@ -470,7 +469,6 @@ nitrobuild
 8167873816
 2348167873816
 877\W?7788969
-doctor\W?zanza
 enduro\Wforce
 (?<=/)right\Wpick(?=[-/<])
 power\Wboost\Wxi

--- a/bad_keywords.txt
+++ b/bad_keywords.txt
@@ -2,7 +2,7 @@ baba\W?ji
 fifa.{0,20}coins?
 fifabay
 Long\W?Path\W?Tool
-writing service
+(?!code\W|script\W)writing service
 tosterone
 we (offer|give out) (loans|funds|funding)
 skin\W?(endear|royale|cell\W?pro|opulent|ology|centric)

--- a/bad_keywords.txt
+++ b/bad_keywords.txt
@@ -183,7 +183,7 @@ instaketones
 apexatropin
 keranique
 rejuvonus
-image\Wrevivey
+image\Wrevive
 cognishield
 spartagen
 blackcore

--- a/bad_keywords.txt
+++ b/bad_keywords.txt
@@ -60,7 +60,6 @@ Remo Recover
 kinnaristeel
 clash of (clan|stone)s? (cheats?|tricks?|gems?)
 slumber pm
-1-844-400-7325
 bestcollegechina
 bbwdesire
 rsorder
@@ -97,7 +96,6 @@ smartican
 t\Wcomplex
 фальшивы(е|х) (деньги|денег|купюры?)
 raging lion
-08151871776
 retrodynamic formula
 ^.{0,199}(contact|offer|join).{0,99}\d{9}.{0,99}$
 Krojam(Soft|Cleaner)?
@@ -132,7 +130,6 @@ slotobit
 putlocker
 vimax
 (contact|call) us (today|now)
-call \d{3}-\d{4}-\d{4}
 Thierno(_| )?M.(_| )Sow
 maxtropin
 geniux
@@ -187,8 +184,7 @@ instaketones
 apexatropin
 keranique
 rejuvonus
-image\Wrevive
-914[-()]{02}517[-]?3229
+image\Wrevivey
 cognishield
 spartagen
 blackcore

--- a/bad_keywords.txt
+++ b/bad_keywords.txt
@@ -2,6 +2,8 @@ baba\W?ji
 fifa.{0,20}coins?
 fifabay
 Long\W?Path\W?Tool
+# documentation: the (?!negative match) syntax won't work in the metasmoke search site
+# but it works for smoke detector.
 (?!code\W|script\W)writing service
 tosterone
 we (offer|give out) (loans|funds|funding)

--- a/bad_keywords.txt
+++ b/bad_keywords.txt
@@ -38,7 +38,6 @@ jivam
 Maximum ?Shred
 black[ -]label[ -]no
 bagprada
-6611165613
 Apowersoft
 ChatSim
 Service Solahart


### PR DESCRIPTION
- the "writing service" keyword will no longer capture people mentioning "code-writing service" or "script-writing service" as false positives. no post mentioning that has been a true positive.
- removed two names of doctors from witch doctor spam. don't bother blacklisting the individual doctor names, they come up with new ones each time.
- removed several obsolete phone numbers with zero matches ever or zero matches in the past couple of years.