### PR TITLE
Add a list of keywords specially for Stack Overflow (really done)

### DIFF
--- a/blacklists.py
+++ b/blacklists.py
@@ -7,6 +7,7 @@ from helpers import log
 
 def load_blacklists():
     GlobalVars.bad_keywords = Blacklist(Blacklist.KEYWORDS).parse()
+    GlobalVars.so_bad_keywords = Blacklist(Blacklist.SO_KEYWORDS).parse()
     GlobalVars.blacklisted_websites = Blacklist(Blacklist.WEBSITES).parse()
     GlobalVars.blacklisted_usernames = Blacklist(Blacklist.USERNAMES).parse()
     GlobalVars.watched_keywords = Blacklist(Blacklist.WATCHED_KEYWORDS).parse()
@@ -110,6 +111,7 @@ class TSVDictParser(BlacklistParser):
 
 class Blacklist:
     KEYWORDS = ('bad_keywords.txt', BasicListParser)
+    SO_KEYWORDS = ('so_bad_keywords.txt', BasicListParser)
     WEBSITES = ('blacklisted_websites.txt', BasicListParser)
     USERNAMES = ('blacklisted_usernames.txt', BasicListParser)
     WATCHED_KEYWORDS = ('watched_keywords.txt', TSVDictParser)

--- a/chatcommands.py
+++ b/chatcommands.py
@@ -748,45 +748,47 @@ def standby(msg, location_search):
 
 
 # noinspection PyIncorrectDocstring
-@command(str, aliases=["test-q", "test-a", "test-u", "test-t"], give_name=True)
+@command(str, aliases=["test-q", "test-a", "test-u", "test-t", "test-so",
+                       "test-q-so", "test-a-so", "test-u-so", "test-t-so"], give_name=True)
 def test(content, alias_used="test"):
     """
-    Test an answer to determine if it'd be automatically reported
+    Test a string to determine if it'd be automatically reported
     :param content:
     :return: A string
     """
     result = "> "
 
-    if alias_used == "test-q":
-        kind = " question."
-        fakepost = Post(api_response={'title': 'Valid title', 'body': content,
-                                      'owner': {'display_name': "Valid username", 'reputation': 1, 'link': ''},
-                                      'site': "", 'IsAnswer': False, 'score': 0})
-    elif alias_used == "test-a":
-        kind = "n answer."
-        fakepost = Post(api_response={'title': 'Valid title', 'body': content,
-                                      'owner': {'display_name': "Valid username", 'reputation': 1, 'link': ''},
-                                      'site': "", 'IsAnswer': True, 'score': 0})
-    elif alias_used == "test-u":
-        kind = " username."
-        fakepost = Post(api_response={'title': 'Valid title', 'body': "Valid question body",
-                                      'owner': {'display_name': content, 'reputation': 1, 'link': ''},
-                                      'site': "", 'IsAnswer': False, 'score': 0})
-    elif alias_used == "test-t":
-        kind = " title."
-        fakepost = Post(api_response={'title': content, 'body': "Valid question body",
-                                      'owner': {'display_name': "Valid username", 'reputation': 1, 'link': ''},
-                                      'site': "", 'IsAnswer': False, 'score': 0})
-    else:
-        kind = " post, title or username."
-        fakepost = Post(api_response={'title': content, 'body': content,
-                                      'owner': {'display_name': content, 'reputation': 1, 'link': ''},
-                                      'site': "", 'IsAnswer': False, 'score': 0})
+    sample_post = {'title': 'Valid title', 'body': 'Valid question body',
+                   'owner': {'display_name': "Valid username", 'reputation': 1, 'link': ''},
+                   'site': "", 'IsAnswer': False, 'score': 0}
 
