### PR TITLE
Force scan with !!/report, merge !!/scan in

### DIFF
--- a/chatcommands.py
+++ b/chatcommands.py
@@ -367,7 +367,7 @@ def brownie():
     return "Brown!"
 
 
-COFFEES = ['Espresso', 'Macchiato', 'Ristretto', 'Americano', 'Latte', 'Cappuccino', 'Mocha', 'Affogato']
+COFFEES = ['Espresso', 'Macchiato', 'Ristretto', 'Americano', 'Latte', 'Cappuccino', 'Mocha', 'Affogato', 'jQuery']
 
 
 # noinspection PyIncorrectDocstring

--- a/chatcommands.py
+++ b/chatcommands.py
@@ -1198,7 +1198,7 @@ def report(msg, args, alias_used="report"):
 
         # scan_spam == False and alias_used == "scan"
         else:
-            output.append("Post {}: This does not look like spam")
+            output.append("Post {}: This does not look like spam".format(index))
 
     if 1 < len(urls) > len(output):
         add_or_update_multiple_reporter(msg.owner.id, msg._client.host, time.time())

--- a/chatcommands.py
+++ b/chatcommands.py
@@ -1112,7 +1112,7 @@ def report(msg, args, alias_used="report"):
                                "for guidance on using custom report reasons.")
 
         if alias_used == "scan":
-            raise CmdException("Custom reason is not supported in scans.")
+            raise CmdException("Custom reason is not supported with `!!/scan`")
     except IndexError:
         custom_reason = None
 
@@ -1163,12 +1163,13 @@ def report(msg, args, alias_used="report"):
 
         # Here's where it starts to be different
 
+        # If alias_used == "report-force" then jump to the next block
         if scan_spam and alias_used in {"scan", "report"}:
             handle_spam(post=post, reasons=scan_reasons, why=scan_why + "\nManually triggered scan")
             continue
 
-        # Scanned as "not spam"
-        elif alias_used in {"report", "report-force"}:
+        # scan_spam == False
+        if alias_used in {"report", "report-force"}:
             if user is not None:
                 message_url = "https://chat.{}/transcript/{}?m={}".format(msg._client.host, msg.room.id, msg.id)
                 add_blacklisted_user(user, message_url, post_data.post_url)
@@ -1195,7 +1196,7 @@ def report(msg, args, alias_used="report"):
                         why=why_info + '\n' + why_append)
             continue
 
-        # Scanned as "not spam" with command "!!/scan"
+        # scan_spam == False and alias_used == "scan"
         else:
             output.append("Post {}: This does not look like spam")
 
@@ -1204,84 +1205,6 @@ def report(msg, args, alias_used="report"):
 
     if len(output) > 0:
         return "\n".join(output)
-
-
-# noinspection PyIncorrectDocstring,PyUnusedLocal
-@command(str, whole_msg=True)
-def scan(msg, args):
-    """
-    Force Smokey to scan a post even if it has no recent activity
-    :param msg:
-    :param url:
-    :return str:
-    """
-    crn, wait = can_report_now(msg.owner.id, msg._client.host)
-    if not crn:
-        raise CmdException("You can execute the !!/scan command again in {1} seconds. "
-                           "To avoid one user sending lots of reports in a few commands and "
-                           "slowing SmokeDetector down due to rate-limiting, you have to "
-                           "wait 30 seconds after you've scanned multiple posts in "
-                           "one go.".format(wait))
-
-    urls = args.split()
-
-    if len(urls) > 5:
-        raise CmdException("To avoid SmokeDetector reporting posts too slowly, you can "
-                           "scan at most 5 posts at a time. This is to avoid "
-                           "SmokeDetector's chat messages getting rate-limited too much, "
-                           "which would slow down reports.")
-
-    response = []
-
-    for index, url in enumerate(urls):
-        post_data = api_get_post(rebuild_str(url))
-
-        if post_data is None:
-            response.append((index, "That does not look like a valid post URL."))
-            continue
-
-        if post_data is False:
-            response.append((index, "Cannot find data for this post in the API. "
-                                    "It may have already been deleted."))
-            continue
-
-        # Update url to be consistent with other code
-        url = to_protocol_relative(post_data.post_url)
-        post = Post(api_response=post_data.as_dict)
-
-        if has_already_been_posted(post_data.site, post_data.post_id, post_data.title) \
-                and not is_false_positive((post_data.post_id, post_data.site)):
-            # Don't re-report if the post wasn't marked as a false positive. If it was marked as a false positive,
-            # this force scan might be attempting to correct that/fix a mistake/etc.
-
-            response_text = "This post is already recently reported"
-            if GlobalVars.metasmoke_key is not None:
-                ms_link = "https://m.erwaysoftware.com/posts/by-url?url={}".format(url)  # se_link == url
-                response.append((index, response_text + " [ [MS]({}) ]".format(ms_link)))
-            else:
-                response.append((index, response_text + "."))
-            continue
-
-        if fetch_post_id_and_site_from_url(url)[2] == "answer":
-            parent = api_get_post("https://{}/q/{}".format(post.post_site, post_data.question_id))
-
-            post._is_answer = True
-            post._parent = Post(api_response=parent.as_dict)
-
-        is_spam, reasons, why = check_if_spam(post)
-
-        if is_spam:
-            handle_spam(post=post, reasons=reasons, why=why + "\nManually triggered scan")
-            continue
-
-        response.append((index, "Post [{}]({}) does not look like spam.".format(sanitize_title(post_data.title), url)))
-
-    if len(response) == 0:
-        return None
-    elif len(response) == 1:
-        return response[0][1]
-    else:
-        return "\n".join("URL {}: {}".format(index + 1, text) for index, text in response)
 
 
 # noinspection PyIncorrectDocstring,PyUnusedLocal

