### PR TITLE
gitmanager.py: Show number of generated PR in chat message

### DIFF
--- a/gitmanager.py
+++ b/gitmanager.py
@@ -171,9 +171,10 @@ class GitManager:
                 try:
                     git.checkout("deploy")  # Return to deploy, pending the accept of the PR in Master.
                     git.branch('-D', branch)  # Delete the branch in the local git tree since we're done with it.
+                    url = response.json()["html_url"]
                     return (True,
-                            "You don't have code privileges, but I've [created a pull request for you]({0}).".format(
-                                response.json()["html_url"]))
+                            "You don't have code privileges, but I've [created PR#{1} for you]({0}).".format(
+                                url, url.split('/')[-1]))
                 except KeyError:
                     git.checkout("deploy")  # Return to deploy
 


### PR DESCRIPTION
When a pull request is being created on a user's behalf, include the number of the pull request in the chat message.

`<` You don't have code privileges, but I've [created a pull request for you](https://github.com/Charcoal-SE/SmokeDetector/pull/1017). 
`>` You don't have code privileges, but I've [created PR#1017 for you](https://github.com/Charcoal-SE/SmokeDetector/pull/1017).

(The abbreviation might be slightly bewildering to a newcomer, but it should be familiar to anyone who understands what a "pull request" is anyway.)