-    reasons, why_response = FindSpam.test_post(fakepost)
+    if alias_used.endswith('-so'):
+        alias_used = alias_used[:-3]
+        sample_post['site'] = 'stackoverflow.com'
+
+    if alias_used == "test-q":
+        kind = "a question"
+        sample_post['body'] = content
+        sample_post['IsAnswer'] = False
+    elif alias_used == "test-a":
+        kind = "an answer"
+        sample_post['body'] = content
+        sample_post['IsAnswer'] = True
+    elif alias_used == "test-u":
+        kind = "a username"
+        sample_post['owner']['display_name'] = content
+    elif alias_used == "test-t":
+        kind = "a title"
+        sample_post['title'] = content
+        sample_post['IsAnswer'] = False
+    else:
+        kind = "a post, title or username"
+        sample_post['title'] = sample_post['body'] = sample_post['owner']['display_name'] = content
+
+    reasons, why_response = FindSpam.test_post(Post(api_response=sample_post))
 
     if len(reasons) == 0:
-        result += "Would not be caught as a{}".format(kind)
+        result += "Would not be caught as {}.".format(kind)
     else:
         result += ", ".join(reasons).capitalize()
 

--- a/chatcommands.py
+++ b/chatcommands.py
@@ -203,9 +203,9 @@ def blacklist(_):
 
 def check_blacklist(string_to_test, **is_what):
     # Test the string and provide a warning message if it is already caught.
-    sample_post = {'api_response': {'title': 'Valid title', 'body': 'Valid body',
-                                    'owner': {'display_name': 'Valid username', 'reputation': 1, 'link': ''},
-                                    'site': '', 'IsAnswer': False, 'score': 0}}
+    sample_post = {'title': 'Valid title', 'body': 'Valid body',
+                   'owner': {'display_name': 'Valid username', 'reputation': 1, 'link': ''},
+                   'site': '', 'IsAnswer': False, 'score': 0}
 
     if is_what['username']:
         sample_post['owner']['display_name'] = string_to_test

--- a/findspam.py
+++ b/findspam.py
@@ -776,14 +776,12 @@ class FindSpam:
         # Category: Bad keywords
         # The big list of bad keywords, for titles and posts
         {'regex': r"(?is)\b({})\b|{}".format("|".join(GlobalVars.bad_keywords), "|".join(bad_keywords_nwb)),
-         'all': True, 'sites': ['stackoverflow.com'], 'reason': "bad keyword in {}", 'title': True, 'body': True,
+         'all': True, 'sites': [], 'reason': "bad keyword in {}", 'title': True, 'body': True,
          'username': True, 'stripcodeblocks': False, 'body_summary': True, 'max_rep': 4, 'max_score': 1},
         # The special list for Stack Overflow
