### PR TITLE
Add better whois return info

### DIFF
--- a/chatcommands.py
+++ b/chatcommands.py
@@ -1275,8 +1275,20 @@ def command_whois(message_parts, ev_user_id, wrap2, *args, **kwargs):
                                 wrap2.get_user(admin).last_message,
                                 wrap2.get_user(admin).last_seen)
                                for admin in admins_not_in_room]
+    
+    singular_return_names = {"admin": "admin",
+                             "code_admin": "code admin"}
 
-    message = "I am aware of {} {}".format(len(admin_ids), message_parts[1])
+    plural_return_names = {"admin": "admins",
+                           "code_admin": "code admins"}
+    
+    return_name = ""
+    if len(admin_ids) == 1:
+        return_name = singular_return_names[valid_roles[message_parts[1]]]
+    else:
+        return_name = plural_return_names[valid_roles[message_parts[1]]]
+
+    message = "I am aware of {} {}".format(len(admin_ids), return_name)
 
     if admins_in_room_list:
         admins_in_room_list.sort(key=lambda x: x[2])    # Sort by last message (last seen = x[3])

--- a/chatcommands.py
+++ b/chatcommands.py
@@ -1275,13 +1275,12 @@ def command_whois(message_parts, ev_user_id, wrap2, *args, **kwargs):
                                 wrap2.get_user(admin).last_message,
                                 wrap2.get_user(admin).last_seen)
                                for admin in admins_not_in_room]
-    
     singular_return_names = {"admin": "admin",
                              "code_admin": "code admin"}
 
     plural_return_names = {"admin": "admins",
                            "code_admin": "code admins"}
-    
+
     return_name = ""
     if len(admin_ids) == 1:
         return_name = singular_return_names[valid_roles[message_parts[1]]]

--- a/chatcommands.py
+++ b/chatcommands.py
@@ -1277,7 +1277,7 @@ def command_whois(message_parts, ev_user_id, wrap2, *args, **kwargs):
                                for admin in admins_not_in_room]
 
     return_names = {"admin": ["admin", "admins"], "code_admin": ["code admin", "code admins"]}
-    return_name = return_names[valid_roles[message_parts[1]][len(admin_ids) - 1]
+    return_name = return_names[valid_roles[message_parts[1]]][len(admin_ids) - 1]
 
     message = "I am aware of {} {}".format(len(admin_ids), return_name)
 

--- a/chatcommands.py
+++ b/chatcommands.py
@@ -1275,17 +1275,9 @@ def command_whois(message_parts, ev_user_id, wrap2, *args, **kwargs):
                                 wrap2.get_user(admin).last_message,
                                 wrap2.get_user(admin).last_seen)
                                for admin in admins_not_in_room]
-    singular_return_names = {"admin": "admin",
-                             "code_admin": "code admin"}
 
-    plural_return_names = {"admin": "admins",
-                           "code_admin": "code admins"}
-
-    return_name = ""
-    if len(admin_ids) == 1:
-        return_name = singular_return_names[valid_roles[message_parts[1]]]
-    else:
-        return_name = plural_return_names[valid_roles[message_parts[1]]]
+    return_names = {"admin": ["admin", "admins"], "code_admin": ["code admin", "code admins"]}
+    return_name = return_names[valid_roles[message_parts[1]][len(admin_ids) - 1]
 
     message = "I am aware of {} {}".format(len(admin_ids), return_name)
 


### PR DESCRIPTION
`!!/whois` currently returns weird info. For example, if you run `!!/whois code_admin` it returns `I am aware of 22 code_admin` and if you run `!!/whois admin` it returns `I am aware of 5 admin`.

With this pull request, `!!/whois code_admin` will be `I am aware of 22 code admins` and `!!/whois admin` returns `I am aware of 5 admins` which looks better and is grammatically correct.