### PR TITLE
[Pending Test] Detect if MS is down and disable it

### DIFF
--- a/chatcommands.py
+++ b/chatcommands.py
@@ -556,6 +556,23 @@ def errorlogs(count):
     return fetch_lines_from_error_log(count or 50)
 
 
+@command(privileged=True, aliases=["ms-down", "ms-up"], give_name=True)
+def metasmoke():
+    if alias_used == "metasmoke":
+        status_text = [
+            "metasmoke is up. Currect failure count (consecutive): {}".format(GlobalVars.metasmoke_failures),
+            "metasmoke is down. Currect failure count (consecutive): {}".format(GlobalVars.metasmoke_failures),
+        ]
+        return status_text[GlobalVars.metasmoke_down]
+    if alias_used == "ms-down":
+        GlobalVars.metasmoke_down = True
+        return "metasmoke is now considered down."
+    if alias_used == "ms-up":
+        GlobalVars.metasmoke_down = False
+        return "metasmoke is now considered up."
+    raise CmdException("Bad command alias. Blame a developer.")
+
+
 # noinspection PyIncorrectDocstring
 @command(aliases=["commands", "help"])
 def info():

--- a/chatcommands.py
+++ b/chatcommands.py
@@ -556,9 +556,9 @@ def errorlogs(count):
     return fetch_lines_from_error_log(count or 50)
 
 