--- a/chatcommands.py
+++ b/chatcommands.py
@@ -24,7 +24,7 @@ from html import unescape
 from ast import literal_eval
 # noinspection PyCompatibility
 import regex
-from helpers import only_blacklists_changed, log, expand_shorthand_link
+from helpers import only_blacklists_changed, log, expand_shorthand_link, to_metasmoke_link
 from classes import Post
 from classes.feedback import *
 
@@ -1077,8 +1077,8 @@ def invite(msg, room_id, roles):
 
 # --- Post Responses --- #
 # noinspection PyIncorrectDocstring
-@command(str, whole_msg=True, privileged=True)
-def report(msg, args):
+@command(str, whole_msg=True, privileged=True, give_name=True, aliases=["scan", "report-force"])
+def report(msg, args, alias_used="report"):
     """
     Report a post (or posts)
     :param msg:
@@ -1086,11 +1086,11 @@ def report(msg, args):
     """
     crn, wait = can_report_now(msg.owner.id, msg._client.host)
     if not crn:
-        raise CmdException("You can execute the !!/report command again in {} seconds. "
+        raise CmdException("You can execute the !!/{} command again in {} seconds. "
                            "To avoid one user sending lots of reports in a few commands and "
                            "slowing SmokeDetector down due to rate-limiting, you have to "
                            "wait 30 seconds after you've reported multiple posts in "
-                           "one go.".format(wait))
+                           "one go.".format(alias_used, wait))
 
     output = []
 
@@ -1110,6 +1110,9 @@ def report(msg, args):
             raise CmdException("You cannot provide multiple custom report reasons. "
                                "Please review the permitted !!/report syntax in the documentation "
                                "for guidance on using custom report reasons.")
+
+        if alias_used == "scan":
+            raise CmdException("Custom reason is not supported in scans.")
     except IndexError:
         custom_reason = None
 
@@ -1117,13 +1120,12 @@ def report(msg, args):
 
     if len(urls) > 5:
         raise CmdException("To avoid SmokeDetector reporting posts too slowly, you can "
-                           "report at most 5 posts at a time. This is to avoid "
+                           "{} at most 5 posts at a time. This is to avoid "
                            "SmokeDetector's chat messages getting rate-limited too much, "
-                           "which would slow down reports.")
+                           "which would slow down reports.".format(alias_used))
 
     for index, url in enumerate(urls, start=1):
-        url = rebuild_str(url)
-        post_data = api_get_post(url)
+        post_data = api_get_post(rebuild_str(url))
 
         if post_data is None:
             output.append("Post {}: That does not look like a valid post URL.".format(index))
@@ -1141,50 +1143,67 @@ def report(msg, args):
 
             if GlobalVars.metasmoke_key is not None:
                 se_link = to_protocol_relative(post_data.post_url)
