### PR TITLE
HTML tag cleaning

### DIFF
--- a/chatcommands.py
+++ b/chatcommands.py
@@ -24,7 +24,7 @@ from html import unescape
 from ast import literal_eval
 # noinspection PyCompatibility
 import regex
-from helpers import only_blacklists_changed
+from helpers import only_blacklists_changed, clean_html
 from classes import Post
 from classes.feedback import *
 
@@ -245,7 +245,7 @@ def do_blacklist(raw_pattern, blacklist_type, msg, force=False):
                                                                     id=msg.owner.id)
 
     # noinspection PyProtectedMember
-    pattern = rebuild_str(raw_pattern)
+    pattern = clean_html(rebuild_str(raw_pattern))
     try:
         regex.compile(pattern)
     except regex._regex_core.error:

--- a/helpers.py
+++ b/helpers.py
@@ -102,13 +102,15 @@ def api_parameter_from_link(link):
     else:
         return None
 
-def clean_html(input):
+
+def clean_html(raw_message):
     """
     Removes some HTML tags from input and replaces it with markdown
     """
-    input = regex.subf("<i>(.*)</i>", "*{1}*", input)
-    input = regex.subf("<b>(.*)</b>", "**{1}**", input)
-    return regex.subf("<code>(.*)</code>", "`{1}`", input)
+    raw_message = regex.subf("<i>(.*)</i>", "*{1}*", raw_message)
+    raw_message = regex.subf("<b>(.*)</b>", "**{1}**", raw_message)
+    return regex.subf("<code>(.*)</code>", "`{1}`", raw_message)
+
 
 class SecurityError(Exception):
     pass

--- a/helpers.py
+++ b/helpers.py
@@ -102,6 +102,13 @@ def api_parameter_from_link(link):
     else:
         return None
 
+def clean_html(input):
+    """
+    Removes some HTML tags from input and replaces it with markdown
+    """
+    input = regex.subf("<i>(.*)</i>", "*{1}*", input)
+    input = regex.subf("<b>(.*)</b>", "**{1}**", input)
+    return regex.subf("<code>(.*)</code>", "`{1}`", input)
 
 class SecurityError(Exception):
     pass

--- a/helpers.py
+++ b/helpers.py
@@ -107,9 +107,9 @@ def clean_html(raw_message):
     """
     Removes some HTML tags from input and replaces it with markdown
     """
-    raw_message = regex.subf("<i>(.*)</i>", "*{1}*", raw_message)
-    raw_message = regex.subf("<b>(.*)</b>", "**{1}**", raw_message)
-    return regex.subf("<code>(.*)</code>", "`{1}`", raw_message)
+    raw_message = regex.subf("<i>(.+?)</i>", "*{1}*", raw_message)
+    raw_message = regex.subf("<b>(.+?)</b>", "**{1}**", raw_message)
+    return regex.subf("<code>(.+?)</code>", "`{1}`", raw_message)
 
 
 class SecurityError(Exception):


### PR DESCRIPTION
Attempts to remove [this problem](https://chat.stackexchange.com/transcript/message/44685266#44685266), where patterns are converted to HTML tags because the pattern is interpreted as markdown and converted.

Since removing HTML tags everywhere isn't necessarily an option, this only applies to adding blacklists. It should probably be added to !!/unwatch as well, but it would need some edits to make sure it's possible to remove blacklists with HTML tags (and I'm not familiar enough with Smokey to do that without breaking stuff). 