### PR TITLE
Move alibaba cloud from blacklisted keywords to watchlist

### DIFF
--- a/bad_keywords.txt
+++ b/bad_keywords.txt
@@ -1129,8 +1129,6 @@ sell\W?old\W?used\W?bikes
 herzolex
 neogelio\W?mask
 vortaxel
-alibaba\W*cloud
-# ^^^ see https://meta.stackoverflow.com/a/363426/5958455
 lyaxtin
 nutrio2
 darkwebsolutions

--- a/watched_keywords.txt
+++ b/watched_keywords.txt
@@ -3367,4 +3367,5 @@
 1525976764	Mithrandir	vbucksunlimservice
 1526016305	Makyen	undergroundsoymarket
 1526016996	Makyen	keto\W*purefit
+1526017063	Makyen.iBug	alibaba\W*cloud
 1526017091	tripleee	anvarol


### PR DESCRIPTION
Detection is down to 17/9/0, which is 68%.
If we count only what we've seen in the last year, then it's 7/8, or 46.7%.
This watch has been solely responsible for two autoflagged false positives (detected in title and body).
Basically, it's accuracy has fallen far below what we need for the blacklist.
[Here is a metasmoke search for this regex](https://metasmoke.erwaysoftware.com/search?utf8=%E2%9C%93&title=&body_is_regex=1&body=%28%5E%7C%24%7C%5CW%29alibaba%5CW*cloud%28%5E%7C%24%7C%5CW%29&username=&why=&site=&post_type=&feedback=&autoflagged=&reason=&user_rep_direction=%3E%3D&user_reputation=0&commit=Search).
There's a [meta post](https://meta.stackoverflow.com/q/363423) about Alibaba Cloud being used for spam seeds.