### PR TITLE
Adapt for MS downtime in (un)blacklist/watchlist commands/replies

### DIFF
--- a/chatcommands.py
+++ b/chatcommands.py
@@ -260,27 +260,22 @@ def do_blacklist(blacklist_type, msg, force=False):
             raise CmdException("That pattern looks like it's already caught by " + format_blacklist_reasons(reasons) +
                                "; append `-force` if you really want to do that.")
 
-    result = None
+    metasmoke_down = False
 
     try:
-        _, result = GitManager.add_to_blacklist(
-            blacklist=blacklist_type,
-            item_to_blacklist=pattern,
-            username=msg.owner.name,
-            chat_profile_link=chat_user_profile_link,
-            code_permissions=is_code_privileged(msg._client.host, msg.owner.id)
-        )
-    except requests.exceptions.ConnectionError as err:
-        if 'metasmoke.erwaysoftware.com' in str(err).lower() and \
-                'failed to establish a new connection' in str(err).lower():
-            _, result = GitManager.add_to_blacklist(
-                blacklist=blacklist_type,
-                item_to_blacklist=pattern,
-                username=msg.owner.name,
-                chat_profile_link=chat_user_profile_link,
-                code_permissions=False,
-                metasmoke_down=True
-            )
+        code_permissions = is_code_privileged(msg._client.host, msg.owner.id)
+    except requests.exceptions.ConnectionError:
+        code_permissions = False  # Because we need the system to assume that we don't have code privs.
+        metasmoke_down = True
+
+    _, result = GitManager.add_to_blacklist(
+        blacklist=blacklist_type,
+        item_to_blacklist=pattern,
+        username=msg.owner.name,
+        chat_profile_link=chat_user_profile_link,
+        code_permissions=code_permissions,
+        metasmoke_down=metasmoke_down
+    )
 
     return result
 

--- a/chatcommands.py
+++ b/chatcommands.py
@@ -260,13 +260,27 @@ def do_blacklist(blacklist_type, msg, force=False):
             raise CmdException("That pattern looks like it's already caught by " + format_blacklist_reasons(reasons) +
                                "; append `-force` if you really want to do that.")
 
-    _, result = GitManager.add_to_blacklist(
-        blacklist=blacklist_type,
-        item_to_blacklist=pattern,
-        username=msg.owner.name,
-        chat_profile_link=chat_user_profile_link,
-        code_permissions=is_code_privileged(msg._client.host, msg.owner.id)
-    )
+    result = None
+
+    try:
+        _, result = GitManager.add_to_blacklist(
+            blacklist=blacklist_type,
+            item_to_blacklist=pattern,
+            username=msg.owner.name,
+            chat_profile_link=chat_user_profile_link,
+            code_permissions=is_code_privileged(msg._client.host, msg.owner.id)
+        )
+    except requests.exceptions.ConnectionError as err:
+        if 'metasmoke.erwaysoftware.com' in str(err).lower() and \
+                'failed to establish a new connection' in str(err).lower():
+            _, result = GitManager.add_to_blacklist(
+                blacklist=blacklist_type,
+                item_to_blacklist=pattern,
+                username=msg.owner.name,
+                chat_profile_link=chat_user_profile_link,
+                code_permissions=False,
+                metasmoke_down=True
+            )
 
     return result
 

--- a/chatcommands.py
+++ b/chatcommands.py
@@ -328,10 +328,17 @@ def unblacklist(msg, item, alias_used="unwatch"):
     else:
         raise CmdException("Invalid blacklist type.")
 
+    metasmoke_down = False
+    try:
+        code_privs = is_code_privileged(msg._client.host, msg.owner.id)
+    except requests.exceptions.ConnectionError:
+        code_privs = False
+        metasmoke_down = True
+
     pattern = msg.content_source.split(" ", 1)[1]
     _status, message = GitManager.remove_from_blacklist(
         rebuild_str(pattern), msg.owner.name, blacklist_type,
-        is_code_privileged(msg._client.host, msg.owner.id))
+        code_privileged=code_privs, metasmoke_down=metasmoke_down)
     return message
 
 

--- a/gitmanager.py
+++ b/gitmanager.py
@@ -135,7 +135,7 @@ class GitManager:
                     url = response.json()["html_url"]
                     if metasmoke_down:
                         return (True,
-                                "MetaSmoke is not reachable, so I can't see if you have code privileges, but I've "
+                                "Metasmoke is not reachable, so I can't see if you have code privileges, but I've "
                                 "[created PR#{1} for you]({0}).".format(
                                     url, url.split('/')[-1]))
                     else:
@@ -178,7 +178,7 @@ class GitManager:
     def remove_from_blacklist(cls, item, username, blacklist_type="", code_privileged=False, metasmoke_down=False):
         if not code_privileged:
             if metasmoke_down:
