### PR TITLE
Improve "body starts with title" detection

### DIFF
--- a/findspam.py
+++ b/findspam.py
@@ -786,8 +786,9 @@ def body_starts_with_title(post):
     if len(post.title) < 10:
         return False, False, False, ''
 
-    s = strip_urls_and_tags(post.body)
-    similarity = similar_ratio(s[:len(post.title)], post.title)
+    s = strip_urls_and_tags(post.body).replace(" ", "")
+    t = post.title.replace(" ", "")
+    similarity = similar_ratio(s[:len(t)], t)
     end_in_url, ending_url = link_at_end(post.body, None)
     if similarity >= BODY_TITLE_SIMILAR_THRESHOLD and end_in_url:
         return False, False, True, \


### PR DESCRIPTION
[This post][1] could've been caught by the reason and thus, autoflagged. Fix by removing white spaces before comparing.

  [1]: https://metasmoke.erwaysoftware.com/post/123116