### PR TITLE
Add an experimental reason to catch Donald Trump usernames

### DIFF
--- a/blacklisted_usernames.txt
+++ b/blacklisted_usernames.txt
@@ -65,4 +65,4 @@ emilie\W?larsen
 air\W?purifier\W?reviews
 Cum\W?Juice
 agen judi‭
-donald\W*j?\.?\W*trump
+donald\W<i>j?.?\W</i>trump

--- a/blacklisted_usernames.txt
+++ b/blacklisted_usernames.txt
@@ -65,4 +65,3 @@ emilie\W?larsen
 air\W?purifier\W?reviews
 Cum\W?Juice
 agen judi‭
-donald\W<i>j?.?\W</i>trump

--- a/findspam.py
+++ b/findspam.py
@@ -1189,7 +1189,12 @@ class FindSpam:
         # Link text points to a different domain than the href
         {'method': malicious_link, 'all': True, 'sites': [], 'reason': 'misleading link', 'title': False,
          'body': True, 'username': False, 'stripcodeblocks': True, 'body_summary': False,
-         'max_rep': 10, 'max_score': 1}
+         'max_rep': 10, 'max_score': 1},
+
+        # Donald Trump username
+        {'regex': r"don(ald)?(\W*j)?\W*trump", 'all': True, 'sites': [],
+         'reason': "potentially bad username", 'title': False, 'body': False, 'username': True,
+         'stripcodeblocks': False, 'body_summary': False, 'max_rep': 1, 'max_score': 0}
     ]
 
     @staticmethod

--- a/globalvars.py
+++ b/globalvars.py
@@ -68,7 +68,8 @@ class GlobalVars:
         "potentially bad keyword in answer",
         "potentially bad keyword in body",
         "potentially bad keyword in title",
-        "potentially bad keyword in username"}
+        "potentially bad keyword in username",
+        "potentially bad username"}
 
     parser = HTMLParser()
     parser.unescape = unescape


### PR DESCRIPTION
We get [a lot](https://metasmoke.erwaysoftware.com/search?utf8=✓&title=&body=&username_is_regex=1&username=don%28ald%29%3F%28+%2Aj%29%3F+%2Atrump&why=&site=&feedback=&autoflagged=&reason=&user_rep_direction=%3E%3D&user_reputation=0&commit=Search) of trolls named after Trump.  The latest of these has posted several answers we have not caught without `!!/report`.

I added an experimental reason to catch users matching `don(ald)?(\W*j)?\W*trump`.  There are 37 `tp`s, 2 `fp`s, and 3 `naa`s in Metasmoke.  On the entire network, there are [38 users](http://data.stackexchange.com/stackoverflow/query/801521/users-named-donald-trump) named Donald Trump or a variant, but only [nine of these](https://gist.github.com/NobodyNada/ac38fa0f4bcf6aaa4b5285b68baed16d) have non-deleted posts.

I added the reason to the end of findspam, with the name "Potentially bad username."  Since the reason contains "username," whitelisting a user will prevent them from being caught by this reason.  I also added this reason to the experimental reason list (although this doesn't cancel its autoflagging weigh, which requires MS console access as far as I can tell.)