### PR TITLE
Add custom reporting reasons for manual reports. (#1965)

### DIFF
--- a/chatcommands.py
+++ b/chatcommands.py
@@ -1071,15 +1071,16 @@ def report(msg, args):
 
     output = []
 
-    argsraw = args.split(' "')
+    argsraw = args.split(' "', 1)
     urls = argsraw[0].split(' ')
 
     # Handle determining whether a custom report reason was provided.
     try:
-        custom_reason = ' "'.join(argsraw[1:])
         # Custom handle trailing quotation marks at the end of the custom reason, which could happen.
-        if custom_reason[-1] is '"':
-            custom_reason = custom_reason[:-1]
+        if argsraw[1][-1] is '"':
+            custom_reason = argsraw[1][:-1].replace('" "', '; ')
+        else:
+            custom_reason = argsraw[1].replace('" "', '; ')
     except IndexError:
         custom_reason = None
 

--- a/chatcommands.py
+++ b/chatcommands.py
@@ -1083,7 +1083,7 @@ def report(msg, args):
     except IndexError:
         custom_reason = None
 
-    urls = list(set(urls.split()))
+    urls = list(set(urls))
 
     if len(urls) > 5:
         raise CmdException("To avoid SmokeDetector reporting posts too slowly, you can "

--- a/chatcommands.py
+++ b/chatcommands.py
@@ -1054,7 +1054,7 @@ def invite(msg, room_id, roles):
 # --- Post Responses --- #
 # noinspection PyIncorrectDocstring
 @command(str, whole_msg=True, privileged=True)
-def report(msg, urls):
+def report(msg, args):
     """
     Report a post (or posts)
     :param msg:
@@ -1070,6 +1070,19 @@ def report(msg, urls):
                            "one go.".format(wait))
 
     output = []
+
+    argsraw = args.split(' "')
+    urls = argsraw[0].split(' ')
+
+    # Handle determining whether a custom report reason was provided.
+    try:
+        custom_reason = ' "'.join(argsraw[1:])
+        # Custom handle trailing quotation marks at the end of the custom reason, which could happen.
+        if custom_reason[-1] is '"':
+            custom_reason = custom_reason[:-1]
+    except IndexError:
+        custom_reason = None
+
     urls = list(set(urls.split()))
 
     if len(urls) > 5:
@@ -1116,7 +1129,13 @@ def report(msg, urls):
             message_url = "https://chat.{}/transcript/{}?m={}".format(msg._client.host, msg.room.id, msg.id)
             add_blacklisted_user(user, message_url, post_data.post_url)
 
-        why_info = u"Post manually reported by user *{}* in room *{}*.\n".format(msg.owner.name, msg.room.name)
+        if custom_reason:
+            why_info = u"Post manually reported by user *{}* in room *{}* with reason: *{}*.\n".format(
+                msg.owner.name, msg.room.name, custom_reason
+            )
+        else:
+            why_info = u"Post manually reported by user *{}* in room *{}*.\n".format(msg.owner.name, msg.room.name)
+
         batch = ""
         if len(urls) > 1:
             batch = " (batch report: post {} out of {})".format(index, len(urls))

--- a/chatcommands.py
+++ b/chatcommands.py
@@ -1078,9 +1078,15 @@ def report(msg, args):
     try:
         # Custom handle trailing quotation marks at the end of the custom reason, which could happen.
         if argsraw[1][-1] is '"':
-            custom_reason = argsraw[1][:-1].replace('" "', '; ')
+            custom_reason = argsraw[1][:-1]
         else:
-            custom_reason = argsraw[1].replace('" "', '; ')
+            custom_reason = argsraw[1]
+
+        # Deny cases of multiple close reasons, in which case custom_reason will still have " chars in it.
+        if '"' in custom_reason:
+            raise CmdException("You cannot provide multiple custom report reasons. "
+                               "Please review the permitted !!/report syntax in the documentation "
+                               "for guidance on using custom report reasons.")
     except IndexError:
         custom_reason = None
 


### PR DESCRIPTION
Custom reporting syntax would then be:

`!!/report url1 [url2 url3 ...] ["Custom Reason"]`

... where both custom report reasons *and* more than one URL are both optional.  This allows for the following 4 command syntaxes to work:

```
!!/report url
!!/report url "Custom Reason"
!!/report url1 url2 url3
!!/report url1 url2 url3 "Custom Reason"
```
... where for batch reports they *all* get the same 'custom reason' for each report generated by the batch, and also supports the original "Manually reported" reason without subsequent details as well.

The original "request" for this feature is in #1965, but this needs approval from at least Undo or Art, as well as a third set of eyes before we consider including.