### PR TITLE
Added new rule for titles that end with comma

### DIFF
--- a/findspam.py
+++ b/findspam.py
@@ -1142,7 +1142,10 @@ class FindSpam:
         {'method': mostly_dots, 'all': True, 'sites': ['codegolf.stackexchange.com'],
          'reason': 'mostly dots in {}', 'title': True, 'body': True, 'username': False, 'body_summary': False,
          'stripcodeblocks': False, 'max_rep': 50, 'max_score': 0},
-
+        # Title ends with Comma (IPS Troll)
+        {'regex': r".*\,$", 'all': False, 'sites': ["interpersonal.stackexchange.com"],
+         'reason': "title ends with comma", 'title': True, 'body': False, 'username': False, 'stripcodeblocks': False,
+         'body_summary': True, 'max_rep': 50, 'max_score': 0},
         #
         # Category: other
         # Blacklisted usernames

--- a/findspam.py
+++ b/findspam.py
@@ -1143,9 +1143,9 @@ class FindSpam:
          'reason': 'mostly dots in {}', 'title': True, 'body': True, 'username': False, 'body_summary': False,
          'stripcodeblocks': False, 'max_rep': 50, 'max_score': 0},
         # Title ends with Comma (IPS Troll)
-        {'regex': r".*\,$", 'all': False, 'sites': ["interpersonal.stackexchange.com"],
+        {'regex': r".*\,$", 'all': True, 'sites': [],
          'reason': "title ends with comma", 'title': True, 'body': False, 'username': False, 'stripcodeblocks': False,
-         'body_summary': True, 'max_rep': 50, 'max_score': 0},
+         'body_summary': False, 'max_rep': 50, 'max_score': 0},
         #
         # Category: other
         # Blacklisted usernames


### PR DESCRIPTION
Series of troll posts across Interpersonal.Stackexchange over the last couple days.

Plus, it's fairly accurate with 416 <-> 8 rate
https://metasmoke.erwaysoftware.com/search?autoflagged=&body=&commit=Search&feedback=&feedback_filter=tp&reason=&site=&title=.%2A%5C%2C%24&title_is_regex=1&user_rep_direction=%3E%3D&user_reputation=0&username=&utf8=%E2%9C%93&why=

Requested by Catija (IPS Moderator)