### PR TITLE
Fix handling of experimental reasons

### DIFF
--- a/spamhandling.py
+++ b/spamhandling.py
@@ -142,7 +142,7 @@ def handle_spam(post, reasons, why):
 
         without_roles = tuple("no-" + reason for reason in reasons) + ("site-no-" + post.post_site,)
 
-        if set(reasons) & GlobalVars.experimental_reasons == {}:
+        if set(reasons) - GlobalVars.experimental_reasons == set():
             chatcommunicate.tell_rooms(message, ("experimental",),
                                        without_roles, notify_site=post.post_site, report_data=(post_url, poster_url))
         else:


### PR DESCRIPTION
The check to decide whether a message should only be posted to experimental rooms was:

    if set(reasons) & GlobalVars.experimental_reasons == {}:

However, `set(reasons) & GlobalVars.experimental_reasons` is the intersection of the two sets, which equals the set of experimental reasons that caught the post.  We wanted the set of *non*-experimental reasons, which is `if set(reasons) - GlobalVars.experimental_reasons`.

Additionally, [`{}` is a dictionary literal](https://stackoverflow.com/questions/6130374/empty-set-literal); we want `set()` for the empty set.

Fixes #1455.