### PR TITLE
Propose a 'support phone number' bad title kword

### DIFF
--- a/findspam.py
+++ b/findspam.py
@@ -727,6 +727,10 @@ class FindSpam:
          'stripcodeblocks': False, 'body_summary': False, 'max_rep': 1, 'max_score': 0},
         {'regex': r'(?i)[\w\s]{0,20}help(?: a)?(?: weak)? postgraduate student(?: to)? write(?: a)? book\??',
          'all': True, 'sites': [], 'reason': 'bad keyword in {}', 'title': True, 'body': False, 'username': False,
+         'stripcodeblocks': False, 'body_summary': False, 'max_rep': 20, 'max_score': 0},
+        # Tech support phone number scam
+        {'regex': r'support\Wphone\Wnumber',
+         'all': True, 'sites': [], 'reason': 'bad keyword in {}', 'title': True, 'body': False, 'username': False,
          'stripcodeblocks': False, 'body_summary': False, 'max_rep': 20, 'max_score': 2},
         # Eltima: separated into its own method so we can constrain length
         {'method': has_eltima, 'all': True, 'sites': [], 'reason': "bad keyword in {}", 'title': False, 'body': True,


### PR DESCRIPTION
[This is the relevant MetaSmoke detection search](https://metasmoke.erwaysoftware.com/search?utf8=✓&title_is_regex=1&title=support%5CWphone%5CWnumber&body=&username=&why=&site=&feedback=&autoflagged=&reason=&user_rep_direction=>%3D&user_reputation=0&commit=Search), focusing on Title Only.  68/69 TPs, 1 FP, and 1 NAA.

After seeing a phone number detection in a post on SO where the capture pattern was *only* in the title for a suspicious phone number, I thought we might consider adding an additional 'support phone number' keyword detection.

While this adds another hard-coded keyword for title-only matching, it's more often than not, I think, only going to be seen in spam posts.  This could also be expanded to match other well known tech support 'scam' patterns that are primarily in the title, but I am only focusing on one currently.