### PR TITLE
Improved detection of obfuscated email addresses

### DIFF
--- a/findspam.py
+++ b/findspam.py
@@ -237,7 +237,7 @@ def keyword_email(s, site, *args):   # a keyword and an email in the same post
                           r"[A-z0-9_.%+-]+\.[A-z]{2,4}\b").search(s)
     if keyword and email:
         return True, u"Keyword *{}* with email {}".format(keyword.group(0), email.group(0))
-    obfuscated_email = regex.compile(r"(?<![=#/])\b[A-z0-9_.%+-]+ *@ *(gmail|yahoo) *\. *com\b").search(s)
+    obfuscated_email = regex.compile(r"(?<![=#/])\b[A-z0-9_.%+-]+ *@ *(g *mail|yahoo) *\. *com\b").search(s)
     if obfuscated_email and not email:
         return True, u"Obfuscated email {}".format(obfuscated_email.group(0))
     return False, ""


### PR DESCRIPTION
Attempt to catch posts like this one: https://metasmoke.erwaysoftware.com/post/76646
where the email address is `@ g mail . com`.