### PR TITLE
Require "dr" to be at the start in pattern_email

### DIFF
--- a/findspam.py
+++ b/findspam.py
@@ -253,9 +253,9 @@ def keyword_email(s, site, *args):   # a keyword and an email in the same post
 
 # noinspection PyUnusedLocal,PyMissingTypeHints
 def pattern_email(s, site, *args):
-    pattern = regex.compile(r"(?<![=#/])\b[A-z0-9_.%+-]*"
-                            r"(dr|loan|hack|financ|fund|spell|temple|herbal|spiritual|atm|heal|priest|classes|"
-                            r"investment)[A-z0-9_.%+-]*"
+    pattern = regex.compile(r"(?<![=#/])\b(dr|[A-z0-9_.%+-]*"
+                            r"(loan|hack|financ|fund|spell|temple|herbal|spiritual|atm|heal|priest|classes|"
+                            r"investment))[A-z0-9_.%+-]*"
                             r"@(?!(example|domain|site|foo|\dx)\.[A-z]{2,4})[A-z0-9_.%+-]+\.[A-z]{2,4}\b"
                             ).search(s.lower())
     if pattern:


### PR DESCRIPTION
Pattern-matching email matched anything containing `dr`, but this caused a couple of `fp`'s because `dr` is a fairly common combination of letters.  I changed the regex to require `dr` to be at the beginning of the email (and killed Metasmoke for 2 minutes in the process).