### PR TITLE
Use logging.warning instead of deprecated logging.warn

### DIFF
--- a/nocrash.py
+++ b/nocrash.py
@@ -38,7 +38,7 @@ def log(message):
 
 
 def warn(message):
-    logging.warn('[NoCrash] {}'.format(message))
+    logging.warning('[NoCrash] {}'.format(message))
 
 
 def error(message):


### PR DESCRIPTION
* https://docs.python.org/3/library/logging.html#logging.warning

* https://stackoverflow.com/questions/15539937/whats-the-difference-between-logging-warn-and-logging-warning-in-python-or-are

