### PR TITLE
More keywords for "pattern-matching product name"

### DIFF
--- a/findspam.py
+++ b/findspam.py
@@ -342,12 +342,13 @@ def has_health(s, site, *args):   # flexible detection of health spam in titles
 
 # noinspection PyUnusedLocal,PyMissingTypeHints
 def pattern_product_name(s, site, *args):
-    keywords = ["Testo?", "Dermapholia", "Garcinia", "Cambogia", "Aurora", "Kamasutra", "HL-?12", "NeuroFuse",
+    keywords = ["Testo?(?:sterone)?", "Dermapholia", "Garcinia", "Cambogia", "Aurora", "Diet", "Slim", "Premier",
                 "Junivive", "Apexatropin", "Gain", "Allure", "Nuvella", "Trimgenix", "Satin", "Prodroxatone",
                 "Elite", "Force", "Exceptional", "Enhance(?:ment)?", "Nitro", "Max", "Boost", "E?xtreme", "Grow",
                 "Deep", "Male", "Pro", "Advanced", "Monster", "Divine", "Royale", "Angele", "Trinity", "Andro",
-                "Pure", "Skin", "Sea", "Muscle", "Ascend", "Youth", "Hyper(?:tone)?", "Hydroluxe", "Booster",
-                "Serum", "Supplement", "Fuel", "Cream", "Keto"]
+                "Pure", "Skin", "Sea", "Muscle", "Ascend", "Youth", "Hyper(?:tone)?", "Hydroluxe", "Boost(?:er)?",
+                "Serum", "Supplement", "Fuel", "Cream", "Keto", "Rapid", "Tone", "Forkskolin",
+                "(?:Anti-)?Ag(?:e|ing)"]
     if site != "math.stackexchange.com" and site != "mathoverflow.net":
         keywords += [r"E?X[tl\d]?", "Alpha", "Plus", "Prime", "Formula"]
     keywords = "|".join(keywords)

--- a/findspam.py
+++ b/findspam.py
@@ -350,11 +350,11 @@ def pattern_product_name(s, site, *args):
                 "Serum", "Supplement", "Fuel", "Cream", "Keto", "Rapid", "Tone", "Forkskolin", "Neuro", "Luma"
                 "(?:Anti-)?Ag(?:ed?|ing)", "Trim", "Premi(?:um|er)", "Vital", "Derma?", "Master"]
     if site != "math.stackexchange.com" and site != "mathoverflow.net":
-        keywords += [r"E?X[LORT\d]?", "Alpha", "Plus", "Prime", "Formula"]
+        keywords += [r"E?X[LORT]?", "Alpha", "Plus", "Prime", "Formula"]
     keywords = "|".join(keywords)
 
-    three_words = regex.compile(r"(?i)\b(({0})\W({0})\W({0}))\b".format(keywords)).findall(s)
-    two_words = regex.compile(r"(?i)\b(({0})\W({0}))\b".format(keywords)).findall(s)
+    three_words = regex.compile(r"(?i)\b(({0})[ -]({0})[ -]({0}))\b".format(keywords)).findall(s)
+    two_words = regex.compile(r"(?i)\b(({0})[ -]({0}))\b".format(keywords)).findall(s)
     if len(three_words) >= 1 and all_matches_unique(three_words):
         return True, u"Pattern-matching product name *{}*".format(three_words[0][0])
     if len(two_words) >= 2 and all_matches_unique(two_words):

--- a/findspam.py
+++ b/findspam.py
@@ -344,13 +344,13 @@ def has_health(s, site, *args):   # flexible detection of health spam in titles
 def pattern_product_name(s, site, *args):
     keywords = ["Testo?(?:sterone)?", "Dermapholia", "Garcinia", "Cambogia", "Aurora", "Diet", "Slim", "Premier",
                 "Junivive", "Apexatropin", "Gain", "Allure", "Nuvella", "Trimgenix", "Satin", "Prodroxatone",
-                "Elite", "Force", "Exceptional", "Enhance(?:ment)?", "Nitro", "Max", "Boost", "E?xtreme", "Grow",
-                "Deep", "Male", "Pro", "Advanced", "Monster", "Divine", "Royale", "Angele", "Trinity", "Andro",
+                "Elite", "Force", "Exceptional", "Enhance(?:ment)?", "Nitro", "Max+", "Boost", "E?xtreme", "Grow",
+                "Deep", "Male", "Pro", "Advanced", "Monster", "Divine", "Royale", "Angele*", "Trinity", "Andro",
                 "Pure", "Skin", "Sea", "Muscle", "Ascend", "Youth", "Hyper(?:tone)?", "Hydroluxe", "Boost(?:er)?",
-                "Serum", "Supplement", "Fuel", "Cream", "Keto", "Rapid", "Tone", "Forkskolin",
-                "(?:Anti-)?Ag(?:e|ing)"]
+                "Serum", "Supplement", "Fuel", "Cream", "Keto", "Rapid", "Tone", "Forkskolin", "Neuro", "Luma"
+                "(?:Anti-)?Ag(?:ed?|ing)", "Trim", "Premi(?:um|er)", "Vital", "Derma?", "Master"]
     if site != "math.stackexchange.com" and site != "mathoverflow.net":
