### PR TITLE
Updated username-blacklist for fuc?k

### DIFF
--- a/blacklisted_usernames.txt
+++ b/blacklisted_usernames.txt
@@ -70,7 +70,7 @@ donald\W*j?\.?\W*trump
 ^christine roebuck$
 techelpp‭
 \W?router$
-fuc?k
+\b(?:moth(?:e?r|a))?fu+[ck]+(?:[ei]ng*|e[dr])?\b
 (hurriyet|turkishdaily)news
 tour\W?packages
 sputnik\W?international


### PR DESCRIPTION
We are getting a lot of fp's on words that contain `fuk\w*`. Essentially the largest part of this fix is that it forces word boundaries so something like **Fukuda** won't be caught. But because we are adding word boundaries, I updated to catch varieties of the usage.

**NSFW:** https://regex101.com/r/vU7McB/1