### PR TITLE
Remove sites.google.com

### DIFF
--- a/watched_keywords.txt
+++ b/watched_keywords.txt
@@ -1877,7 +1877,6 @@
 1512722659	Glorfindel	getapkk\.com
 1512727519	Glorfindel	itechgyan\.com
 1512737502	Glorfindel	tweakboxapp\.info
-1512740173	tripleee	sites\.google\.com/site/
 1512743546	Glorfindel	worldskimmer\.su
 1512764264	Videonauth	quickbookonlinehelpsupport\.wordpress\.com
 1512784865	Jamal	swisswatchjust\.co\.uk


### PR DESCRIPTION
Too many FPs. See the MS search [here](https://metasmoke.erwaysoftware.com/search?body=sites.google.com%2Fsite)

[This](https://metasmoke.erwaysoftware.com/post/106388) is the only TP it has generated so far. All other TPs are also caught for other more accurate reasons/keywords.