### PR TITLE
Scan multiple URLs with one chat message

### DIFF
--- a/chatcommands.py
+++ b/chatcommands.py
@@ -1231,10 +1231,12 @@ def checkpost(msg, args, alias_used='scan'):
 
         if post_data is None:
             response.append((index, "That does not look like a valid post URL."))
+            continue
 
         if post_data is False:
             response.append((index, "Cannot find data for this post in the API. "
                                     "It may have already been deleted."))
+            continue
 
         # Update url to be consistent with other code
         url = to_protocol_relative(post_data.post_url)
@@ -1251,6 +1253,7 @@ def checkpost(msg, args, alias_used='scan'):
                 response.append((index, response_text + " [ [MS]({}) ]".format(ms_link)))
             else:
                 response.append((index, response_text + "."))
+            continue
 
         if fetch_post_id_and_site_from_url(url)[2] == "answer":
             parent = api_get_post("https://{}/q/{}".format(post.post_site, post_data.question_id))

--- a/chatcommands.py
+++ b/chatcommands.py
@@ -1201,7 +1201,7 @@ def report(msg, args):
 
 # noinspection PyIncorrectDocstring,PyUnusedLocal
 @command(str, whole_msg=True, give_name=True, aliases=['scan', 'test-p'])
-def checkpost(msg, args, alias_used='scan'):  # FIXME: Currently does not support batch report
+def checkpost(msg, args, alias_used='scan'):
     """
     Force Smokey to scan a post even if it has no recent activity
     :param msg:
@@ -1213,13 +1213,20 @@ def checkpost(msg, args, alias_used='scan'):  # FIXME: Currently does not suppor
         raise CmdException("You can execute the !!/{0} command again in {1} seconds. "
                            "To avoid one user sending lots of reports in a few commands and "
                            "slowing SmokeDetector down due to rate-limiting, you have to "
-                           "wait 30 seconds after you've reported multiple posts in "
+                           "wait 30 seconds after you've scanned multiple posts in "
                            "one go.".format(alias_used, wait))
 
     urls = args.split()
+
+    if len(urls) > 5:
+        raise CmdException("To avoid SmokeDetector reporting posts too slowly, you can "
+                           "scan at most 5 posts at a time. This is to avoid "
+                           "SmokeDetector's chat messages getting rate-limited too much, "
+                           "which would slow down reports.")
+
     response = []
 
-    for url in urls:
+    for index, url in enumerate(urls):
         post_data = api_get_post(rebuild_str(url))
 
         if post_data is None:
@@ -1263,8 +1270,9 @@ def checkpost(msg, args, alias_used='scan'):  # FIXME: Currently does not suppor
         return None
     elif len(response) == 1:
         return response[0][1]
-    else
-        return "\n".join("URL {}: {}".format(response_item) for response_item in response)
+    else:
+        return "\n".join("URL {}: {}".format(index + 1, text) for index, text in response)
+
 
 # noinspection PyIncorrectDocstring,PyUnusedLocal
 @command(str, whole_msg=True, privileged=True, aliases=['reportuser'])

--- a/chatcommands.py
+++ b/chatcommands.py
@@ -1200,8 +1200,8 @@ def report(msg, args):
 
 
 # noinspection PyIncorrectDocstring,PyUnusedLocal
-@command(str, whole_msg=True, give_name=True, aliases=['scan', 'test-p'])
-def checkpost(msg, args, alias_used='scan'):
+@command(str, whole_msg=True)
+def scan(msg, args):
     """
     Force Smokey to scan a post even if it has no recent activity
     :param msg:
@@ -1210,11 +1210,11 @@ def checkpost(msg, args, alias_used='scan'):
     """
     crn, wait = can_report_now(msg.owner.id, msg._client.host)
     if not crn:
-        raise CmdException("You can execute the !!/{0} command again in {1} seconds. "
+        raise CmdException("You can execute the !!/scan command again in {1} seconds. "
                            "To avoid one user sending lots of reports in a few commands and "
                            "slowing SmokeDetector down due to rate-limiting, you have to "
                            "wait 30 seconds after you've scanned multiple posts in "
-                           "one go.".format(alias_used, wait))
+                           "one go.".format(wait))
 
     urls = args.split()
 

--- a/test/test_chatcommands.py
+++ b/test/test_chatcommands.py
@@ -172,7 +172,7 @@ def test_report(handle_spam):
 
 
 @patch("chatcommands.handle_spam")
-def test_checkpost(handle_spam):
+def test_scan(handle_spam):
     try:
         msg = Fake({
             "owner": {
@@ -193,20 +193,20 @@ def test_checkpost(handle_spam):
             "id": 1337
         })
 
-        assert chatcommands.checkpost("foo", original_msg=msg) == "That does not look like a valid post URL."
-        assert chatcommands.checkpost("https://stackoverflow.com/q/1", original_msg=msg) == \
+        assert chatcommands.scan("foo", original_msg=msg) == "That does not look like a valid post URL."
+        assert chatcommands.scan("https://stackoverflow.com/q/1", original_msg=msg) == \
             "Cannot find data for this post in the API. It may have already been deleted."
 
         # This is the highest voted question on Stack Overflow
         good_post_url = "https://stackoverflow.com/q/11227809"
         post = api_get_post(good_post_url)
-        assert chatcommands.checkpost(good_post_url, original_msg=msg) == \
+        assert chatcommands.scan(good_post_url, original_msg=msg) == \
             "Post [{0}]({1}) does not look like spam.".format(post.title, to_protocol_relative(post.post_url))
 
         # This post is found in Sandbox Archive, so it will remain intact and is a reliable test post
         # backup: https://meta.stackexchange.com/a/228635
         test_post_url = "https://meta.stackexchange.com/a/209772"
-        assert chatcommands.checkpost(test_post_url, original_msg=msg) is None
+        assert chatcommands.scan(test_post_url, original_msg=msg) is None
 
         _, call = handle_spam.call_args_list[0]
         assert isinstance(call["post"], Post)


### PR DESCRIPTION
The `!!/scan` command currently only scans one post per message. It's more convenient to scan more messages in one message. Results are either given as reports (problem found) or squashed into one single chat message.

This is a preparation for implementing #2289. I'll start implementing that after this one is done and merged.