### PR TITLE
Blacklist username "Keshav" on Judaism.SE

### DIFF
--- a/findspam.py
+++ b/findspam.py
@@ -1240,6 +1240,9 @@ class FindSpam:
         {'regex': u"(?i)^jeff$", 'all': False, 'sites': ["parenting.stackexchange.com"],
          'reason': "blacklisted username", 'title': False, 'body': False, 'username': True,
          'stripcodeblocks': False, 'body_summary': False, 'max_rep': 1, 'max_score': 0},
+        {'regex': u"(?i)^keshav$", 'all': False, 'sites': ["judaism.stackexchange.com"],
+         'reason': "blacklisted username", 'title': False, 'body': False, 'username': True,
+         'stripcodeblocks': False, 'body_summary': False, 'max_rep': 1, 'max_score': 0},
 
         # User name similar to link
         {'method': username_similar_website, 'all': True, 'sites': [], 'reason': "username similar to website in {}",


### PR DESCRIPTION
A user named Keshav has just posted [a bunch of anti-Semitic content](https://metasmoke.erwaysoftware.com/search?utf8=✓&title=&body=&username=keshav&why=&site=98&post_type=&feedback=&autoflagged=&reason=&user_rep_direction=%3E%3D&user_reputation=0&commit=Search) to Mi Yodeya.  The username has many false-positives on other sites, but none on Judaism.SE.