### PR TITLE
Fix chatcommands coverage

### DIFF
--- a/test/test_chatcommunicate.py
+++ b/test/test_chatcommunicate.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from ChatExchange.chatexchange import events, client
 from chatcommunicate import *
-import chatcommands # required for coverage
+import chatcommands  # required for coverage
 from datahandling import is_false_positive, is_ignored_post
 import pytest
 

--- a/test/test_chatcommunicate.py
+++ b/test/test_chatcommunicate.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from ChatExchange.chatexchange import events, client
 from chatcommunicate import *
+import chatcommands # required for coverage
 from datahandling import is_false_positive, is_ignored_post
 import pytest
 

--- a/tox_tests.ini
+++ b/tox_tests.ini
@@ -1,3 +1,3 @@
 [flake8]
-ignore = E501,F403,E402,F405,N804
+ignore = E501,F403,E402,F401,F405,N804
 exclude = ChatExchange/*,.idea/*,.git/*


### PR DESCRIPTION
In order for Pytest to count a file towards coverage, it has to be imported by the test. This fixes that (and will also cause a dip in coverage).