### PR TITLE
Post title sanitize

### DIFF
--- a/chatcommands.py
+++ b/chatcommands.py
@@ -1225,7 +1225,7 @@ def checkpost(msg, url, alias_used='scan'):  # FIXME: Currently does not support
         handle_spam(post=post, reasons=reasons, why=why + "\nManually triggered scan")
         return None
 
-    return "Post [{}]({}) does not look like spam.".format(post_data.title, url)
+    return "Post [{}]({}) does not look like spam.".format(sanitize_title(post_data.title), url)
 
 
 # noinspection PyIncorrectDocstring,PyUnusedLocal

--- a/chatcommands.py
+++ b/chatcommands.py
@@ -11,11 +11,9 @@ from utcdate import UtcDate
 from apigetpost import api_get_post, PostData
 from datahandling import *
 from blacklists import load_blacklists
-from metasmoke import Metasmoke
 from parsing import *
 from spamhandling import check_if_spam, handle_spam
 from gitmanager import GitManager
-from tasks import Tasks
 import threading
 import random
 import requests
@@ -917,8 +915,6 @@ def unnotify_all(msg):
     """
     Unsubscribes a user to all events
     :param msg:
-    :param room_id:
-    :param se_site:
     :return: A string
     """
     remove_all_from_notification_list(msg.owner.id)
@@ -1063,7 +1059,6 @@ def report(msg, args):
     """
     Report a post (or posts)
     :param msg:
-    :param urls:
     :return: A string (or None)
     """
     crn, wait = can_report_now(msg.owner.id, msg._client.host)

--- a/classes/_Post.py
+++ b/classes/_Post.py
@@ -13,22 +13,22 @@ class PostParseError(Exception):
 
 
 class Post:
-    _body = ""
-    _body_is_summary = False
-    _is_answer = False
-    _owner_rep = 1
-    _parent = None  # If this is not none, then _is_answer should be 'true' because there would then be a parent post.
-    _post_id = ""
-    _post_score = 0
-    _post_site = ""
-    _post_url = ""
-    _title = ""
-    _user_name = ""
-    _user_url = ""
-    _votes = {'downvotes': None, 'upvotes': None}
-
     def __init__(self, json_data=None, api_response=None, parent=None):
         # type: (AnyStr, dict, Post) -> None
+
+        self._body = ""
+        self._body_is_summary = False
+        self._is_answer = False
+        self._owner_rep = 1
+        self._parent = None  # If not None, _is_answer should be 'true' because there would then be a parent post.
+        self._post_id = ""
+        self._post_score = 0
+        self._post_site = ""
+        self._post_url = ""
+        self._title = ""
+        self._user_name = ""
+        self._user_url = ""
+        self._votes = {'downvotes': None, 'upvotes': None}
 
         if parent is not None:
             if not isinstance(parent, Post):

--- a/globalvars.py
+++ b/globalvars.py
@@ -56,6 +56,7 @@ class GlobalVars:
     startup_utc = datetime.utcnow().strftime("%H:%M:%S")
     latest_questions = []
     api_backoff_time = 0
+    deletion_watcher = None
 
     metasmoke_last_ping_time = datetime.now()
     not_privileged_warning = """

--- a/parsing.py
+++ b/parsing.py
@@ -149,6 +149,9 @@ def unescape_title(title_escaped):
 def escape_special_chars_in_title(title_unescaped):
     return regex.sub(r"([_*\\`\[\]])", r"\\\1", title_unescaped)
 
+# noinspection PyMissingTypeHints
+def sanitize_title(title_unescaped):
+    return regex.sub('(https?://|\n)', '', escape_special_chars_in_title(title_unescaped).replace('\n', u'\u23CE'))
 
 # noinspection PyMissingTypeHints
 def get_user_from_list_command(cmd):  # for example, !!/addblu is a list command

--- a/parsing.py
+++ b/parsing.py
@@ -149,9 +149,11 @@ def unescape_title(title_escaped):
 def escape_special_chars_in_title(title_unescaped):
     return regex.sub(r"([_*\\`\[\]])", r"\\\1", title_unescaped)
 
+
 # noinspection PyMissingTypeHints
 def sanitize_title(title_unescaped):
     return regex.sub('(https?://|\n)', '', escape_special_chars_in_title(title_unescaped).replace('\n', u'\u23CE'))
+
 
 # noinspection PyMissingTypeHints
 def get_user_from_list_command(cmd):  # for example, !!/addblu is a list command

--- a/spamhandling.py
+++ b/spamhandling.py
@@ -1,6 +1,5 @@
 # coding=utf-8
 import sys
-from threading import Thread
 from findspam import FindSpam
 import datahandling
 import chatcommunicate
@@ -9,8 +8,6 @@ from datetime import datetime
 import parsing
 import metasmoke
 import excepthook
-# noinspection PyCompatibility
-import regex
 from classes import Post, PostParseError
 from helpers import log
 from tasks import Tasks
@@ -120,6 +117,7 @@ def handle_spam(post, reasons, why):
         log('debug', GlobalVars.parser.unescape(s).encode('ascii', errors='replace'))
         GlobalVars.deletion_watcher.subscribe(post_url)
 
+        reason = message = None
         for reason_count in range(5, 2, -1):  # Try 5 reasons, then 4, then 3
             reason = ", ".join(reasons[:reason_count])
             if len(reasons) > reason_count:


### PR DESCRIPTION
Sanitize post titles in markdown posts, which were not properly escaped (sometimes escaped twice, sometimes not at all).
See https://chat.stackexchange.com/transcript/11540?m=44097072#44097072 and https://chat.stackexchange.com/transcript/11540?m=44097075#44097075 for examples of the problem.
This pulls the sanitation out into a separate method that can be called from all locations where it is required in the same way.
Also fix some warnings from PyCharm's code analysis.