### PR TITLE
Better handle 'pickle data was truncated' unpickling failures.

### DIFF
--- a/datahandling.py
+++ b/datahandling.py
@@ -37,6 +37,10 @@ def _load_pickle(path, encoding='utf-8'):
         except EOFError:
             os.remove(path)
             raise
+        except pickle.UnpicklingError as err:
+            if 'pickle data was truncated' in str(err).lower():
+                os.remove(path)
+            raise
 
 # methods to load files and filter data in them:
 # load_blacklists() is defined in a separate module blacklists.py, though


### PR DESCRIPTION
Solar Flare died unexpectedly today with an unpickling error regarding pickle data being truncated.  The only way to recover from this failure was to remove the offending pickle file, and restart the SmokeDetector instance.

We already restart Smokey on an unhandled exception such as this unpickling error, but because this issue persisted until we removed the file in the Solar Flare instance, and it caused a constant crashing problem/loop because a specific pickle had data truncated, it's better to capture this error and handle the pickle as we would an EOFError, which would remove the file and raise the error, triggering another restart without causing a constant crash loop like Solar Flare was having.