### PR TITLE
Provide a mechanism to initiate `pip` updates from within Smokey

### DIFF
--- a/chatcommands.py
+++ b/chatcommands.py
@@ -686,6 +686,7 @@ def pip_update():
     else:
         os._exit(20)
 
+
 @command(privileged=True, aliases=['pip-force'])
 def pip_force():
     """

--- a/chatcommands.py
+++ b/chatcommands.py
@@ -674,7 +674,7 @@ def master():
     os._exit(8)
 
 
-@command(privileged=True, aliases=['pip-update'])
+@command(privileged=True)
 def pip_update():
     """
     Initiate `pip` requirement updates in userspace, or warn if we're in a venv.

--- a/chatcommands.py
+++ b/chatcommands.py
@@ -25,7 +25,7 @@ from html import unescape
 from ast import literal_eval
 # noinspection PyCompatibility
 import regex
-from helpers import only_blacklists_changed, only_modules_changed, log, expand_shorthand_link, reload_modules
+from helpers import only_blacklists_changed, only_modules_changed, log, expand_shorthand_link, reload_modules, is_venv
 from classes import Post
 from classes.feedback import *
 
@@ -677,10 +677,21 @@ def master():
 @command(privileged=True, aliases=['pip-update'])
 def pip_update():
     """
-    Initiate `pip` requirement updates in userspace.
+    Initiate `pip` requirement updates in userspace, or warn if we're in a venv.
     :return: None
     """
-    # Exit code 20 triggers the pip calls in nocrash.py
+    if not is_venv():
+        raise CmdException("Smokey is not running in a Python virtualenv.  Updating may cause other unrelated things "
+                           "to break.  Use pip-force to force the pip update anyways.")
+    else:
+        os._exit(20)
+
+@command(privileged=True, aliases=['pip-force'])
+def pip_force():
+    """
+    Force `pip` upgrades regardless of env.
+    :return: None
+    """
     os._exit(20)
 
 

--- a/chatcommands.py
+++ b/chatcommands.py
@@ -683,8 +683,8 @@ def pip_update(alias_used="pip-update"):
     if alias_used == 'pip-update-force' or is_venv():
         os._exit(20)
     else:
-        raise CmdException("Smokey is not running in a Python virtualenv.  Updating may cause other unrelated things "
-                           "to break.  Use pip-force to force the pip update anyways.")
+        raise CmdException("SmokeDetector  is not running in a Python virtualenv. Updating may cause other unrelated "
+                           "things to break.  Use `pip-update-force` to force the update anyways.")
 
 
 # noinspection PyIncorrectDocstring,PyProtectedMember

--- a/chatcommands.py
+++ b/chatcommands.py
@@ -674,6 +674,16 @@ def master():
     os._exit(8)
 
 
+@command(privileged=True, aliases=['pip-update'])
+def pip_update():
+    """
+    Initiate `pip` requirement updates in userspace.
+    :return: None
+    """
+    # Exit code 20 triggers the pip calls in nocrash.py
+    os._exit(20)
+
+
 # noinspection PyIncorrectDocstring,PyProtectedMember
 @command(privileged=True)
 def pull():

--- a/chatcommands.py
+++ b/chatcommands.py
@@ -687,7 +687,7 @@ def pip_update():
         os._exit(20)
 
 
