### PR TITLE
Disable health-related bad keywords for Parenting.SE

### DIFF
--- a/findspam.py
+++ b/findspam.py
@@ -797,7 +797,7 @@ class FindSpam:
          'all': True,
          'sites': ["fitness.stackexchange.com", "biology.stackexchange.com", "health.stackexchange.com",
                    "skeptics.stackexchange.com", "bicycles.stackexchange.com", "islam.stackexchange.com",
-                   "pets.stackexchange.com"],
+                   "pets.stackexchange.com", "parenting.stackexchange.com"],
          'reason': "bad keyword in {}", 'title': True, 'body': True, 'username': False, 'stripcodeblocks': True,
          'body_summary': True, 'max_rep': 1, 'max_score': 0},
         # Korean character in title: requires 3


### PR DESCRIPTION
Case in point: https://metasmoke.erwaysoftware.com/search?body=lose+weight&site=90
Most of the Parenting.SE posts reported by SmokeDetector are trolling anyway.