-                return False, "MetaSmoke is offline, and I can't determine if you are a code admin or not. " \
+                return False, "Metasmoke is offline, and I can't determine if you are a code admin or not. " \
                               "If you are a code admin, then wait for MS to be back up before running this command."
             else:
                 return False, "Ask a code admin to run that for you. Use `!!/whois code_admin` to find out who's here."

--- a/gitmanager.py
+++ b/gitmanager.py
@@ -114,7 +114,7 @@ class GitManager:
                     return (False, "Tell someone to set a GH password")
 
                 payload = {"title": u"{0}: {1} {2}".format(username, op.title(), item),
-                           "body": u"[{0}]({1}) requests the {2} of the {3} `{4}`. See the Metasmoke search [here]"
+                           "body": u"[{0}]({1}) requests the {2} of the {3} `{4}`. See the MS search [here]"
                                    "(https://metasmoke.erwaysoftware.com/search?utf8=%E2%9C%93{5}{6}) and the "
                                    "Stack Exchange search [here](https://stackexchange.com/search?q=%22{7}%22).\n"
                                    u"<!-- METASMOKE-BLACKLIST-{8} {4} -->".format(
@@ -135,7 +135,7 @@ class GitManager:
                     url = response.json()["html_url"]
                     if metasmoke_down:
                         return (True,
-                                "Metasmoke is not reachable, so I can't see if you have code privileges, but I've "
+                                "MS is not reachable, so I can't see if you have code privileges, but I've "
                                 "[created PR#{1} for you]({0}).".format(
                                     url, url.split('/')[-1]))
                     else:
@@ -178,7 +178,7 @@ class GitManager:
     def remove_from_blacklist(cls, item, username, blacklist_type="", code_privileged=False, metasmoke_down=False):
         if not code_privileged:
             if metasmoke_down:
-                return False, "Metasmoke is offline, and I can't determine if you are a code admin or not. " \
+                return False, "MS is offline, and I can't determine if you are a code admin or not. " \
                               "If you are a code admin, then wait for MS to be back up before running this command."
             else:
                 return False, "Ask a code admin to run that for you. Use `!!/whois code_admin` to find out who's here."

--- a/gitmanager.py
+++ b/gitmanager.py
@@ -28,7 +28,7 @@ class GitManager:
 
     @classmethod
     def add_to_blacklist(cls, blacklist='', item_to_blacklist='', username='', chat_profile_link='',
-                         code_permissions=False):
+                         code_permissions=False, metasmoke_down=False):
         if git.config("--get", "user.name", _ok_code=[0, 1]) == "":
             return (False, 'Tell someone to run `git config user.name "SmokeDetector"`')
 
@@ -133,9 +133,16 @@ class GitManager:
                     git.checkout("deploy")  # Return to deploy, pending the accept of the PR in Master.
                     git.branch('-D', branch)  # Delete the branch in the local git tree since we're done with it.
                     url = response.json()["html_url"]
-                    return (True,
-                            "You don't have code privileges, but I've [created PR#{1} for you]({0}).".format(
-                                url, url.split('/')[-1]))
+                    if metasmoke_down:
+                        return (True,
+                                "MetaSmoke is not reachable, so I can't see if you have code privileges, but I've "
+                                "[created PR#{1} for you]({0}).".format(
+                                    url, url.split('/')[-1]))
+                    else:
+                        return (True,
+                                "You don't have code privileges, but I've [created PR#{1} for you]({0}).".format(
+                                    url, url.split('/')[-1]))
+
                 except KeyError:
                     git.checkout("deploy")  # Return to deploy
 

--- a/gitmanager.py
+++ b/gitmanager.py
@@ -175,9 +175,13 @@ class GitManager:
             return (True, "Added `{0}` to watchlist".format(item))
 
     @classmethod
-    def remove_from_blacklist(cls, item, username, blacklist_type="", code_privileged=False):
+    def remove_from_blacklist(cls, item, username, blacklist_type="", code_privileged=False, metasmoke_down=False):
         if not code_privileged:
-            return False, "Ask a code admin to run that for you. Use `!!/whois code_admin` to find out who's here."
+            if metasmoke_down:
+                return False, "MetaSmoke is offline, and I can't determine if you are a code admin or not. " \
+                              "If you are a code admin, then wait for MS to be back up before running this command."
+            else:
+                return False, "Ask a code admin to run that for you. Use `!!/whois code_admin` to find out who's here."
 
         try:
             cls.gitmanager_lock.acquire()


### PR DESCRIPTION
If MS is down we get a connection error problem.  When that happens, we should force code_permissions to be False.  However, to get the proper chat reply that MS is down and a PR made because we can't determine if someone is code privileged or not, we need a metasmoke_down tracker in the 'add to blacklist' function so we can determine which chat reply to send.  This way, we can make PRs if MS is down and we can't determine if someone has code privs.

However, the same can't be said about unblacklist.  It doesn't have PR-branch-creation functionality at all.  So the best we can do is fail with a specific error message.  unblacklist/unwatchlist will need refactored to be able to do that functionality before we can force PRs if someone isn't code-priv'd.