### PR TITLE
Remove "gummy\W\bears?" from watchlist

### DIFF
--- a/watched_keywords.txt
+++ b/watched_keywords.txt
@@ -1908,7 +1908,6 @@
 1513005011	JoErNanO	bankbazaar\.com
 1513060528	Tetsua Yamamoto	webdesigretainer\.com
 1513060544	Tetsua Yamamoto	writemycustomessay\.co\.uk
-1513061257	tripleee	gummy\W?bears?
 1513061613	tripleee	13243752210
 1513061750	tripleee	luxxio
 1513061937	tripleee	parsaya\.com


### PR DESCRIPTION
Pattern generated many false positives lately: https://metasmoke.erwaysoftware.com/search?utf8=%E2%9C%93&body=gummy&commit=Search
Blacklisted more precise pattern "cbd\W?gummy\W?bears?" instead: https://github.com/Charcoal-SE/SmokeDetector/commit/962ad6d