### PR TITLE
Fix uid/site/None being generated

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -103,7 +103,7 @@ def api_parameter_from_link(link):
         return None
 
 
-id_parser_regex = r'https?://[^/]+/\w+/(\d+)'
+id_parser_regex = r'(?:https?:)?//[^/]+/\w+/(\d+)'
 id_parser = regex.compile(id_parser_regex)
 
 


### PR DESCRIPTION
My bad for not noticing that `https://` is stripped before the URL is sent to the function.

Should be fixed now.