### PR TITLE
health was renamed as medicalsciences

### DIFF
--- a/bodyfetcher.py
+++ b/bodyfetcher.py
@@ -46,7 +46,7 @@ class BodyFetcher:
         "expatriates.stackexchange.com": 1,
         "genealogy.stackexchange.com": 1,
         "ham.stackexchange.com": 1,
-        "health.stackexchange.com": 1,
+        "medicalsciences.stackexchange.com": 1,
         "history.stackexchange.com": 1,
         "meta.stackexchange.com": 1,
         "money.stackexchange.com": 1,


### PR DESCRIPTION
The site formerly known as Health is now Medical Sciences, but bodyfetcher has the old URL.