### PR TITLE
Allow the watchlist and blacklist to match the start and end of strings

### DIFF
--- a/findspam.py
+++ b/findspam.py
@@ -1054,11 +1054,11 @@ class FindSpam:
         #
         # Category: Bad keywords
         # The big list of bad keywords, for titles and posts
-        {'regex': r"(?is)\b({})\b|{}".format("|".join(GlobalVars.bad_keywords), "|".join(bad_keywords_nwb)),
+        {'regex': r"(?is)(?:^|\b)({})(?:\b|$)|{}".format("|".join(GlobalVars.bad_keywords), "|".join(bad_keywords_nwb)),
          'all': True, 'sites': [], 'reason': "bad keyword in {}", 'title': True, 'body': True, 'username': True,
          'stripcodeblocks': False, 'body_summary': True, 'max_rep': 4, 'max_score': 1},
         # The small list of *potentially* bad keywords, for titles and posts
-        {'regex': r'(?is)\b({})\b'.format('|'.join(GlobalVars.watched_keywords.keys())),
+        {'regex': r'(?is)(?:^|\b)({})(?:\b|$)'.format('|'.join(GlobalVars.watched_keywords.keys())),
          'reason': 'potentially bad keyword in {}',
          'all': True, 'sites': [], 'title': True, 'body': True, 'username': True,
          'stripcodeblocks': False, 'body_summary': True, 'max_rep': 30, 'max_score': 1},


### PR DESCRIPTION
The Python `\b` assertion matches `^\w` and `\w$`, but it doesn't match `^\W` and `\W$`. If we want to have blacklist and/or watchlist entries which are able to match the beginning or end of the body (and/or titles and usernames when looking for `\W` characters), then we need to bookend the matches with `(?:^|\b)` at the start and `(?:\b|$)` at the end, rather than just with `\b` on both sides.

Documentation: [6.2.1. Regular Expression Syntax](https://docs.python.org/3/library/re.html#regular-expression-syntax)