### PR TITLE
Improve Ramse Dave regex, move to bad_kewords_nwb

### DIFF
--- a/findspam.py
+++ b/findspam.py
@@ -534,7 +534,8 @@ class FindSpam:
         u"Ｃ[Ｏ|0]Ｍ", "ecoflex", "no2factor", "no2blast", "sunergetic", "capilux", "sante ?avis",
         "enduros", "dianabol", r"ICQ#?\d{4}-?\d{5}", "3073598075", "lumieres", "viarex", "revimax",
         "celluria", "viatropin", "(meg|test)adrox", "nordic ?loan ?firm", r"safflower\Woil",
-        "(essay|resume|article|dissertation|thesis) ?writing ?service", "satta ?matka", "b.?o.?j.?i.?t.?e.?r"
+        "(essay|resume|article|dissertation|thesis) ?writing ?service", "satta ?matka", "b.?o.?j.?i.?t.?e.?r",
+        "rams[ey]+\W?dave"
     ]
 
     # Patterns: the top four lines are the most straightforward, matching any site with this string in domain name

--- a/watched_keywords.txt
+++ b/watched_keywords.txt
@@ -793,7 +793,6 @@
 1503646009	tripleee	dcaicollective\.org
 1503646746	tripleee	apkbc\.com
 1503648531	tripleee	windows-key\.net
-1503648624	tripleee	ramse\Wdave
 1503652876	tripleee	ohmi-design\.com
 1503653610	tripleee	dealmoguls\.com
 1503653985	tripleee	bodywaxandthreading\.com


### PR DESCRIPTION
Ramse Dave Loan Company (an apparent knock-off of [Dave Ramsey](https://en.wikipedia.org/wiki/The_Dave_Ramsey_Show_(radio_program))) has been used in a lot of recent loan spam, so [`ramse\Wdave`](https://metasmoke.erwaysoftware.com/search?utf8=✓&title=&body_is_regex=1&body=ramse%5CWdave&username=&why=&site=&feedback=&autoflagged=&reason=&user_rep_direction=%3E%3D&user_reputation=0&commit=Search) was already on the watchlist.  However, Ramse Dave isn't the only variation -- I've seen Ramse Dave, Ramsey Dave, and Ramsy Dave (plus the email address, `ramsedave121@gmail.com`).

I changed the regex to [`rams[ey]+\W?dave`](https://metasmoke.erwaysoftware.com/search?utf8=✓&title=&body_is_regex=1&body=rams%5Bey%5D%2B%5CW%3Fdave&username=&why=&site=&feedback=&autoflagged=&reason=&user_rep_direction=%3E%3D&user_reputation=0&commit=Search) and moved it from the watchlist to `bad_keywords_nwb`.  This way, it should catch all of the variations and the email address.