### PR TITLE
Don't catch IDNA domains as "misleading links"

### DIFF
--- a/findspam.py
+++ b/findspam.py
@@ -164,8 +164,15 @@ def misleading_link(s, site, *args):
     if site == 'stackoverflow.com' and parsed_text.fld.split('.')[-1] in SAFE_EXTENSIONS:
         return False, ''
 
-    href_domain = unquote_plus(parsed_href.domain).encode("idna").decode("ascii")
-    text_domain = unquote_plus(parsed_text.domain).encode("idna").decode("ascii")
+    try:
+        href_domain = unquote_plus(parsed_href.domain.encode("ascii").decode("idna"))
+    except ValueError:
+        href_domain = parsed_href.domain
+    try:
+        text_domain = unquote_plus(parsed_text.domain)  # Nobody posts "xn--abcdefg.com" in link text
+    except ValueError:
+        text_domain = parsed_text.domain
+
     if levenshtein(href_domain, text_domain) > LEVEN_DOMAIN_DISTANCE:
         return True, 'Domain {} indicated by possible misleading text {}.'.format(
             parsed_href.fld, parsed_text.fld

--- a/findspam.py
+++ b/findspam.py
@@ -163,7 +163,10 @@ def misleading_link(s, site, *args):
 
     if site == 'stackoverflow.com' and parsed_text.fld.split('.')[-1] in SAFE_EXTENSIONS:
         return False, ''
-    elif levenshtein(parsed_href.domain.lower(), parsed_text.domain.lower()) > LEVEN_DOMAIN_DISTANCE:
+
+    href_domain = parsed_href.domain.encode("idna").decode("ascii")
+    text_domain = parsed_text.domain.encode("idna").decode("ascii")
+    if levenshtein(href_domain, text_domain) > LEVEN_DOMAIN_DISTANCE:
         return True, 'Domain {} indicated by possible misleading text {}.'.format(
             parsed_href.fld, parsed_text.fld
         )

--- a/findspam.py
+++ b/findspam.py
@@ -4,7 +4,7 @@
 import math
 import regex
 from difflib import SequenceMatcher
-from urllib.parse import urlparse
+from urllib.parse import urlparse, unquote_plus
 from itertools import chain
 from collections import Counter
 from datetime import datetime
@@ -164,8 +164,8 @@ def misleading_link(s, site, *args):
     if site == 'stackoverflow.com' and parsed_text.fld.split('.')[-1] in SAFE_EXTENSIONS:
         return False, ''
 
-    href_domain = parsed_href.domain.encode("idna").decode("ascii")
-    text_domain = parsed_text.domain.encode("idna").decode("ascii")
+    href_domain = unquote_plus(parsed_href.domain).encode("idna").decode("ascii")
+    text_domain = unquote_plus(parsed_text.domain).encode("idna").decode("ascii")
     if levenshtein(href_domain, text_domain) > LEVEN_DOMAIN_DISTANCE:
         return True, 'Domain {} indicated by possible misleading text {}.'.format(
             parsed_href.fld, parsed_text.fld

--- a/test/test_regexes.py
+++ b/test/test_regexes.py
@@ -89,6 +89,7 @@ But when I try to run it using</p>""", 'Pacman', 'stackoverflow.com', False, Fal
     ('Pattern-matching product name', 'Alpha Formula Pro', '', 'math.stackexchange.com', False, False, False),
     ('Body starts with title', 'Body starts with title and ends with <a href="https://example.com">https://example.com</a>', '', '', False, False, True),
     ('Advanced BSWT', '<p><a href="......">Product Name</a> Advanced BSWT is a must-have <a href="https://example.com">https://example.com</a></p>', '', '', False, False, True),
+    ('IDNA misleading link', '<a href="http://www.h%c3%a5nd.no">http://www.h\u00E5nd.no</a>', '', '', False, False, False),
 ])
 def test_regexes(title, body, username, site, body_is_summary, is_answer, match):
     # If we want to test answers separately, this should be changed


### PR DESCRIPTION
See #2217

I was quite resistant about doing this before I noticed that Python has `str.encode('idna')`. So I just happily did this. URL-decoding is also involved in the post mentioned in 2217 so I added support for it, too.