### PR TITLE
Add code format for the keyword

### DIFF
--- a/gitmanager.py
+++ b/gitmanager.py
@@ -148,7 +148,7 @@ class GitManager:
                     return (False, "Tell someone to set a GH password")
 
                 payload = {"title": u"{0}: {1} {2}".format(username, op.title(), item),
-                           "body": u"[{0}]({1}) requests the {2} of the {3} {4}. See the Metasmoke search [here]"
+                           "body": u"[{0}]({1}) requests the {2} of the {3} `{4}`. See the Metasmoke search [here]"
                                    "(https://metasmoke.erwaysoftware.com/search?utf8=%E2%9C%93{5}{6}) and the "
                                    "Stack Exchange search [here](https://stackexchange.com/search?q=%22{7}%22).\n"
                                    u"<!-- METASMOKE-BLACKLIST-{8} {4} -->".format(


### PR DESCRIPTION
iBug requests the watch of the watch_keyword `keywords?`. See the Metasmoke search here and the Stack Exchange search here.

------

It surely looks better now.