### PR TITLE
Listen to chat sockets via poll(), eliminate unused CE worker thread

### DIFF
--- a/chatcommands.py
+++ b/chatcommands.py
@@ -1189,7 +1189,7 @@ def delete_force(msg):
     """
     # noinspection PyBroadException
     try:
-        msg.delete()
+        msg._client._do_action_despite_throttling(("delete", msg.id, ""))
     except:
         pass  # couldn't delete message
 
@@ -1210,7 +1210,7 @@ def delete(msg):
                "#a-note-on-message-deletion) for more details."
     else:
         try:
-            msg.delete()
+            msg._client._do_action_despite_throttling(("delete", msg.id, ""))
         except:
             pass
 
@@ -1228,7 +1228,7 @@ def postgone(msg):
     if edited is None:
         raise CmdException("That's not a report.")
 
-    msg.edit(edited)
+    msg._client._do_action_despite_throttling(("edit", msg.id, edited))
 
 
 # noinspection PyIncorrectDocstring
@@ -1266,7 +1266,7 @@ def false(feedback, msg, alias_used="false"):
 
     try:
         if int(msg.room.id) != int(GlobalVars.charcoal_hq.id):
-            msg.delete()
+            msg._client._do_action_despite_throttling(("delete", msg.id, ""))
     except:
         pass
 

--- a/chatexchange_extension.py
+++ b/chatexchange_extension.py
@@ -1,8 +1,11 @@
 # coding=utf-8
-from ChatExchange.chatexchange import client, rooms
-import sys
+from ChatExchange.chatexchange import browser, client, rooms
 from datetime import datetime
-from helpers import log
+import json
+import os
+import select
+import threading
+import websocket
 
 
 class Room(rooms.Room):
@@ -22,7 +25,72 @@ class Client(client.Client):
     def __init__(self, host):
         super().__init__(host)
         self.last_activity = None
+        self._br = Browser()
+
+    def _worker(self):
+        pass
 
     def get_room(self, room_id, **attrs_to_set):
         return self._get_and_set_deduplicated(
             Room, room_id, self._rooms, attrs_to_set)
+
+
+class Browser(browser.Browser):
+    _poller = select.poll()
+    _kill_poll = False
+    _sockets_by_fd = {}
+
+    _rid, _wid = os.pipe()
+    _poller.register(_rid, select.POLLIN)
+
+    @classmethod
+    def _poll(cls):
+        while True:
+            for ready, event in cls._poller.poll():
+                if ready == cls._rid:
+                    os.read(cls._rid, 1)
+                else:
+                    sock, roomid, on_msg, on_hup = cls._sockets_by_fd[ready]
+
+                    if event & select.POLLHUP:
+                        on_hup(roomid)
+                    else:
+                        msg = sock.recv()
+
+                        if msg:
+                            on_msg(json.loads(msg))
+
+    def leave_room(self, roomid):
+        roomid = str(roomid)
+
+        if roomid in self.sockets:
+            fileno = self.sockets[roomid].fileno()
+
+            Browser._sockets_by_fd.pop(fileno)
+            self._poller.unregister(fileno)
+
+        super().leave_room(roomid)
+        os.write(self._wid, b"\x04")
+
+    def watch_room_socket(self, roomid, callback):
+        roomid = str(roomid)
+
+        l = str(self.rooms[roomid]["eventtime"])
+        ws_url = self.post_fkeyed("ws-auth", {"roomid": roomid}).json()["url"]
+
+        sock = websocket.create_connection(ws_url + "?l=" + l, origin=self.chat_root)
+
+        self.sockets[roomid] = sock
+        Browser._sockets_by_fd[sock.fileno()] = (sock, roomid, callback, self._default_ws_recovery)
+        Browser._poller.register(sock, select.POLLIN | select.POLLHUP)
+
+        os.write(self._wid, b"\x04")
+
+    def _default_ws_recovery(self, roomid):
+        roomid = str(roomid)
+
+        if roomid in self.sockets:
+            super._default_ws_recovery(roomid)
+
+
+threading.Thread(name="poller", target=Browser._poll).start()


### PR DESCRIPTION
This prunes a lot of threads that weren't really doing too much.

1. Previously, ChatExchange would spawn one thread per websocket (that's one thread per room we listen to commands in, essentially). These changes make it so that there's only one thread, which uses an efficient [poll()](https://docs.python.org/3/library/select.html#select.poll) to monitor all the sockets simultaneously. When at least one of them is available to read from, the thread unblocks and dispatches the appropriate callback like normal.

2. This also eliminates the mostly-unused `_worker` thread, which ChatExchange spawns one per chat host in order to do operations like sending or deleting messages asynchronous. In the case of sending messages, we already have our own thread that manages that as well as managing the `_last_messages` for us, and we don't really need to delete messages asynchronously, so it's not really useful.