-                ms_link = "https://m.erwaysoftware.com/posts/by-url?url={}".format(se_link)
+                ms_link = to_metasmoke_link(se_link)
                 output.append("Post {}: Already recently reported [ [MS]({}) ]".format(index, ms_link))
                 continue
             else:
                 output.append("Post {}: Already recently reported".format(index))
                 continue
 
-        post_data.is_answer = (post_data.post_type == "answer")
+        url = to_protocol_relative(post_data.post_url)
         post = Post(api_response=post_data.as_dict)
         user = get_user_from_url(post_data.owner_url)
 
+        if fetch_post_id_and_site_from_url(url)[2] == "answer":
+            parent_data = api_get_post("https://{}/q/{}".format(post.post_site, post_data.question_id))
+            post._is_answer = True
+            post._parent = Post(api_response=parent_data.as_dict)
+
         scan_spam, scan_reasons, scan_why = check_if_spam(post)  # Scan it first
-        # Scan before adding blacklist to prevent showing all reported posts as "Blacklisted user"
 
-        if user is not None:
-            message_url = "https://chat.{}/transcript/{}?m={}".format(msg._client.host, msg.room.id, msg.id)
-            add_blacklisted_user(user, message_url, post_data.post_url)
+        # Here's where it starts to be different
 
-        if custom_reason:
-            why_info = u"Post manually reported by user *{}* in room *{}* with reason: *{}*.\n".format(
-                msg.owner.name, msg.room.name, custom_reason
-            )
+        if scan_spam and alias_used in {"scan", "report"}:
+            handle_spam(post=post, reasons=scan_reasons, why=scan_why + "\nManually triggered scan")
+            continue
+
+        # Scanned as "not spam"
+        elif alias_used in {"report", "report-force"}:
+            if user is not None:
+                message_url = "https://chat.{}/transcript/{}?m={}".format(msg._client.host, msg.room.id, msg.id)
+                add_blacklisted_user(user, message_url, post_data.post_url)
+
+            if custom_reason:
+                why_info = u"Post manually reported by user *{}* in room *{}* with reason: *{}*.\n".format(
+                    msg.owner.name, msg.room.name, custom_reason
+                )
+            else:
+                why_info = u"Post manually reported by user *{}* in room *{}*.\n".format(msg.owner.name, msg.room.name)
+
+            batch = ""
+            if len(urls) > 1:
+                batch = " (batch report: post {} out of {})".format(index, len(urls))
+
+            if scan_spam:
+                why_append = u"This post would have also been caught for: " + ", ".join(scan_reasons).capitalize() + \
+                    '\n' + scan_why
+            else:
+                why_append = u"This post would not have been caught otherwise."
+
+            handle_spam(post=post,
+                        reasons=["Manually reported " + post_data.post_type + batch],
+                        why=why_info + '\n' + why_append)
+            continue
+
+        # Scanned as "not spam" with command "!!/scan"
         else:
-            why_info = u"Post manually reported by user *{}* in room *{}*.\n".format(msg.owner.name, msg.room.name)
-
-        batch = ""
-        if len(urls) > 1:
-            batch = " (batch report: post {} out of {})".format(index, len(urls))
-
-        if scan_spam:
-            why_append = u"This post would have also been caught for: " + ", ".join(scan_reasons).capitalize() + \
-                '\n' + scan_why
-        else:
-            why_append = u"This post would not have been caught otherwise."
-
-        handle_spam(post=post,
-                    reasons=["Manually reported " + post_data.post_type + batch],
-                    why=why_info + '\n' + why_append)
+            output.append("Post {}: This does not look like spam")
 
     if 1 < len(urls) > len(output):
         add_or_update_multiple_reporter(msg.owner.id, msg._client.host, time.time())
 
     if len(output) > 0:
-        return os.linesep.join(output)
+        return "\n".join(output)
 
 
 # noinspection PyIncorrectDocstring,PyUnusedLocal

--- a/helpers.py
+++ b/helpers.py
@@ -130,5 +130,10 @@ def post_id_from_link(link):
         return None
 
 
+def to_metasmoke_link(post_url):
+    return r"https://m.erwaysoftware.com/posts/uid/{}/{}".format(
+        api_parameter_from_link(post_url), post_id_from_link(post_url))
+
+
 class SecurityError(Exception):
     pass

--- a/helpers.py
+++ b/helpers.py
@@ -130,9 +130,9 @@ def post_id_from_link(link):
         return None
 
 
