### PR TITLE
Tighten Virk blacklisted username to avoid FP

### DIFF
--- a/blacklisted_usernames.txt
+++ b/blacklisted_usernames.txt
@@ -86,4 +86,4 @@ away\W?days
 Racist
 Reihmann
 rayaz
-Virk$
+\w*\d+\W+Virk$


### PR DESCRIPTION
We've seen a couple FP on this blacklisted username in the past few days. This tightens it up to catch all the TP we've seen in the last 3 months. With this adjustment it does miss 1 post from 9 months ago and 3 from 2 years ago, but those appear to be incidental to what this is primarily attempting to catch.

[Search with old blacklist entry on MS](https://metasmoke.erwaysoftware.com/search?utf8=%E2%9C%93&title=&body=&username_is_regex=1&username=%28%5E%7C%24%7C%5CW%29virk%24&why=&site=&post_type=&feedback=&autoflagged=&reason=&user_rep_direction=%3E%3D&user_reputation=0&commit=Search)  
[Search with new blacklist entry on MS](https://metasmoke.erwaysoftware.com/search?utf8=%E2%9C%93&title=&body=&username_is_regex=1&username=%28%5E%7C%24%7C%5CW%29%5Cw*%5Cd%2B%5CW%2Bvirk%24&why=&site=&post_type=&feedback=&autoflagged=&reason=&user_rep_direction=%3E%3D&user_reputation=0&commit=Search)  