### PR TITLE
Fix blame2

### DIFF
--- a/chatcommands.py
+++ b/chatcommands.py
@@ -366,7 +366,7 @@ def blame2(msg, x):
         return "It's [{}](https://chat.{}/users/{})'s fault.".format(unlucky_victim.name,
                                                                      msg._client.host,
                                                                      unlucky_victim.id)
-    except HTTPError:
+    except requests.exceptions.HTTPError:
         unlucky_victim = msg.owner
         return "It's [{}](https://chat.{}/users/{})'s fault.".format(unlucky_victim.name,
                                                                      msg._client.host,


### PR DESCRIPTION
The specific HTTPError that needs to be caught comes from `requests.exceptions`, so this PR specifies that in the code. `requests.exceptions.HTTPError` is spelled correctly this time