### PR TITLE
Fix #1273 by correcting interpolation

### DIFF
--- a/spamhandling.py
+++ b/spamhandling.py
@@ -110,7 +110,7 @@ def handle_spam(post, reasons, why):
         else:
             sanitized_title = regex.sub('(https?://|\n)', '', post.title)
 
-        sanitized_title = regex.sub(r'([\]*`])', r'\\$1', sanitized_title).replace('\n', u'\u23CE')
+        sanitized_title = regex.sub(r'([\]*`])', r'\\\1', sanitized_title).replace('\n', u'\u23CE')
 
         prefix = u"[ [SmokeDetector](//goo.gl/eLDYqh) ]"
         if GlobalVars.metasmoke_key:


### PR DESCRIPTION
Don’t ask me why it works, but it does:

```python
>>> import regex
>>> print(regex.sub(r'([\]*`])', r'\\\1', 'a ** b ] `c`'))
=> r'a \*\* b \] \`c\`'
```

Fixes #1273.