### PR TITLE
Removing 234\W... because of fps

### DIFF
--- a/watched_keywords.txt
+++ b/watched_keywords.txt
@@ -2097,7 +2097,6 @@
 1515053113	paper1111	car\.lol
 1515053302	paper1111	it-bari\.net
 1515073825	iBug	pendingbitcoin\.com
-1515074872	iBug	234\W*\d{3}\W*\d{3}\W*\d{2,8}
 1515106120	JoErNanO	b­o­s­s­c­y­b­e­r\.c­o­m
 1515107050	paper1111	alinma\.com
 1515107078	paper1111	alrajhibank\.com\.sa


### PR DESCRIPTION
According to [this MS search](https://metasmoke.erwaysoftware.com/search?utf8=%E2%9C%93&title=&body_is_regex=1&body=234%5B%5Ea-zA-Z0-9_%5D*%5B0-9%5D%7B3%7D%5B%5Ea-zA-Z0-9_%5D*%5B0-9%5D%7B3%7D%5B%5Ea-zA-Z0-9_%5D*%5B0-9%5D%7B2%2C8%7D&username=&why=&site=&feedback=&autoflagged=&reason=&user_rep_direction=%3E%3D&user_reputation=0&commit=Search), the pattern `234\W*\d{3}\W*\d{3}\W*\d{2,8}` has caught 37 posts since it was added to watch. 26 of these were fps, and the remain 11 tps where also caught by another reason, so I don't think we'll miss any posts by removing it.

Note that in the search I've replaced `\W` with `[^a-zA-Z0-9_]` and `\d` with `[0-9]` to make it work on MS.