-        {'regex': r"(?is)\b({}|{})\b|{}".format("|".join(GlobalVars.bad_keywords),
-                                                "|".join(GlobalVars.so_bad_keywords),
-                                                "|".join(bad_keywords_nwb)),
+        {'regex': r"(?is)\b({})\b".format("|".join(GlobalVars.so_bad_keywords)),
          'all': False, 'sites': ['stackoverflow.com'], 'reason': "bad keyword in {}", 'title': True, 'body': True,
-         'username': True, 'stripcodeblocks': False, 'body_summary': True, 'max_rep': 6, 'max_score': 1},
+         'username': True, 'stripcodeblocks': False, 'body_summary': True, 'max_rep': 4, 'max_score': 1},
         # The small list of *potentially* bad keywords, for titles and posts
         {'regex': r'(?is)\b({})\b'.format('|'.join(GlobalVars.watched_keywords.keys())),
          'reason': 'potentially bad keyword in {}',

--- a/findspam.py
+++ b/findspam.py
@@ -776,8 +776,14 @@ class FindSpam:
         # Category: Bad keywords
         # The big list of bad keywords, for titles and posts
         {'regex': r"(?is)\b({})\b|{}".format("|".join(GlobalVars.bad_keywords), "|".join(bad_keywords_nwb)),
-         'all': True, 'sites': [], 'reason': "bad keyword in {}", 'title': True, 'body': True, 'username': True,
-         'stripcodeblocks': False, 'body_summary': True, 'max_rep': 4, 'max_score': 1},
+         'all': True, 'sites': ['stackoverflow.com'], 'reason': "bad keyword in {}", 'title': True, 'body': True,
+         'username': True, 'stripcodeblocks': False, 'body_summary': True, 'max_rep': 4, 'max_score': 1},
+        # The special list for Stack Overflow
+        {'regex': r"(?is)\b({}|{})\b|{}".format("|".join(GlobalVars.bad_keywords),
+                                                "|".join(GlobalVars.so_bad_keywords),
+                                                "|".join(bad_keywords_nwb)),
+         'all': False, 'sites': ['stackoverflow.com'], 'reason': "bad keyword in {}", 'title': True, 'body': True,
+         'username': True, 'stripcodeblocks': False, 'body_summary': True, 'max_rep': 6, 'max_score': 1},
         # The small list of *potentially* bad keywords, for titles and posts
         {'regex': r'(?is)\b({})\b'.format('|'.join(GlobalVars.watched_keywords.keys())),
          'reason': 'potentially bad keyword in {}',

--- a/gitmanager.py
+++ b/gitmanager.py
@@ -60,6 +60,9 @@ class GitManager:
         elif blacklist == "keyword":
             blacklist_type = Blacklist.KEYWORDS
             ms_search_option = "&body_is_regex=1&body="
+        elif blacklist == "sokeyword":
+            blacklist_type = Blacklist.SO_KEYWORDS
+            ms_search_option = "&site=1&body_is_regex=1&body="
         elif blacklist == "username":
             blacklist_type = Blacklist.USERNAMES
             ms_search_option = "&username_is_regex=1&username="

--- a/globalvars.py
+++ b/globalvars.py
@@ -50,6 +50,7 @@ class GlobalVars:
     blacklisted_usernames = []
     blacklisted_websites = []
     bad_keywords = []
+    so_bad_keywords = []
     watched_keywords = {}
     ignored_posts = []
     auto_ignored_posts = []

--- a/helpers.py
+++ b/helpers.py
@@ -34,7 +34,8 @@ def log(log_level, *args):
 
 
 def only_blacklists_changed(diff):
-    blacklist_files = ["bad_keywords.txt", "blacklisted_usernames.txt", "blacklisted_websites.txt",
+    blacklist_files = ["bad_keywords.txt", "so_bad_keywords.txt",
+                       "blacklisted_usernames.txt", "blacklisted_websites.txt",
                        "watched_keywords.txt"]
     files_changed = diff.split()
     non_blacklist_files = [f for f in files_changed if f not in blacklist_files]

--- a/so_bad_keywords.txt
+++ b/so_bad_keywords.txt
@@ -1,2 +1,2 @@
-#placeholder
-long\W?path\W?tool
+# see https://meta.stackoverflow.com/questions/363423
+alibaba\W?cloud

--- a/so_bad_keywords.txt
+++ b/so_bad_keywords.txt
@@ -1,0 +1,2 @@
+#placeholder
+long\W?path\W?tool

--- a/test/test_blacklists.py
+++ b/test/test_blacklists.py
@@ -5,7 +5,7 @@ from helpers import only_blacklists_changed
 
 
 def test_blacklist_integrity():
-    bl_files = glob('bad_*.txt') + glob('blacklisted_*.txt') + \
+    bl_files = glob('bad_*.txt') + glob('so_bad_*.txt') + glob('blacklisted_*.txt') + \
         ['watched_keywords.txt']
     seen = dict()
     for bl_file in bl_files:
@@ -28,6 +28,7 @@ def test_blacklist_integrity():
 def test_blacklist_pull_diff():
     only_blacklists_diff = """watched_keywords.txt
                               bad_keywords.txt
+                              so_bad_keywords.txt
                               blacklisted_websites.txt"""
     assert only_blacklists_changed(only_blacklists_diff)
     mixed_files_diff = """helpers.py

--- a/test/test_chatcommands.py
+++ b/test/test_chatcommands.py
@@ -113,7 +113,7 @@ def test_privileged():
 
 
 def test_deprecated_blacklist():
-    assert chatcommands.blacklist("").startswith("""The !!/blacklist command has been deprecated.""")
+    assert chatcommands.blacklist("").startswith("""The `!!/blacklist` command has been deprecated.""")
 
 
 @patch("chatcommands.handle_spam")

--- a/test/test_regexes.py
+++ b/test/test_regexes.py
@@ -84,7 +84,9 @@ from helpers import log
     ('GUI over bash using glade', """<p>I want to make a remote control for my PC. Basically all I need is to run a command on a button click. Following this <a href="https://www.youtube.com/watch?v=cNWmleAJ2qg" rel="nofollow noreferrer">guide</a> I managed to build the <a href="https://i.stack.imgur.com/dMy9g.jpg" rel="nofollow noreferrer">layout</a> and it's everything i've ever dreamed of.
 But when I try to run it using</p>""", 'Pacman', 'stackoverflow.com', False, False, False),
     ('Misleading link common file whitelist', 'File: <a href="https://www.malicious.com/">https://google.com/file.txt</a>', '', 'stackoverflow.com', False, False, True),
-    ('Misleading link common file whitelist', 'File: <a href="https://www.malicious.txt/">https://google.com</a>', '', 'stackoverflow.com', False, False, False)
+    ('Misleading link common file whitelist', 'File: <a href="https://www.malicious.txt/">https://google.com</a>', '', 'stackoverflow.com', False, False, False),
+    ('SO-only keywords', 'Alibaba Cloud', '', 'stackoverflow.com', False, False, True),
+    ('SO-only keywords', 'Alibaba Cloud', '', 'meta.stackexchange.com', False, False, False)
 ])
 def test_regexes(title, body, username, site, body_is_summary, is_answer, match):
     # If we want to test answers separately, this should be changed

--- a/test/test_spamhandling.py
+++ b/test/test_spamhandling.py
@@ -48,6 +48,8 @@ with open("test/data_test_spamhandling.txt", "r", encoding="utf-8") as f:
     ('FP test for bad URL pattern',
      '''<p>Don't trigger on link to <a href="https://mathoverflow.net/questions-about-reviews">this StackExchange member site</a></p>''', '', '', False),
     ('Mostly Non-latin', '冰冰冰test冰冰冰冰冰冰冰冰冰冰冰冰 test 冰冰冰冰', '', '', True),
+    ('Stack Overflow only test', 'Alibaba Cloud', '', 'stackoverflow.com', True),
+    ('Stack Overflow only test', 'Alibaba Cloud', '', 'meta.stackexchange.com', False),
     ('Pattern Matching product name - 2 words', """<p>vxl male enhancement</p>""", '', '', True),
     ('Pattern Matching product name - 3 words', """<p>Extends Monster Male Enhancement And Male Penile Enhancement</p>""", '', '', True),
     ('A Title', """<p>E x t e n d s  M o n s t e r Male E n h a n c e m e n t And M a l e P e n i l e E n h a n c e m e n t</p>""", '', 'judaism.stackexchange.com', True),


### PR DESCRIPTION
Since Stack Overflow gets special spams, I made an extra list of keywords for it.

RegEx keywords in this list will be checked against Stack Overflow posts only. They will not be checked on other sites. Note that "global" keywords still apply on SO: this list is an exclusive add-on.

The usage is more or less the same as the current keywords. People issue `!!/blacklist-sokeyword` to add keywords to this list.

~~~There's currently one functionality missing: `!!/test` command will not test this list, which may lead to some confusion.~~~ Just implemented it right now. Append `-so` to test commands to test a string as if it's on SO.

There are a few other improvements / code refactory that I've done by the way. Most of them are minor and do not affect how the code works.

---

You can still merge this request. In that case I'll create another for this one final TODO.

**TODO**: Remove keyword from SO blacklist when it is being blacklisted globally. This is unlikely to happen very often, as I can predict.