### PR TITLE
Move urlopener\.com from URL blacklist to watchlist.

### DIFF
--- a/blacklisted_websites.txt
+++ b/blacklisted_websites.txt
@@ -502,7 +502,6 @@ nutribulletrecipes\.org
 wirexapp\.com
 x4up\.org
 decalontop\.com
-urlopener\.com
 mobile57\.com
 learn(spicy|perfact)
 getfitness\.in

--- a/watched_keywords.txt
+++ b/watched_keywords.txt
@@ -3383,4 +3383,5 @@
 1526058040	Glorfindel	247jobsindubai
 1526058915	NobodyNada	techserviceus\.com
 1526066362	NobodyNada	cuck\Win\Wtraining
+1526067000	Makyen.fromBlacklist	urlopener\.com
 1526068928	Glorfindel	hamiast\.com


### PR DESCRIPTION
This site does not qualify for inclusion in the blacklist.
This site, urlopener.com ([metasmoke search](https://metasmoke.erwaysoftware.com/search?utf8=%E2%9C%93&title=&body_is_regex=1&body=%28%5E%7C%24%7C%5CW%29urlopener%5C.com%28%5E%7C%24%7C%5CW%29&username=&why=&site=&post_type=&feedback=&autoflagged=&reason=&user_rep_direction=%3E%3D&user_reputation=0&commit=Search)), has only 2 TP, which are from 2 years ago. It recently picked up an FP, which was reported 3 times. Even discounting the FP, it doesn't have enough TP to justify being on the blacklist. With the FP, it's TP rate is 66.7% (counting all FP as one report). If we count all the FP reports of that one post separately, then urlopener.com's TP rate is only 40%.