### PR TITLE
Move "illuminati" and "vampire" pattern-matching email into findspam.py.

### DIFF
--- a/findspam.py
+++ b/findspam.py
@@ -419,7 +419,7 @@ def keyword_email(s, site):   # a keyword and an email in the same post
 def pattern_email(s, site):
     pattern = regex.compile(r"(?i)(?<![=#/])\b(dr|[A-z0-9_.%+-]*"
                             r"(loan|hack|financ|fund|spell|temple|herbal|spiritual|atm|heal|priest|classes|"
-                            r"investment))[A-z0-9_.%+-]*"
+                            r"investment|illuminati|vampire?))[A-z0-9_.%+-]*"
                             r"@(?!(example|domain|site|foo|\dx)\.[A-z]{2,4})[A-z0-9_.%+-]+\.[A-z]{2,4}\b"
                             ).search(s)
     if pattern:

--- a/watched_keywords.txt
+++ b/watched_keywords.txt
@@ -3691,8 +3691,6 @@
 1528039866	Makyen	how\W?I\W?became\W?a\W?vampire
 1528054337	Zoe	hpsoftwaredrivers\.com
 1528055624	Makyen	kbsu\.ru
-1528073254	Makyen	[a-z0-9!#$%&'*+/=?^_`{|}~.-]*vampire[a-z0-9!#$%&'*+/=?^_`{|}~.-]*@\w*(?:\.\w*)+
-1528073262	Makyen	[a-z0-9!#$%&'*+/=?^_`{|}~.-]*illuminati[a-z0-9!#$%&'*+/=?^_`{|}~.-]*@\w*(?:\.\w*)+
 1528075157	Makyen	templeofanswer@hotmail\.co\.uk
 1528075184	Makyen	drokougbespecialhome@gmail\.com
 1528075194	Makyen	357067391386912


### PR DESCRIPTION
illuminati is 85/0 (tp/fp)
vampire is 26/0 (tp/fp)

They've both been on the watchlist for 3 months. However, the `vampire` is being changed to `vampire?` in order to catch more recent examples.