### PR TITLE
Enhance "Already recently reported" by adding MS link

### DIFF
--- a/chatcommands.py
+++ b/chatcommands.py
@@ -1411,9 +1411,12 @@ def command_report_post(ev_room, ev_user_id, wrap2, message_parts, message_url,
                 (post_data.post_id, post_data.site)):
             # Don't re-report if the post wasn't marked as a false positive. If it was marked as a false positive,
             # this re-report might be attempting to correct that/fix a mistake/etc.
-            se_link = parsing.to_protocol_relative(post_data.post_url)
-            ms_link = "https://m.erwaysoftware.com/posts/by-url?url={}".format(se_link)
-            output.append("Post {}: Already recently reported [[MS]({})]".format(index, ms_link))
+            if GlobalVars.metasmoke_host is not None:
+                se_link = parsing.to_protocol_relative(post_data.post_url)
+                ms_link = "https://m.erwaysoftware.com/posts/by-url?url={}".format(se_link)
+                output.append("Post {}: Already recently reported [[MS]({})]".format(index, ms_link))
+            else:
+                output.append("Post {}: Already recently reported".format(index)
             continue
         post_data.is_answer = (post_data.post_type == "answer")
         post = Post(api_response=post_data.as_dict)

--- a/chatcommands.py
+++ b/chatcommands.py
@@ -1415,8 +1415,8 @@ def command_report_post(ev_room, ev_user_id, wrap2, message_parts, message_url,
                 se_link = parsing.to_protocol_relative(post_data.post_url)
                 ms_link = "https://m.erwaysoftware.com/posts/by-url?url={}".format(se_link)
                 output.append("Post {}: Already recently reported [[MS]({})]".format(index, ms_link))
-            else:
-                output.append("Post {}: Already recently reported".format(index)
+                continue
+            output.append("Post {}: Already recently reported".format(index)
             continue
         post_data.is_answer = (post_data.post_type == "answer")
         post = Post(api_response=post_data.as_dict)

--- a/chatcommands.py
+++ b/chatcommands.py
@@ -1417,7 +1417,7 @@ def command_report_post(ev_room, ev_user_id, wrap2, message_parts, message_url,
                 output.append("Post {}: Already recently reported [[MS]({})]".format(index, ms_link))
                 continue
             else:
-                output.append("Post {}: Already recently reported".format(index)
+                output.append("Post {}: Already recently reported").format(index)
                 continue
         post_data.is_answer = (post_data.post_type == "answer")
         post = Post(api_response=post_data.as_dict)

--- a/chatcommands.py
+++ b/chatcommands.py
@@ -1416,8 +1416,9 @@ def command_report_post(ev_room, ev_user_id, wrap2, message_parts, message_url,
                 ms_link = "https://m.erwaysoftware.com/posts/by-url?url={}".format(se_link)
                 output.append("Post {}: Already recently reported [[MS]({})]".format(index, ms_link))
                 continue
-            output.append("Post {}: Already recently reported".format(index)
-            continue
+            else:
+                output.append("Post {}: Already recently reported".format(index)
+                continue
         post_data.is_answer = (post_data.post_type == "answer")
         post = Post(api_response=post_data.as_dict)
         user = get_user_from_url(post_data.owner_url)

--- a/chatcommands.py
+++ b/chatcommands.py
@@ -1411,7 +1411,9 @@ def command_report_post(ev_room, ev_user_id, wrap2, message_parts, message_url,
                 (post_data.post_id, post_data.site)):
             # Don't re-report if the post wasn't marked as a false positive. If it was marked as a false positive,
             # this re-report might be attempting to correct that/fix a mistake/etc.
-            output.append("Post {}: Already recently reported".format(index))
+            se_link = parsing.to_protocol_relative(post_data.post_url)
+            ms_link = "https://m.erwaysoftware.com/posts/by-url?url={}".format(se_link)
+            output.append("Post {}: Already recently reported [[MS]({})]".format(index, ms_link))
             continue
         post_data.is_answer = (post_data.post_type == "answer")
         post = Post(api_response=post_data.as_dict)

--- a/chatcommands.py
+++ b/chatcommands.py
@@ -1411,7 +1411,7 @@ def command_report_post(ev_room, ev_user_id, wrap2, message_parts, message_url,
                 (post_data.post_id, post_data.site)):
             # Don't re-report if the post wasn't marked as a false positive. If it was marked as a false positive,
             # this re-report might be attempting to correct that/fix a mistake/etc.
-            if GlobalVars.metasmoke_host is not None:
+            if GlobalVars.metasmoke_key is not None:
                 se_link = parsing.to_protocol_relative(post_data.post_url)
                 ms_link = "https://m.erwaysoftware.com/posts/by-url?url={}".format(se_link)
                 output.append("Post {}: Already recently reported [[MS]({})]".format(index, ms_link))


### PR DESCRIPTION
When`!!/report` is used on something that is previously reported, the response is 

> @XXX Post X: Already recently reported

With this PR, the message would be

> @XXX Post X: Already recently reported [MS]

With a link to the MS report.

Closes #990