### PR TITLE
Modify order of except clauses

### DIFF
--- a/flovis.py
+++ b/flovis.py
@@ -40,11 +40,11 @@ class Flovis:
             def run():
                 try:
                     self.ws.run_forever()
+                except websocket._exceptions.WebSocketConnectionClosedException:
+                    log('error', 'Flovis websocket closed unexpectedly, assuming problems and nullifying ws')
                 except websocket._exceptions.WebSocketException as e:
                     if "socket is already opened" not in str(e):
                         raise
-                except websocket._exceptions.WebSocketConnectionClosedException:
-                    log('error', 'Flovis websocket closed unexpectedly, assuming problems and nullifying ws')
                 except (AttributeError, OSError) as e:
                     log('error', str(e))
                 finally:


### PR DESCRIPTION
https://github.com/websocket-client/websocket-client/blob/efcf31b30122e05701fb3f696b029baf8faa6d8e/websocket/_exceptions.py#L29-L33

https://github.com/websocket-client/websocket-client/blob/efcf31b30122e05701fb3f696b029baf8faa6d8e/websocket/_exceptions.py#L50-L55

```python
>>> class WebSocketException(Exception):
...     """
...     websocket exception class.
...     """
...     pass
... 
... 
... class WebSocketConnectionClosedException(WebSocketException):
...     """
...     If remote host closed the connection or some network error happened,
...     this exception will be raised.
...     """
...     pass
... 
... 
... try:
...     raise WebSocketConnectionClosedException
... except WebSocketException:
...     print('caught here')
... except WebSocketConnectionClosedException:
...     print('instead of here')
... 
caught here

```