### PR TITLE
Drop requirement of dulwich

### DIFF
--- a/globalvars.py
+++ b/globalvars.py
@@ -16,7 +16,8 @@ from flovis import Flovis
 
 
 def git_commit_info():
-    data = sp.Popen(['git log -1 --pretty="%h%n%H%n%an%n%s"'], shell=True, cwd=os.getcwd(), stdout=sp.PIPE, stderr=sp.PIPE).communicate()
+    data = sp.Popen(['git log -1 --pretty="%h%n%H%n%an%n%s"'],
+                    shell=True, cwd=os.getcwd(), stdout=sp.PIPE, stderr=sp.PIPE).communicate()
     if data[1]:
         raise OSError("Git error:\n" + data[1].decode('utf-8'))
     short_id, full_id, author, message = data[0].decode('utf-8').strip().split("\n")

--- a/globalvars.py
+++ b/globalvars.py
@@ -16,8 +16,7 @@ from flovis import Flovis
 
 
 def git_commit_info():
-    data = sp.Popen(['git log -1 --pretty="%h%n%H%n%an%n%s"'],
-                    shell=True, cwd=os.getcwd(), stdout=sp.PIPE, stderr=sp.PIPE).communicate()
+    data = sp.Popen(['git', 'log', '-1', '--pretty="%h%n%H%n%an%n%s"'], stdout=sp.PIPE, stderr=sp.PIPE).communicate()
     if data[1]:
         raise OSError("Git error:\n" + data[1].decode('utf-8'))
     short_id, full_id, author, message = data[0].decode('utf-8').strip().split("\n")
@@ -25,14 +24,10 @@ def git_commit_info():
 
 
 def git_status():
-    if 'windows' in platform.platform().lower():
-        data = sp.Popen(['git', 'status'], shell=True, cwd=os.getcwd(), stderr=sp.PIPE, stdout=sp.PIPE).communicate()
-    else:
-        data = sp.Popen(['git status'], shell=True, cwd=os.getcwd(), stderr=sp.PIPE, stdout=sp.PIPE).communicate()
-    if not data[1]:
-        return data[0].decode('utf-8').strip('\n')
-    else:
-        raise OSError("Git error!")
+    data = sp.Popen(['git', 'status'], stdout=sp.PIPE, stderr=sp.PIPE).communicate()
+    if data[1]:
+        raise OSError("Git error:\n" + data[1].decode('utf-8'))
+    return data[0].decode('utf-8').strip('\n')
 
 
 # This is needed later on for properly 'stripping' unicode weirdness out of git log data.

--- a/globalvars.py
+++ b/globalvars.py
@@ -11,17 +11,16 @@ import threading
 # noinspection PyCompatibility
 import regex
 import subprocess as sp
-from dulwich.repo import Repo
 import platform
 from flovis import Flovis
 
 
 def git_commit_info():
-    git = Repo('.')
-    commit = git.get_object(git.head())
-    return {'id': commit.id.decode("utf-8")[0:7], 'id_full': commit.id.decode("utf-8"),
-            'author': regex.findall("(.*?) <(.*?)>", commit.author.decode("utf-8"))[0],
-            'message': commit.message.decode("utf-8").strip('\r\n').split('\n')[0]}
+    data = sp.Popen(['git log -1 --pretty="%h%n%H%n%an%n%s"'], shell=True, cwd=os.getcwd(), stdout=sp.PIPE, stderr=sp.PIPE).communicate()
+    if data[1]:
+        raise OSError("Git error:\n" + data[1].decode('utf-8'))
+    short_id, full_id, author, message = data[0].decode('utf-8').strip().split("\n")
+    return {'id': short_id, 'id_full': full_id, 'author': author, 'message': message}
 
 
 def git_status():

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 git+https://github.com/Manishearth/ChatExchange.git@a0307e431ea29983f846e770629f25bffb8c3814
-dulwich>=0.18.6
 pbs>=0.110
 packaging>=16.8
 appdirs>=1.4.3


### PR DESCRIPTION
`dulwich.repo` is only used once for obtaining Git commit information, which can well be replaced with a subprocess call to CLI `git-log`.