### PR TITLE
Improve "no whitespace" detection --autopull

### DIFF
--- a/findspam.py
+++ b/findspam.py
@@ -1096,7 +1096,7 @@ class FindSpam:
          'stripcodeblocks': True, 'body_summary': False,
          'max_rep': 101, 'max_score': 5},
         # No whitespace, punctuation, or formatting in a post
-        {'regex': r"(?i)^<p>\W+</p>\s*$", 'all': True, 'sites': ["codegolf.stackexchange.com",
+        {'regex': r"(?i)^<p>\w+</p>\s*$", 'all': True, 'sites': ["codegolf.stackexchange.com",
                                                                  "puzzling.stackexchange.com"],
          'reason': "no whitespace in {}", 'title': False, 'body': True, 'username': False, 'stripcodeblocks': False,
          'body_summary': False, 'max_rep': 1, 'max_score': 0},

--- a/findspam.py
+++ b/findspam.py
@@ -1096,7 +1096,7 @@ class FindSpam:
          'stripcodeblocks': True, 'body_summary': False,
          'max_rep': 101, 'max_score': 5},
         # No whitespace, punctuation, or formatting in a post
-        {'regex': r"(?i)^<p>\S+</p>\s*$", 'all': True, 'sites': ["codegolf.stackexchange.com",
+        {'regex': r"(?i)^<p>\W+</p>\s*$", 'all': True, 'sites': ["codegolf.stackexchange.com",
                                                                  "puzzling.stackexchange.com"],
          'reason': "no whitespace in {}", 'title': False, 'body': True, 'username': False, 'stripcodeblocks': False,
          'body_summary': False, 'max_rep': 1, 'max_score': 0},


### PR DESCRIPTION
The `\S+` detection for "no whitespace" starts to catch valid one-line answers with enough punctuation. [For example](https://metasmoke.erwaysoftware.com/post/102944). Changing to "word" (letters+digits+underscore) should solve this issue (although underscore isn't necessary)