### PR TITLE
Detect "writing help" in link text

### DIFF
--- a/findspam.py
+++ b/findspam.py
@@ -436,7 +436,7 @@ def bad_link_text(s, site, *args):   # suspicious text of a hyperlink
         r"\b(porno?|(whole)?sale|coins|replica|luxury|essays?|in \L<city>)\b"
         r"\b\L<city>(?:\b.{1.20}\b)?(service|escort|call girls?)|"
         r"(best|make|full|hd|software|cell|data)[\w ]{1,20}(online|service|company|repair|recovery|school|university)|"
-        r"\b(writing service|essay (writing|tips))", city=FindSpam.city_list)
+        r"\b(writing (service|help)|essay (writing|tips))", city=FindSpam.city_list)
     links = regex.compile(r'nofollow(?: noreferrer)?">([^<]*)(?=</a>)', regex.UNICODE).findall(s)
     business = regex.compile(
         r"(?i)(^| )(airlines?|apple|AVG|BT|netflix|dell|Delta|epson|facebook|gmail|google|hotmail|hp|"


### PR DESCRIPTION
Currently "writing service" in link text is reported, but "writing help" is not. This expression comes up too:
https://metasmoke.erwaysoftware.com/search?utf8=%E2%9C%93&title=&body=writing+help&username=&why=&site=&post_type=&feedback=&autoflagged=&reason=&user_rep_direction=%3E%3D&user_reputation=0&commit=Search