### PR TITLE
Update: fag(g?ot)?   -->   fa+g+(ot)?s?\b

### DIFF
--- a/findspam.py
+++ b/findspam.py
@@ -491,7 +491,7 @@ def is_offensive_post(s, site, *args):
         return False, ""
 
     offensive = regex.compile(
-        r"(?is)\b(ur\Wm[ou]m|(yo)?u suck|[8B]={3,}[D>)]|nigg[aeu][rh]?|(ass\W?|a|a-)hole|fag(g?ot)?|"
+        r"(?is)\b(ur\Wm[ou]m|(yo)?u suck|[8B]={3,}[D>)]|nigg[aeu][rh]?|(ass\W?|a|a-)hole|fa+g+(ot)?s?\b|"
         r"daf[au][qk]|(?<!brain)(mother|mutha)?fuc?k+(a|ing?|e?[rd]| off+| y(ou|e)(rself)?|"
         r" u+|tard)?|(bul+)?shit(t?er|head)?|(yo)?u(r|'?re)? (gay|scum)|dickhead|"
         r"pedo(?!bapt|dont|log|mete?r|troph)|cocksuck(e?[rd])?|"


### PR DESCRIPTION
This is an attempt to decrease fp's when a legitimate word starts with 'fag', such as in a recent FP: Fagnano's.

See the relevant MS post: https://metasmoke.erwaysoftware.com/post/115362

This may actually find more TP's than originally designed: old method wouldn't catch something like:
faaaag, while simultaneously catching less FP's by utilizing a word boundary on the end. No boundary exists in this update at the start of the word - we can adjust if necessary.