### PR TITLE
Update penis/dick length regex to catch more units --autopull

### DIFF
--- a/bad_keywords.txt
+++ b/bad_keywords.txt
@@ -811,7 +811,7 @@ ephamere
 cannabinoid\W?complex
 body\W?slim\W?down
 pusys
-((p[eni]{3,4}s{1,2})|(d[ick]{2,4})|pussy)\W(is\W)?\.?[0-9]+\.?([0-9]+)?\Winch(es)?
+((p[eni]{3,4}s{1,2})|(d[ick]{2,4})|pussy)\W(is\W)?\.?[0-9]+\.?([0-9]+)?\W?(in|inch(es)?|cm|centimet(er|re)s?)
 fukc(ing)?
 truewell
 activguard


### PR DESCRIPTION
The "penis/dick x inches" regex at line 814 failed to catch a wingding post which used cm instead of inches (https://metasmoke.erwaysoftware.com/post/98237). This commit changes the regex to handle metric units as well as abbreviations, as well as when the length value and unit are not separated by a space.