### PR TITLE
Show reasons for posts reported via MS

### DIFF
--- a/chatcommands.py
+++ b/chatcommands.py
@@ -1166,12 +1166,10 @@ def report(msg, args):
             batch = " (batch report: post {} out of {})".format(index, len(urls))
 
         if scan_spam:
-            why_append = ', '.join(scan_reasons)
-            why_append = ''.join(["This post would have also been caught for: ",
-                                  why_append[0].upper() + why_append[1:],
-                                  '\n' + scan_why])
+            why_append = u"This post would have also been caught for: " + ", ".join(scan_reasons).capitalize() + \
+                '\n' + scan_why
         else:
-            why_append = "This post would not have been caught otherwise."
+            why_append = u"This post would not have been caught otherwise."
 
         handle_spam(post=post,
                     reasons=["Manually reported " + post_data.post_type + batch],

--- a/metasmoke.py
+++ b/metasmoke.py
@@ -118,8 +118,9 @@ class Metasmoke:
                         and not datahandling.is_false_positive((post_data.post_id, post_data.site)):
                     return
                 user = parsing.get_user_from_url(post_data.owner_url)
+                post = classes.Post(api_response=post_data)
 
-                scan_spam, scan_reasons, scan_why = spamhandling.check_if_spam(post_data)
+                scan_spam, scan_reasons, scan_why = spamhandling.check_if_spam(post)
                 if scan_spam:
                     why_append = u"This post would have also been caught for: " + \
                         u", ".join(scan_reasons).capitalize() + "\n" + scan_why
@@ -133,17 +134,7 @@ class Metasmoke:
                 why = u"Post manually reported by user *{}* from metasmoke.\n\n{}".format(
                     message["report"]["user"], why_append)
 
-                postobj = classes.Post(api_response={'title': post_data.title, 'body': post_data.body,
-                                                     'owner': {'display_name': post_data.owner_name,
-                                                               'reputation': post_data.owner_rep,
-                                                               'link': post_data.owner_url},
-                                                     'site': post_data.site,
-                                                     'is_answer': (post_data.post_type == "answer"),
-                                                     'score': post_data.score, 'link': post_data.post_url,
-                                                     'question_id': post_data.post_id,
-                                                     'up_vote_count': post_data.up_vote_count,
-                                                     'down_vote_count': post_data.down_vote_count})
-                spamhandling.handle_spam(post=postobj,
+                spamhandling.handle_spam(post=post,
                                          reasons=["Manually reported " + post_data.post_type],
                                          why=why)
             elif "deploy_updated" in message:

--- a/metasmoke.py
+++ b/metasmoke.py
@@ -118,9 +118,21 @@ class Metasmoke:
                         and not datahandling.is_false_positive((post_data.post_id, post_data.site)):
                     return
                 user = parsing.get_user_from_url(post_data.owner_url)
+
+                scan_spam, scan_reasons, scan_why = spamhandling.check_if_spam(post_data)
+                if scan_spam:
+                    why_append = u"This post would have also been caught for: " + \
+                        u", ".join(scan_reasons).capitalize() + "\n" + scan_why
+                else:
+                    why_append = u"This post would not have been caught otherwise."
+
+                # Add user to blacklist *after* post is scanned
                 if user is not None:
                     datahandling.add_blacklisted_user(user, "metasmoke", post_data.post_url)
-                why = u"Post manually reported by user *{}* from metasmoke.\n".format(message["report"]["user"])
+
+                why = u"Post manually reported by user *{}* from metasmoke.\n\n{}".format(
+                    message["report"]["user"], why_append)
+
                 postobj = classes.Post(api_response={'title': post_data.title, 'body': post_data.body,
                                                      'owner': {'display_name': post_data.owner_name,
                                                                'reputation': post_data.owner_rep,


### PR DESCRIPTION
So far if anyone manually reports a post via MS API, there's no post analysis given in the "why" section, which is very different from when a post is reported via chat.

This PR just adds the analysis to posts reported via MS, and a few patches to other parts of the code base.