### PR TITLE
Fix typo

### DIFF
--- a/bad_keywords.txt
+++ b/bad_keywords.txt
@@ -618,4 +618,4 @@ acethinker
 testo\Wmax
 povella
 Poraxin\WRX
-genericore\Wboost
+geneticore\Wboost


### PR DESCRIPTION
I meant to blacklist "Geneticore Boost," but I'm on my phone and I blacklisted "Genericore Boost" instead.