### PR TITLE
remove blacklist if fp from MS (incomplete)

### DIFF
--- a/metasmoke.py
+++ b/metasmoke.py
@@ -95,7 +95,7 @@ class Metasmoke:
                 datahandling.add_blacklisted_user((message['blacklist']['uid'], message['blacklist']['site']),
                                                   "metasmoke", message['blacklist']['post'])
             elif "unblacklist" in message:
-                datahandling.remove_blacklisted_user(message['unblacklist']['uid'}
+                datahandling.remove_blacklisted_user(message['unblacklist']['uid'])
             elif "naa" in message:
                 post_site_id = parsing.fetch_post_id_and_site_from_url(message["naa"]["post_link"])
                 datahandling.add_ignored_post(post_site_id[0:2])

--- a/metasmoke.py
+++ b/metasmoke.py
@@ -100,6 +100,8 @@ class Metasmoke:
             elif "fp" in message:
                 post_site_id = parsing.fetch_post_id_and_site_from_url(message["fp"]["post_link"])
                 datahandling.add_false_positive(post_site_id[0:2])
+                if datahandling.is_blacklisted_user(user):
+                    datahandling.remove_blacklisted_user(user)
             elif "report" in message:
                 post_data = apigetpost.api_get_post(message["report"]["post_link"])
                 if post_data is None or post_data is False:

--- a/metasmoke.py
+++ b/metasmoke.py
@@ -100,8 +100,8 @@ class Metasmoke:
             elif "fp" in message:
                 post_site_id = parsing.fetch_post_id_and_site_from_url(message["fp"]["post_link"])
                 datahandling.add_false_positive(post_site_id[0:2])
-                if datahandling.is_blacklisted_user(user):
-                    datahandling.remove_blacklisted_user(user)
+                if datahandling.is_blacklisted_user(message["fp"]["user_id"]):
+                    datahandling.remove_blacklisted_user(message["fp"]["user_id"])
             elif "report" in message:
                 post_data = apigetpost.api_get_post(message["report"]["post_link"])
                 if post_data is None or post_data is False:

--- a/metasmoke.py
+++ b/metasmoke.py
@@ -94,14 +94,14 @@ class Metasmoke:
             elif "blacklist" in message:
                 datahandling.add_blacklisted_user((message['blacklist']['uid'], message['blacklist']['site']),
                                                   "metasmoke", message['blacklist']['post'])
+            elif "unblacklist" in message:
+                datahandling.remove_blacklisted_user(message['unblacklist']['uid'}
             elif "naa" in message:
                 post_site_id = parsing.fetch_post_id_and_site_from_url(message["naa"]["post_link"])
                 datahandling.add_ignored_post(post_site_id[0:2])
             elif "fp" in message:
                 post_site_id = parsing.fetch_post_id_and_site_from_url(message["fp"]["post_link"])
                 datahandling.add_false_positive(post_site_id[0:2])
-                if datahandling.is_blacklisted_user(message["fp"]["user_id"]):
-                    datahandling.remove_blacklisted_user(message["fp"]["user_id"])
             elif "report" in message:
                 post_data = apigetpost.api_get_post(message["report"]["post_link"])
                 if post_data is None or post_data is False:


### PR DESCRIPTION
Currently only fp feedback from chat will remove the user from the blacklist. With this PR, if someone marks a post fp in MS (via the API or review), the user will be removed from the blacklist too.