### PR TITLE
Possible bug fix for Makyen privileges in SOCVR

### DIFF
--- a/globalvars.py
+++ b/globalvars.py
@@ -330,8 +330,8 @@ class GlobalVars:
             "4805174",  # kayess
             "2370483",  # Machavity
             "1873567",  # CalvT
-            "4826457"   # suraj
-            "3773011",  # Makyen
+            "4826457",  # suraj
+            "3773011"   # Makyen
         ],
         '111347': [     # SOBotics
             "3160466",  # ArtOfCode


### PR DESCRIPTION
@NathanOliver1 recently [made a PR](https://github.com/Charcoal-SE/SmokeDetector/pull/1029) to add Makyen to SOCVR. He [still didn't get privileges](https://chat.stackoverflow.com/transcript/message/38816260#38816260), I'm assuming because of the syntax error Nathan made.

This PR _should_ fix the problem.