### PR TITLE
Fix api_parameter_from_link for localized SO

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -77,8 +77,8 @@ def unshorten_link(url, request_type='HEAD', explicitly_ignore_security_warning=
     return url
 
 
-parser_regex = r'((?:meta\.)?(?:(?:(?:math|(?:\w{2}\.)?stack)overflow|askubuntu|superuser|serverfault)|\w+)(?:\.meta)?)' \
-               r'\.(?:stackexchange\.com|com|net)'
+parser_regex = r'((?:meta\.)?(?:(?:(?:math|(?:\w{2}\.)?stack)overflow|askubuntu|superuser|serverfault)|\w+)' \
+               r'(?:\.meta)?)\.(?:stackexchange\.com|com|net)'
 parser = regex.compile(parser_regex)
 exceptions = {
     'meta.superuser': 'meta.superuser',
@@ -95,7 +95,7 @@ def api_parameter_from_link(link):
     if match:
         if match[1] in exceptions.keys():
             return exceptions[match[1]]
-        elif 'meta.' in match[1] and not 'stackoverflow' in match[1]:
+        elif 'meta.' in match[1] and 'stackoverflow' not in match[1]:
             return '.'.join(match[1].split('.')[::-1])
         else:
             return match[1]

--- a/helpers.py
+++ b/helpers.py
@@ -77,11 +77,10 @@ def unshorten_link(url, request_type='HEAD', explicitly_ignore_security_warning=
     return url
 
 
-parser_regex = r'((?:meta\.)?(?:(?:(?:math|stack)overflow|askubuntu|superuser|serverfault)|\w+)(?:\.meta)?)' \
+parser_regex = r'((?:meta\.)?(?:(?:(?:math|(?:\w{2}\.)?stack)overflow|askubuntu|superuser|serverfault)|\w+)(?:\.meta)?)' \
                r'\.(?:stackexchange\.com|com|net)'
 parser = regex.compile(parser_regex)
 exceptions = {
-    'meta.stackoverflow': 'meta.stackoverflow',
     'meta.superuser': 'meta.superuser',
     'meta.serverfault': 'meta.serverfault',
     'meta.askubuntu': 'meta.askubuntu',
@@ -96,7 +95,7 @@ def api_parameter_from_link(link):
     if match:
         if match[1] in exceptions.keys():
             return exceptions[match[1]]
-        elif 'meta.' in match[1]:
+        elif 'meta.' in match[1] and not 'stackoverflow' in match[1]:
             return '.'.join(match[1].split('.')[::-1])
         else:
             return match[1]

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -42,7 +42,9 @@ def test_unshorten_link(shortened, original):
     ('meta.askubuntu.com', 'meta.askubuntu'),
     ('3dprinting.meta.stackexchange.com', '3dprinting.meta'),
     ('blender.meta.stackexchange.com', 'blender.meta'),
-    ('meta.stackexchange.com', 'meta')
+    ('meta.stackexchange.com', 'meta'),
+    ('ja.stackoverflow.com', 'ja.stackoverflow'),
+    ('meta.ja.stackoverflow.com', 'meta.ja.stackoverflow')
 ])
 def test_api_parameter_from_link(link, param):
     assert helpers.api_parameter_from_link(link) == param


### PR DESCRIPTION
`api_parameter_from_link` incorrectly returned `stackoverflow` for localized SO sites and their metas.  I fixed the bug by modifying the `parser` regex to allow optionally two word characters followed by a dot before "stackoverflow."

In order to make Metas work, I removed `meta.stackoverflow` from the exceptions list and excempted sites containing "stackoverflow" from being reversed as is usual for Meta sites.

Fixes #2161.