### PR TITLE
!!/unblacklist command

### DIFF
--- a/chatcommands.py
+++ b/chatcommands.py
@@ -290,6 +290,14 @@ def blacklist_keyword(msg, pattern, alias_used="blacklist-keyword"):
     return do_blacklist(parts[1], msg, force=len(parts) > 2)
 
 
+@command(str, whole_msg=True, privileged=True)
+def unblacklist(msg, item):
+    pattern = msg.content_source.split(" ", 1)[1]
+    _status, message = GitManager.unblacklist(rebuild_str(pattern), msg.owner.name, is_code_privileged(
+        msg._client.host, msg.owner.id))
+    return message
+
+
 # noinspection PyIncorrectDocstring
 @command(str, whole_msg=True, privileged=True, give_name=True,
          aliases=["watch-keyword", "watch-force", "watch-keyword-force"])

--- a/chatcommands.py
+++ b/chatcommands.py
@@ -280,7 +280,7 @@ def do_blacklist(blacklist_type, msg, force=False):
                                                                         "blacklist-username-force"])
 def blacklist_keyword(msg, pattern, alias_used="blacklist-keyword"):
     """
-    Adds a string to the blacklist and commits/pushes to GitHub
+    Adds a pattern to the blacklist and commits/pushes to GitHub
     :param msg:
     :param pattern:
     :return: A string
@@ -293,11 +293,11 @@ def blacklist_keyword(msg, pattern, alias_used="blacklist-keyword"):
 # noinspection PyIncorrectDocstring
 @command(str, whole_msg=True, privileged=True, give_name=True,
          aliases=["watch-keyword", "watch-force", "watch-keyword-force"])
-def watch(msg, website, alias_used="watch"):
+def watch(msg, pattern, alias_used="watch"):
     """
-    Adds a string to the watched keywords list and commits/pushes to GitHub
+    Adds a pattern to the watched keywords list and commits/pushes to GitHub
     :param msg:
