### PR TITLE
Add backslash into watched keywords

### DIFF
--- a/watched_keywords.txt
+++ b/watched_keywords.txt
@@ -2083,4 +2083,4 @@
 1514543789	Glorfindel	uniformonline\.com
 1514605149	paper1111	mylifeshirt\.com
 1514613278	paper1111	iuktvnowapk\.com
-1514614412	paper1111	press-start\.com
+1514614412	paper1111	press\-start\.com

--- a/watched_keywords.txt
+++ b/watched_keywords.txt
@@ -2083,4 +2083,4 @@
 1514543789	Glorfindel	uniformonline\.com
 1514605149	paper1111	mylifeshirt\.com
 1514613278	paper1111	iuktvnowapk\.com
-1514614412	paper1111	press-start.com
+1514614412	paper1111	press-start\.com


### PR DESCRIPTION
I have accidentally forgotten to add the backslash for a `watched_keywords.txt` entry. This PR adds it.