### PR TITLE
Git lockdir

### DIFF
--- a/gitmanager.py
+++ b/gitmanager.py
@@ -5,6 +5,7 @@ import time
 import json
 from datetime import datetime
 from threading import Lock
+from os import mkdir, rmdir
 
 import regex
 import requests
@@ -33,6 +34,12 @@ class GitManager:
         username = kwargs.get("username", "")
         chat_profile_link = kwargs.get("chat_profile_link", "http://chat.stackexchange.com/users")
         code_permissions = kwargs.get("code_permissions", False)
+
+        # Block if git lock directory exists
+        try:
+            mkdir('gitmanager.lock')
+        except FileExistsError:
+            return (False, "Previous operation in progress; `!!/pull` to force")
 
         # Make sure git credentials are set up
         if git.config("--get", "user.name", _ok_code=[0, 1]) == "":
@@ -228,4 +235,8 @@ class GitManager:
 
     @staticmethod
     def pull_remote():
+        try:
+            rmdir('gitmanager.lock')
+        except FileNotFoundError:
+            pass
         git.pull()

--- a/gitmanager.py
+++ b/gitmanager.py
@@ -1,20 +1,24 @@
 # coding=utf-8
+
 import platform
-from helpers import log
-from requests.auth import HTTPBasicAuth
-from globalvars import GlobalVars
-import requests
 import time
 import json
-import regex
 from datetime import datetime
 from threading import Lock
+
+import regex
+import requests
+from requests.auth import HTTPBasicAuth
+
 from urllib.parse import quote_plus
 if 'windows' in str(platform.platform()).lower():
     # noinspection PyPep8Naming
     from classes import Git as git
 else:
     from sh import git
+
+from helpers import log
+from globalvars import GlobalVars
 
 
 # noinspection PyRedundantParentheses,PyClassHasNoInit,PyBroadException


### PR DESCRIPTION
Smokey gets wedged if you blacklist or watch something while a previous Git operation is still running in CI.  Prevent that by creating a local lock directory which is removed when you pull.

The `gitmanager_lock` is probably redundant if this is accepted, but I am no longer entirely sure whether there were some other failure scenarios which it covered differently...