### PR TITLE
Fix Rob's UserID for SOBotics

### DIFF
--- a/globalvars.py
+++ b/globalvars.py
@@ -349,7 +349,7 @@ class GlobalVars:
             "4687348",  # FelixSFD
             "6375113",  # Bugs
             "4622463",  # angussidney
-            "158742",   # Rob
+            "563532",   # Rob
             "4050842"   # Thaillie
         ]
     }


### PR DESCRIPTION
I accidentally added my StackExchange UserID, rather than my StackOverflow UserID.

Related pull request: https://github.com/Charcoal-SE/SmokeDetector/pull/1010