### PR TITLE
Replace \W and \. in the SE search link

### DIFF
--- a/gitmanager.py
+++ b/gitmanager.py
@@ -157,7 +157,7 @@ class GitManager:
 
                 payload = {"title": u"{0}: {1} {2}".format(username, op.title(), item),
                            "body": u"[{0}]({1}) requests the {2} of the {3} {4}. See the Metasmoke search [here]"
-                                   "(https://metasmoke.erwaysoftware.com/search?utf8=%E2%9C%93{5}{6}) and the"
+                                   "(https://metasmoke.erwaysoftware.com/search?utf8=%E2%9C%93{5}{6}) and the "
                                    "Stack Exchange search [here](https://stackexchange.com/search?q=%22{7}%22).\n"
                                    u"<!-- METASMOKE-BLACKLIST-{8} {4} -->".format(
                                        username, chat_profile_link, op, blacklist,

--- a/gitmanager.py
+++ b/gitmanager.py
@@ -158,11 +158,12 @@ class GitManager:
                 payload = {"title": u"{0}: {1} {2}".format(username, op.title(), item),
                            "body": u"[{0}]({1}) requests the {2} of the {3} {4}. See the Metasmoke search [here]"
                                    "(https://metasmoke.erwaysoftware.com/search?utf8=%E2%9C%93{5}{6}) and the"
-                                   "Stack Exchange search [here](https://stackexchange.com/search?q=%22{6}%22).\n"
-                                   u"<!-- METASMOKE-BLACKLIST-{7} {4} -->".format(
+                                   "Stack Exchange search [here](https://stackexchange.com/search?q=%22{7}%22).\n"
+                                   u"<!-- METASMOKE-BLACKLIST-{8} {4} -->".format(
                                        username, chat_profile_link, op, blacklist,
                                        item, ms_search_option,
                                        quote_plus(item),
+                                       quote_plus(item.replace("\\W", " ").replace("\\.", ".")),
                                        blacklist.upper()),
                            "head": branch,
                            "base": "master"}


### PR DESCRIPTION
Replaces `\W` and `\.` with ` ` and `.` in the Stack Exchange search link in blacklist PRs, so patterns like `example\.com` link to SE searches like `example.com`.