### PR TITLE
Add 'errorlog' alias

### DIFF
--- a/chatcommands.py
+++ b/chatcommands.py
@@ -520,7 +520,7 @@ def alive():
 
 
 # noinspection PyIncorrectDocstring
-@command(int, privileged=True, arity=(0, 1), aliases=["errlogs", "errlog"])
+@command(int, privileged=True, arity=(0, 1), aliases=["errlogs", "errlog", "errorlog"])
 def errorlogs(count):
     """
     Shows the most recent lines in the error logs


### PR DESCRIPTION
We have 'errlog' now, but not 'errorlog' which is a common typo that (at least I) regularly make when trying to access error logs.  So let's add that in there while we're at it.