### PR TITLE
Stop catching i.stack.imgur.com

### DIFF
--- a/findspam.py
+++ b/findspam.py
@@ -35,13 +35,14 @@ COMMON_MALFORMED_PROTOCOLS = [
 SAFE_EXTENSIONS = set(('htm', 'py', 'java', 'sh'))
 SE_SITES_RE = r'(?:{sites})'.format(
     sites='|'.join([
-        r'([a-z]+\.)stackoverflow\.com',
+        r'(?:[a-z]+\.)*stackoverflow\.com',
         r'(?:{doms})\.com'.format(doms='|'.join(
-            [r'askubuntu', r'superuser', r'serverfault'])),
+            [r'askubuntu', r'superuser', r'serverfault', r'stackapps', r'i\.stack\.imgur'])),
         r'mathoverflow\.net',
         r'(?:[a-z]+\.)*stackexchange\.com']))
 SE_SITES_DOMAINS = ['stackoverflow.com', 'askubuntu.com', 'superuser.com', 'serverfault.com',
-                    'mathoverflow.net', 'stackapps.com', 'stackexchange.com', 'sstatic.net']
+                    'mathoverflow.net', 'stackapps.com', 'stackexchange.com', 'sstatic.net',
+                    'i.stack.imgur.com'] # Frequently catching FP
 
 
 # Flee before the ugly URL validator regex!

--- a/findspam.py
+++ b/findspam.py
@@ -42,7 +42,7 @@ SE_SITES_RE = r'(?:{sites})'.format(
         r'(?:[a-z]+\.)*stackexchange\.com']))
 SE_SITES_DOMAINS = ['stackoverflow.com', 'askubuntu.com', 'superuser.com', 'serverfault.com',
                     'mathoverflow.net', 'stackapps.com', 'stackexchange.com', 'sstatic.net',
-                    'i.stack.imgur.com'] # Frequently catching FP
+                    'i.stack.imgur.com']  # Frequently catching FP
 
 
 # Flee before the ugly URL validator regex!


### PR DESCRIPTION
"Misleading link" linking to `i.stack.imgur.com` is too falsey.

See [the MS search](https://metasmoke.erwaysoftware.com/search?body=href%3D%22https%3A%2F%2Fi.stack.imgur.com&reason=139&commit=Search).

+Another minor tweak.