### PR TITLE
Flovis: Fix unhandled "Socket already closed" errors.

### DIFF
--- a/flovis.py
+++ b/flovis.py
@@ -61,5 +61,14 @@ class Flovis:
         if data is not None:
             msg_data['data'] = data
 
-        if self.ws is not None:
-            self.ws.send(json.dumps(msg_data))
+        retries = 0  # Tracker for communication retry attempts
+        for retries in range(1, 5):
+            try:
+                if self.ws is not None:
+                    self.ws.send(json.dumps(msg_data))
+                break
+            except websocket.WebSocketConnectionClosedException:
+                if retries == 5:
+                    raise  # Actually raise the initial error if we've exceeded number of init retries
+
+                self._init_websocket()

--- a/flovis.py
+++ b/flovis.py
@@ -61,7 +61,6 @@ class Flovis:
         if data is not None:
             msg_data['data'] = data
 
-        retries = 0  # Tracker for communication retry attempts
         for retries in range(1, 5):
             try:
                 if self.ws is not None:


### PR DESCRIPTION
We have an observed problem with Flovis where the socket is sometimes closed without any other errors, and then trying to use the socket triggers a `WebSocketConnectionClosedException` error.

This may be because we don't have a mechanism to reinitialize the Flovis socket on these errors.

This PR includes my proposed changes to the Flovis code so that if we stage something to Flovis, we don't get a crash, or rather, reinit the websocket and retry if the Flovis socket is already down.

We could probably expand this to fix the SSL problem as well, but that's a different issue for a different time.