### PR TITLE
Updated spell spam regex & added herbal centre

### DIFF
--- a/bad_keywords.txt
+++ b/bad_keywords.txt
@@ -551,4 +551,4 @@ skin\W?fresh\W?md
 renuvica
 Max\WTest\WUltra
 2348149470344
-herbal (doctor|center)
+herbal (doctor|center|centre)

--- a/bad_keywords.txt
+++ b/bad_keywords.txt
@@ -120,7 +120,7 @@ service proposal essay
 enetdocumentation
 okaygoods
 (love|miracle).*spell ?casters?
-(spell(home)?|temple|classes)\w*@gmail\.com
+\w*(spell(home)?|temple|classes)\w*@
 black magic specialist
 great\Wspell\Wcaster
 viagra


### PR DESCRIPTION
The spell spam regex wasn't built with the implicit `\b ... \b` word boundary in mind so it basically wasn't working: it had [7tp/1fp](https://metasmoke.erwaysoftware.com/search?utf8=%E2%9C%93&title=&body_is_regex=1&body=%5Cb%28spell%28home%29%3F%7Ctemple%7Cclasses%29%5Cw*%40gmail%5C.com%5Cb&username=&why=&site=&feedback=&autoflagged=&reason=&user_rep_direction=%3E%3D&user_reputation=0&commit=Search). These emails usually have extra words at the beginning like "hindu spell temple" or "dr agave spell temple" or whatever.

I've made two changes to this regex:

- added a `\w*` at the beginning, which [makes this regex functional](https://metasmoke.erwaysoftware.com/search?utf8=%E2%9C%93&title=&body_is_regex=1&body=%5Cb%5Cw*%28spell%28home%29%3F%7Ctemple%7Cclasses%29%5Cw*%40gmail%5C.com%5Cb&username=&why=&site=&feedback=&autoflagged=&reason=&user_rep_direction=%3E%3D&user_reputation=0&commit=Search): this way it has 235tp/2fp/1naa.
- removed the gmail domain from the regex, which [expands its spam coverage](https://metasmoke.erwaysoftware.com/search?utf8=%E2%9C%93&title=&body_is_regex=1&body=%5Cb%5Cw*%28spell%28home%29%3F%7Ctemple%7Cclasses%29%5Cw*%40%5Cb&username=&why=&site=&feedback=&autoflagged=&reason=&user_rep_direction=%3E%3D&user_reputation=0&commit=Search) up to 330tp/2fp/1naa (so, +95tp).

I also added the British spelling of "herbal centre", which just adds +1tp.