### PR TITLE
Wrap commit messages in code blocks

### DIFF
--- a/gitmanager.py
+++ b/gitmanager.py
@@ -99,7 +99,7 @@ class GitManager:
                 git.add('watched_keywords.txt')
 
             git.commit("--author='SmokeDetector <smokey@erwaysoftware.com>'",
-                       "-m", u"Auto {0} of {1} by {2} --autopull".format(op, item, username))
+                       "-m", u"Auto {0} of `{1}` by {2} --autopull".format(op, item, username))
 
             if code_permissions:
                 git.checkout("master")

--- a/globalvars.py
+++ b/globalvars.py
@@ -7,7 +7,6 @@ from html import unescape
 from hashlib import md5
 from configparser import NoOptionError, RawConfigParser
 from helpers import environ_or_none, log
-from parsing import escape_markdown
 import threading
 # noinspection PyCompatibility
 import regex
@@ -91,7 +90,7 @@ class GlobalVars:
     commit_with_author = "%s (%s: *%s*)" % (commit['id'],
                                             commit['author'][0] if type(commit['author']) in [list, tuple]
                                             else commit['author'],
-                                            escape_markdown(commit['message']))
+                                            commit['message'])
 
     on_master = "HEAD detached" not in git_status()
 


### PR DESCRIPTION
This would be a better solution to the broken chat messages caused by special characters in commit messages than escaping them. However I'm not sure if Smokey's commit message format is important (will break userscripts, etc.).