### PR TITLE
WhatsApp number may be preceded by +

### DIFF
--- a/findspam.py
+++ b/findspam.py
@@ -1155,7 +1155,7 @@ class FindSpam:
          'body': True, 'username': False, 'stripcodeblocks': True, 'body_summary': False, 'max_rep': 1, 'max_score': 0},
         # QQ/ICQ/Whatsapp... numbers, for all sites
         {'regex': r'(?i)(?<![a-z0-9])Q{1,2}(?:(?:[vw]|[^a-z0-9])\D{0,8})?\d{5}[.-]?\d{4,5}(?!["\d])|'
-                  r'\bICQ[ :]{0,5}\d{9}\b|\bwh?atsapp?[ :]{0,5}\d{10}', 'all': True, 'sites': [],
+                  r'\bICQ[ :]{0,5}\d{9}\b|\bwh?atsa+pp?[ :+]{0,5}\d{10}', 'all': True, 'sites': [],
          'reason': "messaging number in {}", 'title': True, 'body': True, 'username': False, 'stripcodeblocks': True,
          'body_summary': False, 'max_rep': 1, 'max_score': 0},
         #


### PR DESCRIPTION
Now the "Messaging number" regex also matches the posts 
https://metasmoke.erwaysoftware.com/post/114005
https://metasmoke.erwaysoftware.com/post/114006
https://metasmoke.erwaysoftware.com/post/114007
that were not caught.