-def to_metasmoke_link(post_url):
-    return r"https://m.erwaysoftware.com/posts/uid/{}/{}".format(
-        api_parameter_from_link(post_url), post_id_from_link(post_url))
+def to_metasmoke_link(post_url, protocol=True):
+    return "{}//m.erwaysoftware.com/posts/uid/{}/{}".format(
+        "https:" if protocol else "", api_parameter_from_link(post_url), post_id_from_link(post_url))
 
 
 class SecurityError(Exception):

--- a/spamhandling.py
+++ b/spamhandling.py
@@ -9,7 +9,7 @@ import parsing
 import metasmoke
 import excepthook
 from classes import Post, PostParseError
-from helpers import log, api_parameter_from_link, post_id_from_link
+from helpers import log, to_metasmoke_link
 from tasks import Tasks
 
 
@@ -40,11 +40,9 @@ def check_if_spam(post):
             blacklisted_post_url = blacklisted_user_data[2]
             if blacklisted_post_url:
                 rel_url = blacklisted_post_url.replace("http:", "", 1)
-                why += u"\nBlacklisted user - blacklisted for {} (" \
-                       u"https://m.erwaysoftware.com/posts/uid/{}/{}) by {}".format(
-                           blacklisted_post_url, api_parameter_from_link(rel_url),
-                           post_id_from_link(rel_url), blacklisted_by
-                       )
+                why += u"\nBlacklisted user - blacklisted for {} ({}) by {}".format(
+                    blacklisted_post_url, to_metasmoke_link(rel_url), blacklisted_by
+                )
             else:
                 why += u"\n" + u"Blacklisted user - blacklisted by {}".format(blacklisted_by)
     if 0 < len(test):
@@ -97,10 +95,8 @@ def handle_spam(post, reasons, why):
 
         prefix = u"[ [SmokeDetector](//goo.gl/eLDYqh) ]"
         if GlobalVars.metasmoke_key:
-            prefix_ms = u"[ [SmokeDetector](//goo.gl/eLDYqh) | [MS](//m.erwaysoftware.com/posts/uid/{}/{}) ]".format(
-                api_parameter_from_link(post_url),
-                post.post_id
-            )
+            prefix_ms = u"[ [SmokeDetector](//goo.gl/eLDYqh) | [MS]({}) ]".format(
+                to_metasmoke_link(post_url, protocol=False))
         else:
             prefix_ms = prefix
 

--- a/test/test_chatcommands.py
+++ b/test/test_chatcommands.py
@@ -178,8 +178,8 @@ def test_report(handle_spam):
         assert call["why"].endswith("Manually triggered scan")
 
         # Now with report-force
-        GlobalVars.blacklisted_users = []
-        GlobalVars.latest_questions = []
+        GlobalVars.blacklisted_users.clear()
+        GlobalVars.latest_questions.clear()
         assert chatcommands.report(test_post_url, original_msg=msg, alias_used="report-force") is None
         _, call = handle_spam.call_args_list[-1]
         assert isinstance(call["post"], Post)
@@ -195,8 +195,8 @@ def test_report(handle_spam):
         # Can use report command multiple times in 30s if only one URL was used
         assert chatcommands.report('https://stackoverflow.com/q/1732348', original_msg=msg, alias_used="report") is None
     finally:
-        GlobalVars.blacklisted_users = []
-        GlobalVars.latest_questions = []
+        GlobalVars.blacklisted_users.clear()
+        GlobalVars.latest_questions.clear()
 
 
 @patch("chatcommands.handle_spam")
@@ -276,7 +276,7 @@ def test_allspam(handle_spam):
         assert call["why"] == "User manually reported by *El'endia Starman* in room *Charcoal HQ*.\n"
 
     finally:
-        GlobalVars.blacklisted_users = []
+        GlobalVars.blacklisted_users.clear()
 
 
 @pytest.mark.skipif(os.path.isfile("blacklistedUsers.p"), reason="shouldn't overwrite file")

--- a/test/test_chatcommands.py
+++ b/test/test_chatcommands.py
@@ -121,6 +121,9 @@ def test_deprecated_blacklist():
 
 @patch("chatcommands.handle_spam")
 def test_report(handle_spam):