-@command(privileged=True, aliases=['pip-force'])
+@command(privileged=True)
 def pip_force():
     """
     Force `pip` upgrades regardless of env.

--- a/chatcommands.py
+++ b/chatcommands.py
@@ -674,26 +674,17 @@ def master():
     os._exit(8)
 
 
-@command(privileged=True)
-def pip_update():
+@command(privileged=True, aliases=['pip-update-force'], give_name=True)
+def pip_update(alias_used="pip-update"):
     """
     Initiate `pip` requirement updates in userspace, or warn if we're in a venv.
     :return: None
     """
-    if not is_venv():
+    if alias_used == 'pip-update-force' or is_venv():
+        os._exit(20)
+    else:
         raise CmdException("Smokey is not running in a Python virtualenv.  Updating may cause other unrelated things "
                            "to break.  Use pip-force to force the pip update anyways.")
-    else:
-        os._exit(20)
-
-
-@command(privileged=True)
-def pip_force():
-    """
-    Force `pip` upgrades regardless of env.
-    :return: None
-    """
-    os._exit(20)
 
 
 # noinspection PyIncorrectDocstring,PyProtectedMember

--- a/helpers.py
+++ b/helpers.py
@@ -183,3 +183,9 @@ def blacklist_integrity_check():
 
 class SecurityError(Exception):
     pass
+
+
+
+def is_venv():
+    return (hasattr(sys, 'real_prefix') or
+            (hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix))

--- a/helpers.py
+++ b/helpers.py
@@ -185,7 +185,6 @@ class SecurityError(Exception):
     pass
 
 
-
 def is_venv():
     return (hasattr(sys, 'real_prefix') or
             (hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix))

--- a/nocrash.py
+++ b/nocrash.py
@@ -33,6 +33,11 @@ stoprunning = False
 ecode = None  # Define this to prevent errors
 
 
+def is_venv():
+    return (hasattr(sys, 'real_prefix') or
+            (hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix))
+
+
 def log(message):
     logging.info('[NoCrash] {}'.format(message))
 
@@ -155,11 +160,17 @@ while not stoprunning:
         crashcount = 0
 
         log('Initiating automated `pip` upgrade calls within userspace.')
+        if is_venv():
+            command = "python3 -m pip install --upgrade -r "
+        else:
+            command = "python3 -m pip install --upgrade -user -r "
+            warn("This may break your user-level package space, this is on you, and not the Charcoal team.")
+
         sleep(5)
         errored = False
         for filename in ['requirements.txt', 'user_requirements.txt']:
             try:
-                ecode = sp.call('python3 -m pip install --upgrade --user -r ' + filename, env=os.environ.copy())
+                ecode = sp.call(command + filename, env=os.environ.copy())
             except sp.SubprocessError:
                 errored = True
                 exc_type, exc_obj, exc_tb = sys.exc_info()

--- a/nocrash.py
+++ b/nocrash.py
@@ -157,7 +157,7 @@ while not stoprunning:
 
         if errored:
             error('Could not upgrade PIP, please check the logs. Terminating...')
-            break
+            stoprunning = True
 
     else:
         error('Died for unknown reason -- check logs.  Sleeping before restart')

--- a/nocrash.py
+++ b/nocrash.py
@@ -144,6 +144,16 @@ while not stoprunning:
         count = 0
 
     elif ecode == 20:
+        log('Pull in new updates beforeo we do `pip` upgrades.')
+        if 'windows' not in str(platform.platform()).lower():
+            git.checkout('deploy')
+            git.pull()
+        else:
+            warn('Not pulling updates; we are on Windows')
+
+        count = 0
+        crashcount = 0
+
         log('Initiating automated `pip` upgrade calls within userspace.')
         sleep(5)
         errored = False

--- a/nocrash.py
+++ b/nocrash.py
@@ -143,6 +143,22 @@ while not stoprunning:
         sleep(5)
         count = 0
 
+    elif ecode == 20:
+        log('Initiating automated `pip` upgrade calls within userspace.')
+        sleep(5)
+        errored = False
+        for filename in ['requirements.txt', 'user_requirements.txt']:
+            try:
+                ecode = sp.call('pip3 install --upgrade --user -r ' + filename, env=os.environ.copy())
+            except sp.SubprocessError:
+                errored = True
+                exc_type, exc_obj, exc_tb = sys.exc_info()
+                log("subprocess.call() error {0}: {1}".format(exc_type.__name__, exc_obj))
+
+        if errored:
+            error('Could not upgrade PIP, please check the logs. Terminating...')
+            break
+
     else:
         error('Died for unknown reason -- check logs.  Sleeping before restart')
         sleep(5)

--- a/nocrash.py
+++ b/nocrash.py
@@ -9,6 +9,7 @@ from time import sleep
 import logging
 import sys
 from getpass import getpass
+from helpers import is_venv
 if 'windows' in str(platform.platform()).lower():
     # noinspection PyPep8Naming
     from classes import Git as git
@@ -31,11 +32,6 @@ count = 0
 crashcount = 0
 stoprunning = False
 ecode = None  # Define this to prevent errors
-
-
-def is_venv():
-    return (hasattr(sys, 'real_prefix') or
-            (hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix))
 
 
 def log(message):
@@ -163,8 +159,7 @@ while not stoprunning:
         if is_venv():
             command = "python3 -m pip install --upgrade -r "
         else:
-            command = "python3 -m pip install --upgrade -user -r "
-            warn("This may break your user-level package space, this is on you, and not the Charcoal team.")
+            command = "python3 -m pip install --upgrade --user -r "
 
         sleep(5)
         errored = False

--- a/nocrash.py
+++ b/nocrash.py
@@ -149,7 +149,7 @@ while not stoprunning:
         errored = False
         for filename in ['requirements.txt', 'user_requirements.txt']:
             try:
-                ecode = sp.call('pip3 install --upgrade --user -r ' + filename, env=os.environ.copy())
+                ecode = sp.call('python3 -m pip install --upgrade --user -r ' + filename, env=os.environ.copy())
             except sp.SubprocessError:
                 errored = True
                 exc_type, exc_obj, exc_tb = sys.exc_info()


### PR DESCRIPTION
Currently, whenever we have a requirements file change, we ping all maintainers and require them to update the Smokey instances manually, likely due to system libraries or system `pip` or such being in use.

This pull request adjusts `nocrash.py` to utilize an exit code (`20`) that does two things:  (1) Pulls the `deploy` branch to update it, and then (2) calls a `pip` update within userspace of both the `requirements.txt` and the `user_requirements.txt` files.

This will permit us to properly get new requirements upgrades done automatically without any major requirements or mass-pinging or mass manual updating of instances each time.

**This will require all running SmokeDetectors to be manually restarted, however, because of the changes to `nocrash.py`**

We also implement the `pip_update` and `pip-update` alias for Chat Commands to call `os._exit(20)` which will be caught by `nocrash.py` and initiate the `pip` upgrade process.  If for any reason `pip` calls fail, the Smokey instance will not automatically restart because we could be in a dangerous 'half-upgraded requirements' state which could explode Smokey.  However, provided `pip` works as intended and updates go smoothly, SmokeDetector should automatically restart.