### PR TITLE
Tighten D-Bal blacklist

### DIFF
--- a/bad_keywords.txt
+++ b/bad_keywords.txt
@@ -1311,7 +1311,7 @@ unlimited\W?fit(?:\W?forskolin)?
 iphone\W?data\W?recovery
 apeaksoft
 lutragen
-D\W?Bal
+D\W+Bal
 iq\W?180(?:\W?cognitive)?
 flawless\W?keto
 rama?\W*?(?:(?:was|is|a|an)\W*?)*\W*?(?:bastard|impotent|asshole|(?:mother\W*?)?fuck(?:ing|ers|s)|(?:fag|mag)(?:g?[eio]t)?s?)+


### PR DESCRIPTION
The \W? has resulted in 11 FP ([MS search](https://metasmoke.erwaysoftware.com/search?utf8=%E2%9C%93&title=&body_is_regex=1&body=%28%5E%7C%24%7C%5CW%29D%5CW%3FBal%28%5E%7C%24%7C%5CW%29&username=&why=&site=&post_type=&feedback=&autoflagged=&reason=&user_rep_direction=%3E%3D&user_reputation=0&commit=Search)) while `d\W?bal` has been active in the blacklist. It was [initially added](https://chat.stackexchange.com/transcript/11540?m=43306031#43306031), but then removed by PR #1763 as a result of issue #1757 (too many FP). It was later [re-added as `D\W?Bal`](https://chat.stackexchange.com/transcript/11540?m=44474453#44474453).

Changing to `D\W+Bal` ([MS search](https://metasmoke.erwaysoftware.com/search?utf8=%E2%9C%93&title=&body_is_regex=1&body=%28%5E%7C%24%7C%5CW%29D%5CW%2BBal%28%5E%7C%24%7C%5CW%29&username=&why=&site=&post_type=&feedback=&autoflagged=&reason=&user_rep_direction=%3E%3D&user_reputation=0&commit=Search)) still detects all 18 TP, but none of the FP.