### PR TITLE
AU should be a special case with queue size 1

### DIFF
--- a/bodyfetcher.py
+++ b/bodyfetcher.py
@@ -57,7 +57,7 @@ class BodyFetcher:
         "travel.stackexchange.com": 1,
         "webapps.stackexchange.com": 1,
         "woodworking.stackexchange.com": 1,
-        "writers.stackexchange.com": 1,
+        "writing.stackexchange.com": 1,
         "android.stackexchange.com": 1,
         "anime.stackexchange.com": 1,
         "apple.stackexchange.com": 1,
@@ -83,10 +83,11 @@ class BodyFetcher:
         "superuser.com": 1,
         "windowsphone.stackexchange.com": 1,
         "workplace.stackexchange.com": 1,
-        "interpersonal.stackexchange.com": 1
+        "interpersonal.stackexchange.com": 1,
+        "askubuntu.com": 1
     }
 
-    time_sensitive = ["askubuntu.com", "superuser.com", "security.stackexchange.com", "movies.stackexchange.com",
+    time_sensitive = ["security.stackexchange.com", "movies.stackexchange.com",
                       "mathoverflow.net", "gaming.stackexchange.com", "webmasters.stackexchange.com",
                       "arduino.stackexchange.com", "workplace.stackexchange.com"]
 


### PR DESCRIPTION
AU is by far the most spammed site outside of SO. It was also hit by a troll recently. There is enough spare API calls to use queue size 1 for AU (doubling the number of requests to it). 

Also: since "time sensitive" category means that queue size drops to 1 between UTC 4 and UTC 12, the sites that have queue size 1 already need not be in that category, it's redundant.  

Finally, writers.SE is now writing.SE, the old name still works for the API but will not match the new site name provided by websocket connections.