### PR TITLE
Use asyncio Tasks

### DIFF
--- a/chatcommands.py
+++ b/chatcommands.py
@@ -15,8 +15,8 @@ from metasmoke import Metasmoke
 from parsing import *
 from spamhandling import handle_spam
 from gitmanager import GitManager
+from tasks import Tasks
 import threading
-from threading import Thread
 import random
 import requests
 import os
@@ -687,10 +687,7 @@ def status():
 # noinspection PyIncorrectDocstring
 @command(privileged=True)
 def stopflagging():
-    t_metasmoke = Thread(name="stop_autoflagging", target=Metasmoke.stop_autoflagging,
-                         args=())
-    t_metasmoke.start()
-
+    Tasks.do(Metasmoke.stop_autoflagging)
     return "Request sent..."
 
 

--- a/classes/feedback.py
+++ b/classes/feedback.py
@@ -1,5 +1,5 @@
-import threading
 from metasmoke import Metasmoke
+from tasks import Tasks
 
 
 class Feedback:
@@ -18,9 +18,7 @@ class Feedback:
 
     @staticmethod
     def send_custom(type, url, msg):
-        threading.Thread(name="metasmoke feedback send on " + url,
-                         target=Metasmoke.send_feedback_for_post,
-                         args=(url, type, msg.owner.name, msg.owner.id, msg._client.host,)).start()
+        Tasks.do(Metasmoke.send_feedback_for_post, url, type, msg.owner.name, msg.owner.id, msg._client.host)
 
 
 TRUE_FEEDBACKS = {

--- a/deletionwatcher.py
+++ b/deletionwatcher.py
@@ -6,13 +6,13 @@ import time
 import websocket
 # noinspection PyPackageRequirements
 from bs4 import BeautifulSoup
-from threading import Thread
 from urllib.parse import urlparse
 import chatcommunicate
 import metasmoke
 from globalvars import GlobalVars
 import datahandling
 from parsing import fetch_post_id_and_site_from_url
+from tasks import Tasks
 
 
 # noinspection PyClassHasNoInit,PyBroadException,PyMethodParameters
@@ -52,9 +52,7 @@ class DeletionWatcher:
             try:
                 a = ws.recv()
             except websocket.WebSocketTimeoutException:
-                t_metasmoke = Thread(name="metasmoke send deletion stats",
-                                     target=metasmoke.Metasmoke.send_deletion_stats_for_post, args=(post_url, False))
-                t_metasmoke.start()
+                Tasks.do(metasmoke.Metasmoke.send_deletion_stats_for_post, post_url, False)
                 return False
             if a is not None and a != "":
                 try:
@@ -70,14 +68,10 @@ class DeletionWatcher:
                         and ((post_type == "answer" and "aId" in d and str(d["aId"]) == post_id) or
                              post_type == "question"):
 
-                    t_metasmoke = Thread(name="metasmoke send deletion stats",
-                                         target=metasmoke.Metasmoke.send_deletion_stats_for_post, args=(post_url, True))
-                    t_metasmoke.start()
+                    Tasks.do(metasmoke.Metasmoke.send_deletion_stats_for_post, post_url, True)
                     return True
 
-        t_metasmoke = Thread(name="metasmoke send deletion stats",
-                             target=metasmoke.Metasmoke.send_deletion_stats_for_post, args=(post_url, False))
-        t_metasmoke.start()
+        Tasks.do(metasmoke.Metasmoke.send_deletion_stats_for_post, post_url, False)
         return False
 
     @classmethod

--- a/deletionwatcher.py
+++ b/deletionwatcher.py
@@ -64,12 +64,10 @@ class DeletionWatcher:
                         d = json.loads(json.loads(a)["data"])
                 except:
                     continue
-                if d["a"] == "post-deleted" and str(d["qId"]) == question_id \
-                        and ((post_type == "answer" and "aId" in d and str(d["aId"]) == post_id) or
-                             post_type == "question"):
-
-                    Tasks.do(metasmoke.Metasmoke.send_deletion_stats_for_post, post_url, True)
-                    return True
+                if d["a"] == "post-deleted" and str(d["qId"]) == question_id:
+                    if (post_type == "answer" and "aId" in d and str(d["aId"]) == post_id) or post_type == "question":
+                        Tasks.do(metasmoke.Metasmoke.send_deletion_stats_for_post, post_url, True)
+                        return True
 
         Tasks.do(metasmoke.Metasmoke.send_deletion_stats_for_post, post_url, False)
         return False

--- a/metasmoke.py
+++ b/metasmoke.py
@@ -67,7 +67,6 @@ class Metasmoke:
 
     @staticmethod
     def check_last_pingtime():
-        threading.Timer(30, Metasmoke.check_last_pingtime).start()
         now = datetime.utcnow()
         errlog = open('errorLogs.txt', 'a', encoding="utf-8")
         if GlobalVars.metasmoke_last_ping_time is None:
@@ -265,7 +264,6 @@ class Metasmoke:
             log('info', "Metasmoke location not defined; not sending status ping")
             return
 
-        threading.Timer(60, Metasmoke.send_status_ping).start()
         metasmoke_key = GlobalVars.metasmoke_key
 
         try:
@@ -347,7 +345,7 @@ class Metasmoke:
                       data=json.dumps(payload), headers=headers)
 
     @staticmethod
