### PR TITLE
Revert rule for titles that end with comma

### DIFF
--- a/findspam.py
+++ b/findspam.py
@@ -1142,7 +1142,10 @@ class FindSpam:
         {'method': mostly_dots, 'all': True, 'sites': ['codegolf.stackexchange.com'],
          'reason': 'mostly dots in {}', 'title': True, 'body': True, 'username': False, 'body_summary': False,
          'stripcodeblocks': False, 'max_rep': 50, 'max_score': 0},
-
+        # Title ends with Comma (IPS Troll)
+        {'regex': r".*\,$", 'all': False, 'sites': ['interpersonal.stackexchange.com'],
+         'reason': "title ends with comma", 'title': True, 'body': False, 'username': False, 'stripcodeblocks': False,
+         'body_summary': False, 'max_rep': 50, 'max_score': 0},
         #
         # Category: other
         # Blacklisted usernames

--- a/findspam.py
+++ b/findspam.py
@@ -1142,10 +1142,7 @@ class FindSpam:
         {'method': mostly_dots, 'all': True, 'sites': ['codegolf.stackexchange.com'],
          'reason': 'mostly dots in {}', 'title': True, 'body': True, 'username': False, 'body_summary': False,
          'stripcodeblocks': False, 'max_rep': 50, 'max_score': 0},
-        # Title ends with Comma (IPS Troll)
-        {'regex': r".*\,$", 'all': True, 'sites': [],
-         'reason': "title ends with comma", 'title': True, 'body': False, 'username': False, 'stripcodeblocks': False,
-         'body_summary': False, 'max_rep': 50, 'max_score': 0},
+
         #
         # Category: other
         # Blacklisted usernames


### PR DESCRIPTION
Looks like we were misled in https://github.com/Charcoal-SE/SmokeDetector/commit/c0b52fe1a35dab9ef3fcdc290754e374983edfb7 by metasmoke's natural tendency toward true positives. [It's not doing well](https://metasmoke.erwaysoftware.com/reason/140) on real data from the network. The detected posts are 3/13, and the true positives have plenty of weight without this reason (which metasmoke is still clamping to 0).