### PR TITLE
Effectively blacklist blacklisting disk-partition.com

### DIFF
--- a/globalvars.py
+++ b/globalvars.py
@@ -151,7 +151,7 @@ class GlobalVars:
     # Miscellaneous
     log_time_format = config.get("log_time_format", "%H:%M:%S")
 
-    valid_content = """This is a totally valid post that should never be caught. Any blacklist or watchlist item that triggers on this item should be avoided. java.io.BbbCccDddException: nothing wrong found. class Safe { perfect valid code(int float &#%$*v a b c =+ /* - 0 1 2 3 456789.EFGQ} English 中文Français Español Português Italiano Deustch ~@#%*-_/'()?!:;" vvv kkk www sss ttt mmm absolute std::adjacent_find (power).each do |s| bbb end ert zal l gsopsq kdowhs@ xjwk* %_sooqmzb xjwpqpxnf."""  # noqa: E501
+    valid_content = """This is a totally valid post that should never be caught. Any blacklist or watchlist item that triggers on this item should be avoided. java.io.BbbCccDddException: nothing wrong found. class Safe { perfect valid code(int float &#%$*v a b c =+ /* - 0 1 2 3 456789.EFGQ} English 中文Français Español Português Italiano Deustch ~@#%*-_/'()?!:;" vvv kkk www sss ttt mmm absolute std::adjacent_find (power).each do |s| bbb end ert zal l gsopsq kdowhs@ xjwk* %_sooqmzb xjwpqpxnf.  Please don't blacklist disk-partition.com, it's a valid domain (though it also gets spammed rather frequently)."""  # noqa: E501
 
     @staticmethod
     def reload():


### PR DESCRIPTION
disk-partition.com has been in and out of the blacklist repeatedly. It should not be blacklisted.

Add disk-partition.com to GlobalVars.valid_content so as to trigger the "too broad" check if someone attempts to blacklist it again.