### PR TITLE
Load ChatExchange credentials from config file

### DIFF
--- a/config.sample
+++ b/config.sample
@@ -1,6 +1,10 @@
 [Config]
 location=location_here
 
+# Set ChatExchange login credentials, environmental variables take precedence over here
+# ChatExchangeU=stackexchange_login@example.com
+# ChatExchangeP=p@55w0rd
+
 # Set the location for metasmoke here if you're running it. See https://github.com/Charcoal-SE/metasmoke.
 # metasmoke_host=https://metasmoke.erwaysoftware.com
 # metasmoke_ws_host=wss://metasmoke.erwaysoftware.com/cable

--- a/globalvars.py
+++ b/globalvars.py
@@ -133,10 +133,17 @@ class GlobalVars:
     metasmoke_ws = None
 
     try:
+        chatexchange_u = config.get("Config", "ChatExchangeU")
+        chatexchange_p = config.get("Config", "ChatExchangeP")
+    except NoOptionError:
+        chatexchange_u = None
+        chatexchange_p = None
+
+    try:
         metasmoke_host = config.get("Config", "metasmoke_host")
     except NoOptionError:
         metasmoke_host = None
-        log('info', "metasmoke host not found. Set it as metasmoke_host in the config file."
+        log('info', "metasmoke host not found. Set it as metasmoke_host in the config file. "
             "See https://github.com/Charcoal-SE/metasmoke.")
 
     try:

--- a/ws.py
+++ b/ws.py
@@ -78,15 +78,17 @@ except TldIOError as ioerr:
             raise ioerr
 
 if "ChatExchangeU" in os.environ:
+    log('debug', "ChatExchange username loaded from environment")
     username = os.environ["ChatExchangeU"]
 elif GlobalVars.chatexchange_u:
-    log('info', "ChatExchange username loaded from config")
+    log('debug', "ChatExchange username loaded from config")
     username = GlobalVars.chatexchange_u
 else:
-    log('error', "No ChatExchange username provided. Set it in config or provide it via environment variable")
+    log('debug', "No ChatExchange username provided. Set it in config or provide it via environment variable")
     os._exit(6)
 
 if "ChatExchangeP" in os.environ:
+    log('debug', "ChatExchange password loaded from environment")
     password = os.environ["ChatExchangeP"]
 elif GlobalVars.chatexchange_p:
     log('info', "ChatExchange password loaded from config")

--- a/ws.py
+++ b/ws.py
@@ -15,7 +15,6 @@ install_thread_excepthook()
 import os
 # noinspection PyPackageRequirements
 import websocket
-import getpass
 from threading import Thread
 import traceback
 from bodyfetcher import BodyFetcher
@@ -80,12 +79,21 @@ except TldIOError as ioerr:
 
 if "ChatExchangeU" in os.environ:
     username = os.environ["ChatExchangeU"]
+elif GlobalVars.chatexchange_u:
+    log('info', "ChatExchange username loaded from config")
+    username = GlobalVars.chatexchange_u
 else:
-    username = input("Username: ")
+    log('error', "No ChatExchange username provided. Set it in config or provide it via environment variable")
+    os._exit(6)
+
 if "ChatExchangeP" in os.environ:
     password = os.environ["ChatExchangeP"]
+elif GlobalVars.chatexchange_p:
+    log('info', "ChatExchange password loaded from config")
+    password = GlobalVars.chatexchange_p
 else:
-    password = getpass.getpass("Password: ")
+    log('error', "No ChatExchange password provided. Set it in config or provide it via environment variable")
+    os._exit(6)
 
 # We need an instance of bodyfetcher before load_files() is called
 GlobalVars.bodyfetcher = BodyFetcher()


### PR DESCRIPTION
In addition to loading CE creds from environment variables, this enables the loading from local `config` file. If both are present, the ones defined in environment takes precedence, so this does essentially nothing to running instances.

As a downside, I removed asking for input via `input` and `getpass` as it causes confusion.

Previously CE cred is asked in both `nocrash.py` and `ws.py` if it's not found. It can be confusing if one is present in `config` but still asked from input, because `nocrash.py` does not load config. There were two options available:

1. Load `config` in `nocrash.py` and suppress terminal input if cred is found
2. Totally drop terminal input for cred

To keep things simple, I picked 2, because `nocrash.py` is a replacement for `nocrash.sh` and does not depend on any other files, and it's important (at least to me) to keep this isolation.