-    :param website:
+    :param pattern:
     :return: A string
     """
 
@@ -306,6 +306,12 @@ def watch(msg, website, alias_used="watch"):
 
 @command(str, whole_msg=True, privileged=True, give_name=True, aliases=["unwatch"])
 def unblacklist(msg, item, alias_used="unwatch"):
+    """
+    Removes a pattern from watchlist/blacklist and commits/pushes to GitHub
+    :param msg:
+    :param pattern:
+    :return: A string
+    """
     if alias_used == "unwatch":
         blacklist_type = "watch"
     elif alias_used == "unblacklist":

--- a/chatcommands.py
+++ b/chatcommands.py
@@ -293,8 +293,9 @@ def blacklist_keyword(msg, pattern, alias_used="blacklist-keyword"):
 @command(str, whole_msg=True, privileged=True)
 def unblacklist(msg, item):
     pattern = msg.content_source.split(" ", 1)[1]
-    _status, message = GitManager.unblacklist(rebuild_str(pattern), msg.owner.name, is_code_privileged(
-        msg._client.host, msg.owner.id))
+    _status, message = GitManager.remove_from_blacklist(
+        rebuild_str(pattern), msg.owner.name, "blacklist",
+        is_code_privileged(msg._client.host, msg.owner.id))
     return message
 
 
@@ -315,8 +316,9 @@ def watch(msg, website, alias_used="watch"):
 @command(str, whole_msg=True, privileged=True)
 def unwatch(msg, item):
     pattern = msg.content_source.split(" ", 1)[1]
-    _status, message = GitManager.unwatch(rebuild_str(pattern), msg.owner.name, is_code_privileged(
-        msg._client.host, msg.owner.id))
+    _status, message = GitManager.remove_from_blacklist(
+        rebuild_str(pattern), msg.owner.name, "watch",
+        is_code_privileged(msg._client.host, msg.owner.id))
     return message
 
 

--- a/chatcommands.py
+++ b/chatcommands.py
@@ -290,15 +290,6 @@ def blacklist_keyword(msg, pattern, alias_used="blacklist-keyword"):
     return do_blacklist(parts[1], msg, force=len(parts) > 2)
 
 
-@command(str, whole_msg=True, privileged=True)
-def unblacklist(msg, item):
-    pattern = msg.content_source.split(" ", 1)[1]
-    _status, message = GitManager.remove_from_blacklist(
-        rebuild_str(pattern), msg.owner.name, "blacklist",
-        is_code_privileged(msg._client.host, msg.owner.id))
-    return message
-
-
 # noinspection PyIncorrectDocstring
 @command(str, whole_msg=True, privileged=True, give_name=True,
          aliases=["watch-keyword", "watch-force", "watch-keyword-force"])
@@ -313,11 +304,18 @@ def watch(msg, website, alias_used="watch"):
     return do_blacklist("watch_keyword", msg, force=alias_used.split("-")[-1] == "force")
 
 
-@command(str, whole_msg=True, privileged=True)
-def unwatch(msg, item):
+@command(str, whole_msg=True, privileged=True, give_name=True, aliases=["unwatch"])
+def unblacklist(msg, item, alias_used="unwatch"):
+    if alias_used == "unwatch":
+        blacklist_type = "watch"
+    elif alias_used == "unblacklist":
+        blacklist_type = "blacklist"
+    else:
+        raise CmdException("Invalid blacklist type.")
+
     pattern = msg.content_source.split(" ", 1)[1]
     _status, message = GitManager.remove_from_blacklist(
-        rebuild_str(pattern), msg.owner.name, "watch",
+        rebuild_str(pattern), msg.owner.name, blacklist_type,
         is_code_privileged(msg._client.host, msg.owner.id))
     return message
 

--- a/gitmanager.py
+++ b/gitmanager.py
@@ -207,7 +207,7 @@ class GitManager:
 
             git.add(file_name)
             git.commit("--author='SmokeDetector <smokey@erwaysoftware.com>'",
-                       '-m', 'Auto un{} of `{}` by {} --autopull'.format(list_type, item, username))
+                       '-m', 'Auto un{} of `{}` by {} --autopull'.format(blacklist_type, item, username))
 
             git.checkout('master')
             git.merge(branch)

--- a/gitmanager.py
+++ b/gitmanager.py
@@ -168,26 +168,38 @@ class GitManager:
             return (True, "Added `{0}` to watchlist".format(item))
 
     @classmethod
-    def unwatch(cls, item, username, code_privileged=False):
+    def remove_from_blacklist(cls, item, username, blacklist_type="", code_privileged=False):
         if not code_privileged:
-            return (False, "Ask a code admin to run that for you. Use `!!/whois code_admin` to find out who's here.")
+            return False, "Ask a code admin to run that for you. Use `!!/whois code_admin` to find out who's here."
 
         try:
             cls.gitmanager_lock.acquire()
 
-            watchlist = Blacklist.WATCHED_KEYWORDS
-            file_name = watchlist[0]
-            manager = Blacklist(watchlist)
+            if blacklist_type == "watch":
+                blacklists = [Blacklist.WATCHED_KEYWORDS]
+                list_type = "watchlist"
+            elif blacklist_type == "blacklist":
+                blacklists = [Blacklist.KEYWORDS, Blacklist.WEBSITES, Blacklist.USERNAMES]
+                list_type = "blacklist"
+            else:
+                return False, "`blacklist_type` not set, blame a developer."
 
-            exists, _line = manager.exists(item)
+            for blacklist in blacklists:
+                file_name = blacklist[0]
+                manager = Blacklist(blacklist)
+
+                exists, _line = manager.exists(item)
+                if exists:
+                    break
+
             if not exists:
-                return (False, 'No such item `{}` in watchlist.'.format(item))
+                return False, 'No such item `{}` in {}.'.format(item, list_type)
 
             status, message = cls.prepare_git_for_operation(file_name)
             if not status:
-                return (False, message)
+                return False, message
 
-            branch = 'auto-unwatch-{}'.format(time.time())
+            branch = 'auto-un{}-{}'.format(blacklist_type, time.time())
             git.checkout('-b', branch)
             git.reset('HEAD')
 
@@ -195,7 +207,7 @@ class GitManager:
 
             git.add(file_name)
             git.commit("--author='SmokeDetector <smokey@erwaysoftware.com>'",
-                       '-m', 'Auto unwatch of `{}` by {} --autopull'.format(item, username))
+                       '-m', 'Auto un{} of `{}` by {} --autopull'.format(list_type, item, username))
 
             git.checkout('master')
             git.merge(branch)
@@ -203,59 +215,13 @@ class GitManager:
             git.branch('-D', branch)
         except Exception as e:
             log('error', '{}: {}'.format(type(e).__name__, e))
-            return (False, 'Git operations failed for unspecified reasons.')
+            return False, 'Git operations failed for unspecified reasons.'
         finally:
             git.checkout('deploy')
             cls.gitmanager_lock.release()
 
-        return (True, 'Removed `{}` from watchlist'.format(item))
-
-    @classmethod
-    def unblacklist(cls, item, username, code_privileged=False):
-        if not code_privileged:
-            return False, "Ask a code admin to run that for you. Use `!!/whois code_admin` to find out who's here."
-
-        try:
-            cls.gitmanager_lock.acquire()
-
-            for bl in [Blacklist.KEYWORDS, Blacklist.WEBSITES, Blacklist.USERNAMES]:
-                file_name = bl[0]
-                manager = Blacklist(bl)
-
-                exists, _line = manager.exists(item)
-                if exists:
-                    break
-
-            if not exists:
-                return False, 'No such item `{}` in blacklists.'.format(item)
-
-            status, message = cls.prepare_git_for_operation(file_name)
-            if not status:
-                return (False, message)
-
-            branch = 'auto-unblacklist-{}'.format(time.time())
-            git.checkout('-b', branch)
-            git.reset('HEAD')
-
-            manager.remove(item)
-
-            git.add(file_name)
-            git.commit("--author='SmokeDetector <smokey@erwaysoftware.com>'",
-                       '-m', 'Auto unblacklist of `{}` by {} --autopull'.format(item, username))
-
-            git.checkout('master')
-            git.merge(branch)
-            git.push('origin', 'master')
-            git.branch('-D', branch)
-        except Exception as e:
-            log('error', '{}: {}'.format(type(e).__name__, str(e)))
-            return (False, 'Git operations failed for unspecified reasons.')
-        finally:
-            git.checkout('deploy')
-            cls.gitmanager_lock.release()
-
-        # With no exception happened, file_name should be correctly set
-        return True, 'Removed `{}` from {}'.format(item, file_name)
+        # With no exception raised, list_type should be set
+        return True, 'Removed `{}` from {}'.format(item, list_type)
 
     @staticmethod
     def prepare_git_for_operation(blacklist_file_name):


### PR DESCRIPTION
New command `!!/unblacklist`. Removes an item from the three blacklist files. This would be useful when people think a blacklisted item generates too many FPs.

Same as `!!/unwatch`, code-admins only, no PR.

There was originally an idea about something like `!!/demote` that moves a blacklist item to watchlist, but I've decided to suspend it after evaluating the difficulty of implementing it over the current code base.