+    # Documentation: The process before scanning the post is identical regardless of alias_used.
+    #   No need to supply alias_used to test that part.
+    #   If no alias_used is supplied, it acts as if it's "scan"
     try:
         msg = Fake({
             "owner": {
@@ -141,79 +144,35 @@ def test_report(handle_spam):
             "id": 1337
         })
 
-        assert chatcommands.report("test", original_msg=msg) == "Post 1: That does not look like a valid post URL."
+        assert chatcommands.report("test", original_msg=msg, alias_used="report") == "Post 1: That does not look like a valid post URL."
 
-        assert chatcommands.report("one two three four five plus-an-extra", original_msg=msg) == (
+        assert chatcommands.report("one two three four five plus-an-extra", original_msg=msg, alias_used="report") == (
             "To avoid SmokeDetector reporting posts too slowly, you can report at most 5 posts at a time. This is to avoid "
             "SmokeDetector's chat messages getting rate-limited too much, which would slow down reports."
         )
 
-        assert chatcommands.report('http://stackoverflow.com/q/1', original_msg=msg) == \
+        assert chatcommands.report('https://stackoverflow.com/q/1', original_msg=msg) == \
             "Post 1: Could not find data for this post in the API. It may already have been deleted."
 
         # Valid post
-        assert chatcommands.report('http://stackoverflow.com/a/1732454', original_msg=msg) is None
+        assert chatcommands.report('https://stackoverflow.com/a/1732454', original_msg=msg, alias_used="report") is None
 
         _, call = handle_spam.call_args_list[0]
         assert isinstance(call["post"], Post)
         assert call["reasons"] == ["Manually reported answer"]
-        assert call["why"].startswith("Post manually reported by user *El'endia Starman* in room *Charcoal HQ*.\n\nThis post")
+        assert call["why"] == (
+            "Post manually reported by user *El'endia Starman* in room *Charcoal HQ*."
+            "\n\nThis post would not have been caught otherwise."
+        )
 
         # Don't re-report
         GlobalVars.latest_questions = [('stackoverflow.com', '1732454', 'RegEx match open tags except XHTML self-contained tags')]
-        assert chatcommands.report('http://stackoverflow.com/a/1732454', original_msg=msg).startswith("Post 1: Already recently "
-                                                                                                      "reported")
+        assert chatcommands.report('https://stackoverflow.com/a/1732454', original_msg=msg).startswith("Post 1: Already recently reported")
 
         # Can use report command multiple times in 30s if only one URL was used
-        assert chatcommands.report('http://stackoverflow.com/q/1732348', original_msg=msg) is None
+        assert chatcommands.report('https://stackoverflow.com/q/1732348', original_msg=msg, alias_used="report") is None
     finally:
         GlobalVars.blacklisted_users = []
-        GlobalVars.latest_questions = []
-
-
-@patch("chatcommands.handle_spam")
-def test_scan(handle_spam):
-    try:
-        msg = Fake({
-            "owner": {
-                "name": "foo",
-                "id": 1,
-                "is_moderator": False
-            },
-            "room": {
-                "id": 11540,
-                "name": "Charcoal HQ",
-                "_client": {
-                    "host": "stackexchange.com"
-                }
-            },
-            "_client": {
-                "host": "stackexchange.com"
-            },
-            "id": 1337
-        })
-
-        assert chatcommands.scan("foo", original_msg=msg) == "That does not look like a valid post URL."
-        assert chatcommands.scan("https://stackoverflow.com/q/1", original_msg=msg) == \
-            "Cannot find data for this post in the API. It may have already been deleted."
-
-        # This is the highest voted question on Stack Overflow
-        good_post_url = "https://stackoverflow.com/q/11227809"
-        post = api_get_post(good_post_url)
-        assert chatcommands.scan(good_post_url, original_msg=msg) == \
-            "Post [{0}]({1}) does not look like spam.".format(post.title, to_protocol_relative(post.post_url))
-
-        # This post is found in Sandbox Archive, so it will remain intact and is a reliable test post
-        # backup: https://meta.stackexchange.com/a/228635
-        test_post_url = "https://meta.stackexchange.com/a/209772"
-        assert chatcommands.scan(test_post_url, original_msg=msg) is None
-
-        _, call = handle_spam.call_args_list[0]
-        assert isinstance(call["post"], Post)
-        assert call["why"].endswith("Manually triggered scan")
-
-        # Strangely it doesn't work if scanned repeatedly
-    finally:
         GlobalVars.latest_questions = []
 
 

--- a/test/test_chatcommands.py
+++ b/test/test_chatcommands.py
@@ -168,10 +168,10 @@ def test_report(handle_spam):
         )
 
         # Bad post
-        # This post is found in Sandbox Archive, so it will remain intact and is a reliable test post  
-        # backup: https://meta.stackexchange.com/a/228635  
-        test_post_url = "https://meta.stackexchange.com/a/209772"  
-        assert chatcommands.report(test_post_url, original_msg=msg, alias_used="scan") is None  
+        # This post is found in Sandbox Archive, so it will remain intact and is a reliable test post
+        # backup: https://meta.stackexchange.com/a/228635
+        test_post_url = "https://meta.stackexchange.com/a/209772"
+        assert chatcommands.report(test_post_url, original_msg=msg, alias_used="scan") is None
 
         _, call = handle_spam.call_args_list[-1]
         assert isinstance(call["post"], Post)
@@ -180,7 +180,7 @@ def test_report(handle_spam):
         # Now with report-force
         GlobalVars.blacklisted_users = []
         GlobalVars.latest_questions = []
-        assert chatcommands.report(test_post_url, original_msg=msg, alias_used="report-force") is None  
+        assert chatcommands.report(test_post_url, original_msg=msg, alias_used="report-force") is None
         _, call = handle_spam.call_args_list[-1]
         assert isinstance(call["post"], Post)
         assert call["why"].startswith(

--- a/test/test_chatcommands.py
+++ b/test/test_chatcommands.py
@@ -116,7 +116,7 @@ def test_privileged():
 
 
 def test_deprecated_blacklist():
-    assert chatcommands.blacklist("").startswith("""The !!/blacklist command has been deprecated.""")
+    assert chatcommands.blacklist("").startswith("The !!/blacklist command has been deprecated.")
 
 
 @patch("chatcommands.handle_spam")
@@ -151,19 +151,24 @@ def test_report(handle_spam):
             "SmokeDetector's chat messages getting rate-limited too much, which would slow down reports."
         )
 
+        assert chatcommands.report('a a a a a "invalid"""', original_msg=msg, alias_used="report") \
+            .startswith("You cannot provide multiple custom report reasons.")
+        assert chatcommands.report('a "custom reason"', original_msg=msg, alias_used="scan") == \
+            "Custom reason is not supported with `!!/scan`"
+
         assert chatcommands.report('https://stackoverflow.com/q/1', original_msg=msg) == \
             "Post 1: Could not find data for this post in the API. It may already have been deleted."
 
         # Valid post
         assert chatcommands.report('https://stackoverflow.com/a/1732454', original_msg=msg, alias_used="scan") == \
             "Post 1: This does not look like spam"
-        assert chatcommands.report('https://stackoverflow.com/a/1732454', original_msg=msg, alias_used="report") is None
+        assert chatcommands.report('https://stackoverflow.com/a/1732454 "reason"', original_msg=msg, alias_used="report") is None
 
         _, call = handle_spam.call_args_list[-1]
         assert isinstance(call["post"], Post)
         assert call["reasons"] == ["Manually reported answer"]
         assert call["why"] == (
-            "Post manually reported by user *El'endia Starman* in room *Charcoal HQ*."
+            "Post manually reported by user *El'endia Starman* in room *Charcoal HQ* with reason: *reason*."
             "\n\nThis post would not have been caught otherwise."
         )
 


### PR DESCRIPTION
#2289 is a good idea. I had thought of it several times before but didn't bring it up.

This PR basically just implements what's proposed in #2289, with the following changes:

- `!!/scan` gets merged into `report()` as an alias
- `!!/report` acts the same as `!!/scan` if the given post is determined as spam
- `!!/report` falls back to original "report" if the post isn't caught, while `!!/scan` will tell you "it doesn't look like spam"
- New command `!!/report-force`, which as intuitive as its name suggests, skips the "scan first" and acts exactly like the original `!!/report`, with scan analysis supplied in the `why` section
- A new `to_metasmoke_link` function that simplifies code and increases maintainability. More uses of this function ~~will come up in another PR or be pushed directly where applicable~~ are dispatched already
- Relevant CI tests for the merged function

One side effect is that `!!/scan` will become a privileged command. This shouldn't cause a lot of trouble as all those who issues this command are privileged users. (Hard to fix)

P.S. I personally don't want `!!/report-force` to be canonically documented because it isn't quite necessary. Users are encouraged to stick to `!!/report`.