### PR TITLE
Include an SE search link in blacklist PRs

### DIFF
--- a/gitmanager.py
+++ b/gitmanager.py
@@ -157,7 +157,7 @@ class GitManager:
 
                 payload = {"title": u"{0}: {1} {2}".format(username, op.title(), item),
                            "body": u"[{0}]({1}) requests the {2} of the {3} {4}. See the Metasmoke search [here]"
-                                   "(https://metasmoke.erwaysoftware.com/search?utf8=%E2%9C%93{5}{6}), and the"
+                                   "(https://metasmoke.erwaysoftware.com/search?utf8=%E2%9C%93{5}{6}) and the"
                                    "Stack Exchange search [here](https://stackexchange.com/search?q=%22{5}%22).\n"
                                    u"<!-- METASMOKE-BLACKLIST-{7} {4} -->".format(
                                        username, chat_profile_link, op, blacklist,

--- a/gitmanager.py
+++ b/gitmanager.py
@@ -9,6 +9,7 @@ import json
 import regex
 from datetime import datetime
 from threading import Lock
+from urllib.parse import quote_plus
 if 'windows' in str(platform.platform()).lower():
     # noinspection PyPep8Naming
     from classes import Git as git
@@ -156,11 +157,12 @@ class GitManager:
 
                 payload = {"title": u"{0}: {1} {2}".format(username, op.title(), item),
                            "body": u"[{0}]({1}) requests the {2} of the {3} {4}. See the Metasmoke search [here]"
-                                   "(https://metasmoke.erwaysoftware.com/search?utf8=%E2%9C%93{5}{6})\n"
+                                   "(https://metasmoke.erwaysoftware.com/search?utf8=%E2%9C%93{5}{6}), and the"
+                                   "Stack Exchange search [here](https://stackexchange.com/search?q=%22{5}%22).\n"
                                    u"<!-- METASMOKE-BLACKLIST-{7} {4} -->".format(
                                        username, chat_profile_link, op, blacklist,
                                        item, ms_search_option,
-                                       item.replace(" ", "+"),
+                                       quote_plus(item),
                                        blacklist.upper()),
                            "head": branch,
                            "base": "master"}


### PR DESCRIPTION
When reviewing a blacklist/watchlist PR, I often do a [global Stack Exchange search](https://stackexchange.com/search) for the keyword or URL, just to be sure the keyword isn't used in non-spam posts.  I modified the auto-generated blacklist PR message to add an SE search link.

While I was at it, I also changed the MS search link to use `urllib`'s `quote_plus`, which converts spaces to pluses and percent-escapes other special characters.