### PR TITLE
Provide username of reporter when reporting in API

### DIFF
--- a/metasmoke.py
+++ b/metasmoke.py
@@ -118,8 +118,8 @@ class Metasmoke:
             datahandling.add_false_positive(post_site_id[0:2])
         elif "report" in message:
             import chatcommands  # Do it here
-            chatcommands.report_posts([message["report"]["post_link"]], "the metasmoke API", None,
-                                      "the metasmoke API")
+            chatcommands.report_posts([message["report"]["post_link"]], message["report"]["user"],
+                                      None, "the metasmoke API")
             return
             post_data = apigetpost.api_get_post(message["report"]["post_link"])
             if post_data is None or post_data is False:


### PR DESCRIPTION
Implement as requested in message https://chat.stackexchange.com/transcript/message/46883691#46883691

Example text: `Post manually reported by *user*.`
