### PR TITLE
Wrap up the regex module and make a global cache

### DIFF
--- a/regex_proxy.py
+++ b/regex_proxy.py
@@ -1,0 +1,16 @@
+from regex import *
+from regex import compile as raw_compile
+
+
+_cache = {}
+
+
+# Wrap regex.compile up so we have a global cache
+def compile(s, *args, **kwargs):
+    global _cache
+    try:
+        return _cache[s]
+    except KeyError:
+        r = raw_compile(s, *args, **kwargs)
+        _cache[s] = r
+        return r


### PR DESCRIPTION
We're compiling the same regexes repeatedly in various places. It can be a little hard and complicated to fix all of them into reusing the compiled regex object. Here's another approach by wrapping up the `regex` module and make `regex.compile()` cache regexes on its own. This way minimal changes to the source is required. We only need to replace `import regex` with `import regex_proxy as regex` with 100% compatibility.

I want some reviews before pushing this.