-    def send_statistics(should_repeat=True):
+    def send_statistics():
         GlobalVars.posts_scan_stats_lock.acquire()
         if GlobalVars.post_scan_time != 0:
             posts_per_second = GlobalVars.num_posts_scanned / GlobalVars.post_scan_time
@@ -367,6 +365,3 @@ class Metasmoke:
         if GlobalVars.metasmoke_host is not None:
             requests.post(GlobalVars.metasmoke_host + "/statistics.json",
                           data=json.dumps(payload), headers=headers)
-
-        if should_repeat:
-            threading.Timer(600, Metasmoke.send_statistics).start()

--- a/spamhandling.py
+++ b/spamhandling.py
@@ -13,6 +13,7 @@ import excepthook
 import regex
 from classes import Post, PostParseError
 from helpers import log
+from tasks import Tasks
 
 
 # noinspection PyMissingTypeHints
@@ -127,12 +128,10 @@ def handle_spam(post, reasons, why):
                                                             post.user_name.strip(), poster_url, shortened_site)
             username = post.user_name.strip()
 
-        t_metasmoke = Thread(name="metasmoke send post",
-                             target=metasmoke.Metasmoke.send_stats_on_post,
-                             args=(post.title_ignore_type, post_url, reasons, post.body, username,
-                                   post.user_link, why, post.owner_rep, post.post_score,
-                                   post.up_vote_count, post.down_vote_count))
-        t_metasmoke.start()
+        Tasks.do(metasmoke.Metasmoke.send_stats_on_post,
+                 post.title_ignore_type, post_url, reasons, post.body, username,
+                 post.user_link, why, post.owner_rep, post.post_score,
+                 post.up_vote_count, post.down_vote_count)
 
         log('debug', GlobalVars.parser.unescape(s).encode('ascii', errors='replace'))
         datahandling.append_to_latest_questions(post.post_site, post.post_id, post.title)

--- a/tasks.py
+++ b/tasks.py
@@ -1,0 +1,37 @@
+import asyncio
+import threading
+
+
+class Tasks:
+    loop = asyncio.new_event_loop()
+
+    @classmethod
+    def _run(cls):
+        try:
+            cls.loop.run_forever()
+        finally:
+            cls.loop.close()
+
+    @classmethod
+    def do(cls, func, *args, **kwargs):
+        cls.loop.call_soon(lambda: func(*args, **kwargs))
+        cls.loop._write_to_self()
+
+    @classmethod
+    def later(cls, func, *args, after=None, **kwargs):
+        cls.loop.call_later(after, lambda: func(*args, **kwargs))
+        cls.loop._write_to_self()
+
+    @classmethod
+    def periodic(cls, func, *args, interval=None, **kwargs):
+        @asyncio.coroutine
+        def f():
+            while True:
+                yield from asyncio.sleep(interval)
+                func(*args, **kwargs)
+
+        cls.loop.create_task(f())
+        cls.loop._write_to_self()
+
+
+threading.Thread(name="tasks", target=Tasks._run, daemon=True).start()


### PR DESCRIPTION
This swaps out many of our short-lived threads (things like sending stats to Metasmoke) for efficient [asyncio Tasks](https://docs.python.org/3/library/asyncio.html) that run on a single dedicated thread.

The base of this is a new class `Tasks` with three methods:

- `Tasks.do`: takes in a function and arguments and schedules it to be run as soon as the thread is free (first in, first out)
- `Tasks.later`: takes in a function and arguments and schedules to be called after a certain delay in seconds (specified by the keyword argument `after=`)
- `Tasks.periodic`: takes in a function and arguments and schedules it to be called every `interval` seconds

Some examples:

    Tasks.do(metasmoke.Metasmoke.send_deletion_stats_for_post, post_url, True)
    Tasks.later(restart_automatically, after=21600)
    Tasks.periodic(Metasmoke.send_status_ping, interval=60)

I have swapped out most of our one-off thread usage for this, with three exceptions:

- `deletionwatcher.post_message_if_not_deleted` and `deletionwatcher.check_if_report_was_deleted`: these still spawns a thread for each report, since the `websocket` module doesn't offer a way to monitor the websocket for deletion asynchronously. (I may have an alternate way though, still thinking about it.)
- `bodyfetcher post enqueing`: I wasn't entirely certain why this was running on a thread at all, so I chose not to touch it for now.