### PR TITLE
Throttle less important messages (incomplete)

### DIFF
--- a/chatcommunicate.py
+++ b/chatcommunicate.py
@@ -50,6 +50,8 @@ _global_block = -1
 _rooms = {}
 _last_messages = LastMessages({}, collections.OrderedDict())
 _msg_queue = queue.Queue()
+_th_msg_queue = queue.Queue()  # Throttled message queue
+_TH_TYPES = set(("debug", "metasmoke"))  # Throttle these types of messages
 
 _pickle_run = threading.Event()
 


### PR DESCRIPTION
This is an implementation of feature request #1735.

I plan to do this by adding another "throttled message queue" (TMQ). Messages in TMQ will be extracted and squashed into one when necessary. Debug messages and MS messages will go to this queue by default. Usually, this should have little to no effect on Smokey's behavior, but when there's a lot of debug messages, it will make a difference.

I'll be working on this FR/PR in the next few days, and drop the *incomplete* notice from the title after I think I've done.