### PR TITLE
Neither SE nor regular Metasmoke supports regex search

### DIFF
--- a/gitmanager.py
+++ b/gitmanager.py
@@ -162,11 +162,10 @@ class GitManager:
                 payload = {"title": u"{0}: {1} {2}".format(username, op.title(), item),
                            "body": u"[{0}]({1}) requests the {2} of the {3} {4}. See the Metasmoke search [here]"
                                    "(https://metasmoke.erwaysoftware.com/search?utf8=%E2%9C%93{5}{6}) and the "
-                                   "Stack Exchange search [here](https://stackexchange.com/search?q=%22{7}%22).\n"
-                                   u"<!-- METASMOKE-BLACKLIST-{8} {4} -->".format(
+                                   "Stack Exchange search [here](https://stackexchange.com/search?q=%22{6}%22).\n"
+                                   u"<!-- METASMOKE-BLACKLIST-{7} {4} -->".format(
                                        username, chat_profile_link, op, blacklist,
                                        item, ms_search_option,
-                                       quote_plus(item),
                                        quote_plus(item.replace("\\W", " ").replace("\\.", ".")),
                                        blacklist.upper()),
                            "head": branch,


### PR DESCRIPTION
Search links in the generated PR text were still wrong. Use the same expression for both Metasmoke and StackExchange search. (Both are still pretty brittle, because we are trying to convert a regex to a plain search string.)