-@command(privileged=True, aliases=["ms-down", "ms-up"], give_name=True)
-def metasmoke():
-    if alias_used == "metasmoke":
+@command(privileged=True, aliases=["ms-status", "ms-down", "ms-up"], give_name=True)
+def metasmoke(alias_used):
+    if alias_used in {"metasmoke", "ms-status"}:
         status_text = [
             "metasmoke is up. Currect failure count (consecutive): {}".format(GlobalVars.metasmoke_failures),
             "metasmoke is down. Currect failure count (consecutive): {}".format(GlobalVars.metasmoke_failures),

--- a/chatcommands.py
+++ b/chatcommands.py
@@ -557,14 +557,18 @@ def errorlogs(count):
     return fetch_lines_from_error_log(count or 50)
 
 
-@command(privileged=True, aliases=["ms-status", "ms-down", "ms-up"], give_name=True)
-def metasmoke(alias_used):
+@command(whole_msg=True, aliases=["ms-status", "ms-down", "ms-up"], give_name=True)
+def metasmoke(msg, alias_used):
     if alias_used in {"metasmoke", "ms-status"}:
         status_text = [
             "metasmoke is up. Currect failure count (consecutive): {}".format(GlobalVars.metasmoke_failures),
             "metasmoke is down. Currect failure count (consecutive): {}".format(GlobalVars.metasmoke_failures),
         ]
         return status_text[GlobalVars.metasmoke_down]
+    # The next aliases/functionalities require privilege
+    if not is_privileged(msg.owner, msg.room):
+        raise CmdException(GlobalVars.not_privileged_warning)
+
     if alias_used == "ms-down":
         GlobalVars.metasmoke_down = True
         return "metasmoke is now considered down."

--- a/globalvars.py
+++ b/globalvars.py
@@ -133,6 +133,8 @@ class GlobalVars:
     location = config.get("Config", "location")
 
     metasmoke_ws = None
+    metasmoke_down = False
+    metasmoke_failures = 0  # Consecutive count, not cumulative
 
     try:
         chatexchange_u = config.get("Config", "ChatExchangeU")

--- a/metasmoke.py
+++ b/metasmoke.py
@@ -446,5 +446,5 @@ class Metasmoke:
     post = request_sender.__func__(requests.post)
 
     @staticmethod
-    def reset_failure_count():
+    def reset_failure_count():  # For use in other places
         GlobalVars.metasmoke_failures = 0

--- a/metasmoke.py
+++ b/metasmoke.py
@@ -445,3 +445,7 @@ class Metasmoke:
 
     get = request_sender.__func__(requests.get)
     post = request_sender.__func__(requests.post)
+
+    @staticmethod
+    def reset_failure_count():
+        GlobalVars.metasmoke_failures = 0

--- a/metasmoke.py
+++ b/metasmoke.py
@@ -433,12 +433,15 @@ class Metasmoke:
                 GlobalVars.metasmoke_failures += 1
                 if GlobalVars.metasmoke_failures > MAX_FAILURES:
                     GlobalVars.metasmoke_down = True
-                raise  # Maintain minimal difference to the original get/post
+                    chatcommunicate.tell_rooms_with('debug', "**Warning**: {} latest connections to metasmoke have fa"
+                                                    "iled. Disabling metasmoke".format(GlobalVars.metasmoke_failures))
+                # No need to log here because it's re-raised
+                raise  # Maintain minimal difference to the original get/post methods
             else:
-                GlobalVars.metasmoke_failures = 0  # Reset on success
+                GlobalVars.metasmoke_failures = 0  # Reset on success, what about decrementing instead of resetting?
 
             return response
         return func
 
-    get = Metasmoke.request_sender(requests.get)
-    post = Metasmoke.request_sender(requests.post)
+    get = request_sender(requests.get)
+    post = request_sender(requests.post)

--- a/metasmoke.py
+++ b/metasmoke.py
@@ -56,9 +56,11 @@ class Metasmoke:
                         payload = json.dumps({"command": "subscribe",
                                               "identifier": "{\"channel\":\"SmokeDetectorChannel\"}"})
                         GlobalVars.metasmoke_ws.send(payload)
+                        GlobalVars.metasmoke_failures += 1
                         log('error', e)
                         traceback.print_exc()
             except Exception:
+                GlobalVars.metasmoke_failures += 1
                 log('error', "Couldn't bind to MS websocket")
                 if not has_succeeded:
                     break
@@ -419,7 +421,7 @@ class Metasmoke:
 
     # Some sniffy stuff
     @staticmethod
-    def request_sender(method)
+    def request_sender(method):
         def func(url, *args, **kwargs):
             if GlobalVars.metasmoke_down:
                 return None
@@ -431,7 +433,7 @@ class Metasmoke:
                 GlobalVars.metasmoke_failures += 1
                 if GlobalVars.metasmoke_failures > MAX_FAILURES:
                     GlobalVars.metasmoke_down = True
-                raise
+                raise  # Maintain minimal difference to the original get/post
             else:
                 GlobalVars.metasmoke_failures = 0  # Reset on success
 

--- a/metasmoke.py
+++ b/metasmoke.py
@@ -443,5 +443,5 @@ class Metasmoke:
             return response
         return func
 
-    get = request_sender(requests.get)
-    post = request_sender(requests.post)
+    get = request_sender.__func__(requests.get)
+    post = request_sender.__func__(requests.post)

--- a/metasmoke.py
+++ b/metasmoke.py
@@ -413,3 +413,36 @@ class Metasmoke:
         response = requests.get(GlobalVars.metasmoke_host + '/api/v2.0/posts/urls', params=payload).json()
 
         return response['items']
+
+    # Some sniffy stuff
+    @staticmethod
+    def get(url, *args, **kwargs):
+        if GlobalVars.metasmoke_down:
+            return None
+
+        response = None  # Should return None upon failure, if any
+        try:
+            response = requests.get(GlobalVars.metasmoke_host + url, *args, **args)
+        except Exception:
+            GlobalVars.metasmoke_failures += 1
+            raise
+        else:
+            GlobalVars.metasmoke_failures = 0  # Reset on success
+
+        return response
+
+    @staticmethod
+    def post(url, *args, **kwargs):
+        if GlobalVars.metasmoke_down:
+            return None
+
+        response = None  # Should return None upon failure, if any
+        try:
+            response = requests.post(GlobalVars.metasmoke_host + url, *args, **args)
+        except Exception:
+            GlobalVars.metasmoke_failures += 1
+            raise
+        else:
+            GlobalVars.metasmoke_failures = 0  # Reset on success
+
+        return response


### PR DESCRIPTION
MS gets down from time to time and it throttles Smokey a lot because communication with MS runs on the main thread.

This approach does these:

- [X] Wrap-up `get` and `post` so they count failures
- [X] Wrap-up `get` and `post` so they return None during MS down
- [X] Mark flag `GlobalVars.metasmoke_down` when failurecount exceeds threshold, send warning to chat rooms when that happens
- [x] Replace existing code so they used the wrapped-up `get` and `post`
- [x] Integrate MS websocket into this counting
- [x] Quick command that enables/disables MS
- [ ] Prevent automatic reboot from resetting the flag