### PR TITLE
Fix regex for p---/d--- length --autopull

### DIFF
--- a/bad_keywords.txt
+++ b/bad_keywords.txt
@@ -826,4 +826,4 @@ ephamere
 cannabinoid\W?complex
 body\W?slim\W?down
 pusys
-((p[eni]{3 4}s{1 2})|(d[ick]{2 4})|pussy)\W(is\W)?\.?[0-9]+\.?([0-9]+)?\Winch(es)?
+((p[eni]{3,4}s{1,2})|(d[ick]{2,4})|pussy)\W(is\W)?\.?[0-9]+\.?([0-9]+)?\Winch(es)?


### PR DESCRIPTION
Turns out the comma is a separator for multiple patterns. Edited the last line to correct.