### PR TITLE
+Sonic the Anonymous Hedgehog in Tavern on the Meta

### DIFF
--- a/rooms.yml
+++ b/rooms.yml
@@ -299,6 +299,7 @@ meta.stackexchange.com:
       - 284336   # Catija
       - 310369   # quartata
       - 350567   # iDebug (iBug on SO)
+      - 377214   # Sonic the Anonymous Hedgehog (gparyani elsewhere)
 
 
 stackoverflow.com:


### PR DESCRIPTION
See [his request](https://github.com/Charcoal-SE/SmokeDetector/issues/1545). He's already privileged in CHQ.