-        keywords += [r"E?X[tl\d]?", "Alpha", "Plus", "Prime", "Formula"]
+        keywords += [r"E?X[LORT\d]?", "Alpha", "Plus", "Prime", "Formula"]
     keywords = "|".join(keywords)
 
     three_words = regex.compile(r"(?i)\b(({0})\W({0})\W({0}))\b".format(keywords)).findall(s)

--- a/findspam.py
+++ b/findspam.py
@@ -342,23 +342,23 @@ def has_health(s, site, *args):   # flexible detection of health spam in titles
 
 # noinspection PyUnusedLocal,PyMissingTypeHints
 def pattern_product_name(s, site, *args):
-    keywords = ["Testo?(?:sterone)?", "Dermapholia", "Garcinia", "Cambogia", "Aurora", "Diet", "Slim", "Premier",
+    keywords = ["Testo", "Dermapholia", "Garcinia", "Cambogia", "Aurora", "Diet", "Slim", "Premier", "Diet",
                 "Junivive", "Apexatropin", "Gain", "Allure", "Nuvella", "Trimgenix", "Satin", "Prodroxatone",
                 "Elite", "Force", "Exceptional", "Enhance(?:ment)?", "Nitro", "Max+", "Boost", "E?xtreme", "Grow",
                 "Deep", "Male", "Pro", "Advanced", "Monster", "Divine", "Royale", "Angele*", "Trinity", "Andro",
                 "Pure", "Skin", "Sea", "Muscle", "Ascend", "Youth", "Hyper(?:tone)?", "Hydroluxe", "Boost(?:er)?",
-                "Serum", "Supplement", "Fuel", "Cream", "Keto", "Rapid", "Tone", "Forkskolin", "Neuro", "Luma"
+                "Serum", "Supplement", "Fuel", "Cream", "Keto", "Rapid", "Tone", "Forskolin", "Neuro", "Luma"
                 "(?:Anti-)?Ag(?:ed?|ing)", "Trim", "Premi(?:um|er)", "Vital", "Derma?", "Master"]
     if site != "math.stackexchange.com" and site != "mathoverflow.net":
-        keywords += [r"E?X[LORT]?", "Alpha", "Plus", "Prime", "Formula"]
+        keywords += ["X[LORT]", "Alpha", "Plus", "Prime", "Formula"]
     keywords = "|".join(keywords)
 
     three_words = regex.compile(r"(?i)\b(({0})[ -]({0})[ -]({0}))\b".format(keywords)).findall(s)
     two_words = regex.compile(r"(?i)\b(({0})[ -]({0}))\b".format(keywords)).findall(s)
     if len(three_words) >= 1 and all_matches_unique(three_words):
-        return True, u"Pattern-matching product name *{}*".format(three_words[0][0])
+        return True, u"Pattern-matching product name *{}*".format(match[0] for match in three_words)
     if len(two_words) >= 2 and all_matches_unique(two_words):
-        return True, u"Pattern-matching product name *{}*".format(two_words[0][0])
+        return True, u"Pattern-matching product name *{}*".format(match[0] for match in two_words)
     return False, ""
 
 

--- a/helpers.py
+++ b/helpers.py
@@ -22,7 +22,7 @@ def environ_or_none(key):
 
 # Checks that all items in a pattern-matching product name are unique
 def all_matches_unique(match):
-    return all(len(m[1:]) == len(set(m[1:])) for m in match)
+    return any(len(m[1:]) == len(set(m[1:])) for m in match)
 
 
 # noinspection PyMissingTypeHints

--- a/helpers.py
+++ b/helpers.py
@@ -22,7 +22,7 @@ def environ_or_none(key):
 
 # Checks that all items in a pattern-matching product name are unique
 def all_matches_unique(match):
-    return len(match[0][1:]) == len(set(match[0][1:]))
+    return all(len(m[1:]) == len(set(m[1:])) for m in match)
 
 
 # noinspection PyMissingTypeHints


### PR DESCRIPTION
I think [I've resurrected][1] the "pattern-matching product name" reason. See [this example][2].

Since it's been left alone for a long time without maintenance, we can probably utilize this reason by updating the keywords list so it catches more recent spam. I have added and changed a few keywords according to the [latest "blacklisted website in title" posts][3]. I'd like to know what else we can do about this reason.

[1]: https://github.com/Charcoal-SE/SmokeDetector/commit/9eccdd5e62c60c61b1e8feb6d788e05c3f0f11af
[2]: https://chat.stackexchange.com/transcript/message/45169071#45169071
[3]: https://metasmoke.erwaysoftware.com/reason/61