### PR TITLE
Reduce queue to 1 on Buddhism and Judaism

### DIFF
--- a/bodyfetcher.py
+++ b/bodyfetcher.py
@@ -85,7 +85,9 @@ class BodyFetcher:
         "workplace.stackexchange.com": 1,
         "interpersonal.stackexchange.com": 1,
         "askubuntu.com": 1,
-        "hinduism.stackexchange.com": 1
+        "hinduism.stackexchange.com": 1,
+        "buddhism.stackexchange.com": 1,
+        "judaism.stackexchange.com": 1
     }
 
     time_sensitive = ["security.stackexchange.com", "movies.stackexchange.com",


### PR DESCRIPTION
We've been getting quite a bit of trolling on four sites: Buddhism, Judaism (Mi Yodeya), Islam and Hinduism. Islam and Hinduism were previously lowered to a queue of 1. This lowers the queue depth on the other two sites to 1 also. The impetus for doing so is that we've had people running a manual `!!/scan` on 5 posts on Judaism today. I've also included Buddhism to provide it a similar level of scanning.