### PR TITLE
Unwatch "good answer"

### DIFF
--- a/watched_keywords.txt
+++ b/watched_keywords.txt
@@ -3162,7 +3162,7 @@
 1524733777	Tetsuya Yamamoto	amarnathjourney\.com
 1524734334	Byte Commander	printerstuffs\.com
 1524737867	Mithrandir	news313news
-1524738079	Mithrandir	(nice|useful|good)\W?(article|answer|blog)
+1524738079	Mithrandir	(nice|useful|good)\W?(article|blog)
 1524740311	Zoe	socialnavy\.com
 1524744623	WELZ	topquotelifeinsurance\.com
 1524744802	WELZ	sajadwani\d+


### PR DESCRIPTION
The regex `(nice|useful|good)\W?(article|answer|blog)` is intended to catch blogspam, but "good answer" causes [a lot of fps](https://metasmoke.erwaysoftware.com/search?utf8=✓&title=&body=good+answer&username=&why=&site=&post_type=&feedback=&autoflagged=&reason=&user_rep_direction=%3E%3D&user_reputation=0&commit=Search).  This PR removes "answer" from the regex.