### PR TITLE
Demote code-industry\.net to watchlist

### DIFF
--- a/blacklisted_websites.txt
+++ b/blacklisted_websites.txt
@@ -1270,7 +1270,6 @@ healthbuzzer\.com
 biotestosteronexrtry\.com
 tophealthbuy\.com
 ibwpro\.com
-code-industry\.net
 omindiatech\.blogspot\.in
 care2world\.com
 nidmindia\.com

--- a/watched_keywords.txt
+++ b/watched_keywords.txt
@@ -3737,4 +3737,5 @@
 1527783127	Makyen	[a-z_]*(?:1_*)?646[\W_]*396[\W_]*3787[a-z_]*
 1527783173	Makyen	cyberwizard_hacker@outlook\.com
 1527794433	Makyen	casting@renegade83\.com
+1527800000	Makyen	code-industry\.net
 1527801825	doppelgreener	istikharahonline\.net


### PR DESCRIPTION
Per discussion started by @Videonauth [here](https://chat.stackexchange.com/transcript/message/44915752#44915752).
Some research results [here](https://chat.stackexchange.com/transcript/message/44916041#44916041), which show that it's 4/3/1 with two of the TP having conflicting feedback.
There are also [61 hits](https://stackexchange.com/search?page=1&q=url%3acode-industry.net) on SE (tends to show duplicate hits).
I'm not sure that this even deserves a watch at this point, but...