### PR TITLE
Make mostly dots calculate length *before* stripping code blocks

### DIFF
--- a/findspam.py
+++ b/findspam.py
@@ -541,6 +541,9 @@ def mostly_dots(s, site, *args):
     body = strip_urls_and_tags(s)
     body_length = len(body)
 
+    body = regex.sub("(?s)<pre>.*?</pre>", "", body)
+    body = regex.sub("(?s)<code>.*?</code>", "", body)
+
     dot_count = len(regex.findall(r"\.", body))
 
     if body_length and dot_count / float(body_length) >= 0.4:
@@ -1065,7 +1068,7 @@ class FindSpam:
         # Mostly dots in post
         {'method': mostly_dots, 'all': True, 'sites': ['codegolf.stackexchange.com'],
          'reason': 'mostly dots in {}', 'title': True, 'body': True, 'username': False, 'body_summary': False,
-         'stripcodeblocks': True, 'max_rep': 50, 'max_score': 0},
+         'max_rep': 50, 'max_score': 0},
 
         #
         # Category: other

--- a/findspam.py
+++ b/findspam.py
@@ -1068,7 +1068,7 @@ class FindSpam:
         # Mostly dots in post
         {'method': mostly_dots, 'all': True, 'sites': ['codegolf.stackexchange.com'],
          'reason': 'mostly dots in {}', 'title': True, 'body': True, 'username': False, 'body_summary': False,
-         'max_rep': 50, 'max_score': 0},
+         'stripcodeblocks': False, 'max_rep': 50, 'max_score': 0},
 
         #
         # Category: other


### PR DESCRIPTION
Currently mostly dots strips code blocks first, then calculates the ratio of dots to characters in the post. This causes a lot of FPs when posts have long code blocks but not much else. This change makes it so that the length of those code blocks is still factored in, just not any dots in them.