### PR TITLE
Fetch message source for blacklist/watch commands

### DIFF
--- a/chatcommands.py
+++ b/chatcommands.py
@@ -1,7 +1,7 @@
 # coding=utf-8
 # noinspection PyUnresolvedReferences
 from chatcommunicate import add_room, block_room, CmdException, command, get_report_data, is_privileged, message, \
-    tell_rooms
+    tell_rooms, fetch_source
 # noinspection PyUnresolvedReferences
 from globalvars import GlobalVars
 from findspam import FindSpam
@@ -241,6 +241,7 @@ def do_blacklist(blacklist_type, msg, force=False):
     :return: A string
     """
 
+    msg.content_source = fetch_source(msg)
     chat_user_profile_link = "https://chat.{host}/users/{id}".format(host=msg._client.host,
                                                                      id=msg.owner.id)
 

--- a/chatcommunicate.py
+++ b/chatcommunicate.py
@@ -141,6 +141,18 @@ def pickle_last_messages():
             pickle.dump(_last_messages, pickle_file)
 
 
+def fetch_source(msg):
+    headers = {"Content-type": "text/plain"}
+    try:
+        response = requests.get(r"https://chat.{}/message/{}?plain=true".format(msg._client.host, msg.id), headers=headers)
+    except:  # Something wrong, not handling them for now, use placeholder
+        return msg.content_source
+
+    if response.status_code == 200:
+        return response.content.decode(response.encoding)
+    return msg.content_source
+
+
 def send_messages():
     while True:
         room, msg, report_data = _msg_queue.get()
@@ -185,26 +197,11 @@ def send_messages():
         _msg_queue.task_done()
 
 
-def fetch_source(msg):
-    headers = {"Content-type": "text/plain"}
-    try:
-        response = requests.get(r"https://chat.{}/message/{}?plain=true".format(msg._client.host, msg.id), headers=headers)
-    except:  # Something wrong, not handling them for now, use placeholder
-        return msg.content_source
-
-    if response.status_code == 200:
-        return response.content.decode(response.encoding)
-    return msg.content_source
-
-
 def on_msg(msg, client):
     if not isinstance(msg, events.MessagePosted) and not isinstance(msg, events.MessageEdited):
         return
 
     message = msg.message
-    log("info", message.content)
-    log("info", message.content_source)
-    log("info", fetch_source(message))
     if message.owner.id == client._br.user_id:
         return
 

--- a/chatcommunicate.py
+++ b/chatcommunicate.py
@@ -185,40 +185,56 @@ def send_messages():
         _msg_queue.task_done()
 
 
+def fetch_source(msg):
+    headers = {"Content-type": "text/plain"}
+    try:
+        response = requests.get(r"https://chat.{}/message/{}?plain=true".format(msg._client.host, msg.id), headers=headers)
+    except:  # Something wrong, not handling them for now, use placeholder
+        return msg.content_source
+
+    if response.status_code == 200:
+        return response.content.decode(response.encoding)
+    return msg.content_source
+
+
 def on_msg(msg, client):
-    if isinstance(msg, events.MessagePosted) or isinstance(msg, events.MessageEdited):
-        message = msg.message
+    if not isinstance(msg, events.MessagePosted) and not isinstance(msg, events.MessageEdited):
+        return
 
-        if message.owner.id == client._br.user_id:
-            return
+    message = msg.message
+    log("info", message.content)
+    log("info", message.content_source)
+    log("info", fetch_source(message))
+    if message.owner.id == client._br.user_id:
+        return
 
-        room_data = _rooms[(client.host, message.room.id)]
+    room_data = _rooms[(client.host, message.room.id)]
 
-        if message.parent:
-            if message.parent.owner.id == client._br.user_id:
-                strip_mention = regex.sub("^(<span class=(\"|')mention(\"|')>)?@.*?(</span>)? ", "", message.content)
-                cmd = GlobalVars.parser.unescape(strip_mention)
+    if message.parent:
+        if message.parent.owner.id == client._br.user_id:
+            strip_mention = regex.sub("^(<span class=(\"|')mention(\"|')>)?@.*?(</span>)? ", "", message.content)
+            cmd = GlobalVars.parser.unescape(strip_mention)
 
-                result = dispatch_reply_command(message.parent, message, cmd)
-
-                if result:
-                    _msg_queue.put((room_data, ":{} {}".format(message.id, result), None))
-        elif message.content.startswith("sd "):
-            result = dispatch_shorthand_command(message)
-
-            if result:
-                _msg_queue.put((room_data, ":{} {}".format(message.id, result), None))
-        elif message.content.startswith("!!/"):
-            result = dispatch_command(message)
+            result = dispatch_reply_command(message.parent, message, cmd)
 
             if result:
                 _msg_queue.put((room_data, ":{} {}".format(message.id, result), None))
-        elif classes.feedback.FEEDBACK_REGEX.search(message.content) \
-                and is_privileged(message.owner, message.room) and datahandling.last_feedbacked:
-                ids, expires_in = datahandling.last_feedbacked
+    elif message.content.startswith("sd "):
+        result = dispatch_shorthand_command(message)
 
-                if time.time() < expires_in:
-                    Tasks.do(metasmoke.Metasmoke.post_auto_comment, message.content_source, message.owner, ids=ids)
+        if result:
+            _msg_queue.put((room_data, ":{} {}".format(message.id, result), None))
+    elif message.content.startswith("!!/"):
+        result = dispatch_command(message)
+
+        if result:
+            _msg_queue.put((room_data, ":{} {}".format(message.id, result), None))
+    elif classes.feedback.FEEDBACK_REGEX.search(message.content) \
+            and is_privileged(message.owner, message.room) and datahandling.last_feedbacked:
+            ids, expires_in = datahandling.last_feedbacked
+
+            if time.time() < expires_in:
+                Tasks.do(metasmoke.Metasmoke.post_auto_comment, message.content_source, message.owner, ids=ids)
 
 
 def tell_rooms_with(prop, msg, notify_site="", report_data=None):


### PR DESCRIPTION
From time to time people edit blacklist commands and it's known that Smokey takes the source of the original (unedited) message, which has caused some troubles. Manually fetching the latest message source is a solution, and since it's applied only on blacklist/watch commands, it won't have a mattering performance impact.

For my analysis details [read down from this message](https://chat.stackexchange.com/transcript/message/45646416#45646416).