### PR TITLE
del-force only for reports

### DIFF
--- a/chatcommands.py
+++ b/chatcommands.py
@@ -1203,8 +1203,10 @@ def delete(msg):
     :return: None
     """
     if msg.room.id == 11540:
-        return "Messages from SmokeDetector in Charcoal HQ are generally kept "\
-               "as records. If you really need to delete a message, please use "\
+    post_data = get_report_data(msg)
+    if post_data and msg.room.id == 11540:
+        return "Reports from SmokeDetector in Charcoal HQ are generally kept "\
+               "as records. If you really need to delete a report, please use "\
                "`sd delete-force`. See [this note on message deletion]"\
                "(https://charcoal-se.org/smokey/Commands"\
                "#a-note-on-message-deletion) for more details."

--- a/chatcommands.py
+++ b/chatcommands.py
@@ -1202,7 +1202,7 @@ def delete(msg):
     :param msg:
     :return: None
     """
-    if msg.room.id == 11540:
+
     post_data = get_report_data(msg)
     if post_data and msg.room.id == 11540:
         return "Reports from SmokeDetector in Charcoal HQ are generally kept "\


### PR DESCRIPTION
This PR implements the request for levels of deletion in #1139. Currently, all messages in CHQ have to be deleted with -force, but with this PR only reports need to be deleted with -force.

(Fixes #1139)