### PR TITLE
GlobalVars.parser.unescape(): avoid deprecation warning

### DIFF
--- a/globalvars.py
+++ b/globalvars.py
@@ -4,6 +4,7 @@ import os
 from datetime import datetime
 from chatexchange_extension import Client
 from html.parser import HTMLParser
+from html import unescape
 from hashlib import md5
 from configparser import NoOptionError, RawConfigParser
 from helpers import environ_or_none, log
@@ -90,6 +91,7 @@ class GlobalVars:
     non_tavern_sites = ["stackoverflow.com"]
 
     parser = HTMLParser()
+    parser.unescape = unescape
     wrap = Client("stackexchange.com")
     wrapm = Client("meta.stackexchange.com")
     wrapso = Client("stackoverflow.com")


### PR DESCRIPTION
HTMLParser.unescape() was supposed to have been removed in Python 3.5
(but was allegedly still forgotten in).  The canonical replacement is simply
html.unescape().  Hack it in to the parser object so the existing code can
continue to work without deprecation warnings (though it's only actually
used in 3 places; we should really avoid using a global for this eventually).

Ref: https://stackoverflow.com/questions/2087370/decode-html-entities-in-python-string