### PR TITLE
Prevent "this isn't complex" etc. from being triggered.

### DIFF
--- a/bad_keywords.txt
+++ b/bad_keywords.txt
@@ -92,7 +92,7 @@ Whizz Systems?
 intellux
 viooz
 smartican
-t\Wcomplex
+(?<!')t\Wcomplex
 фальшивы(е|х) (деньги|денег|купюры?)
 raging lion
 retrodynamic formula


### PR DESCRIPTION
The `t\Wcomplex` regex in the blacklist is prone to false positives; fix it by requiring the word boundary before the first character to not be a single quote (which is also the conventional apostrophe in plain ASCII).