### PR TITLE
Smokey Pickle Transfer Protocol

### DIFF
--- a/chatcommands.py
+++ b/chatcommands.py
@@ -1591,12 +1591,22 @@ def feedback(msg, post_url, feedback):
 
 @command(privileged=True, aliases=['dump-data'])
 def dump_data():
-    return NotImplemented
+    s = SmokeyTransfer.dump()
+    tell_rooms_with('dump', s)
+    return None
 
 
 @command(int, privileged=True, aliased=['load-data'])
 def load_data(msg_id):
-    return NotImplemented
+    msg = get_message(msg_id)
+    if msg.owner.id != 120914:  # TODO: implement an is_self() in chatcommunicate, don't use magic numbers
+        raise CmdException("Message owner is not SmokeDetector, refusing to load")
+    try:
+        s = msg.content_source
+        SmokeyTransfer.load(s)
+    except ValueError as e:
+        raise CmdException(str(e)) from None
+    return None
 
 
 #

--- a/chatcommands.py
+++ b/chatcommands.py
@@ -1589,6 +1589,16 @@ def feedback(msg, post_url, feedback):
     raise CmdException("No such feedback.")
 
 
+@command(privileged=True, aliases=['dump-data'])
+def dump_data():
+    return NotImplemented
+
+
+@command(int, privileged=True, aliased=['load-data'])
+def load_data(msg_id):
+    return NotImplemented
+
+
 #
 #
 # Subcommands go below here

--- a/chatcommands.py
+++ b/chatcommands.py
@@ -1596,7 +1596,7 @@ def dump_data():
     return None
 
 
-@command(int, privileged=True, aliased=['load-data'])
+@command(int, privileged=True, aliases=['load-data'])
 def load_data(msg_id):
     msg = get_message(msg_id)
     if msg.owner.id != 120914:  # TODO: implement an is_self() in chatcommunicate, don't use magic numbers

--- a/chatcommands.py
+++ b/chatcommands.py
@@ -1592,7 +1592,7 @@ def feedback(msg, post_url, feedback):
 @command(privileged=True, aliases=['dump-data'])
 def dump_data():
     try:
-        s = SmokeyTransfer.dump()
+        s, metadata = SmokeyTransfer.dump()
         tell_rooms_with('dump', s)
     except Exception:
         log_exception(*sys.exc_info())

--- a/chatcommands.py
+++ b/chatcommands.py
@@ -1591,9 +1591,13 @@ def feedback(msg, post_url, feedback):
 
 @command(privileged=True, aliases=['dump-data'])
 def dump_data():
-    s = SmokeyTransfer.dump()
-    tell_rooms_with('dump', s)
-    return None
+    try:
+        s = SmokeyTransfer.dump()
+        tell_rooms_with('dump', s)
+    except Exception:
+        log_exception(*sys.exc_info())
+        raise CmdException("Failed to dump data. Run `!!/errorlogs` for details.")
+    return "Data successfully dumped"
 
 
 @command(int, privileged=True, aliases=['load-data'])
@@ -1602,11 +1606,13 @@ def load_data(msg_id):
     if msg.owner.id != 120914:  # TODO: implement an is_self() in chatcommunicate, don't use magic numbers
         raise CmdException("Message owner is not SmokeDetector, refusing to load")
     try:
-        s = msg.content_source
-        SmokeyTransfer.load(s)
+        SmokeyTransfer.load(msg.content_source)
     except ValueError as e:
         raise CmdException(str(e)) from None
-    return None
+    except Exception:
+        log_exception(*sys.exc_info())
+        raise CmdException("Failed to load data. Run `!!/errorlogs` for details.")
+    return "Data successfully loaded"
 
 
 #

--- a/chatcommunicate.py
+++ b/chatcommunicate.py
@@ -445,6 +445,12 @@ def message(msg):
     return msg
 
 
+def get_message(id, host="stackexchange.com"):
+    if host not in _clients:
+        raise ValueError("Invalid host")
+    return _clients[host].get_message(int(id))
+
+
 def dispatch_command(msg):
     command_parts = GlobalVars.parser.unescape(msg.content).split(" ", 1)
 

--- a/datahandling.py
+++ b/datahandling.py
@@ -590,7 +590,7 @@ class SmokeyTransfer:
         # need to transfer via chat, so text only
         b64_s = base64.b64encode(z_data).decode('ascii')
 
-        chunk_size = 512
+        chunk_size = 64  # The same value as GnuPG armored output
         s = "{}\n\n{}\n\n{}".format(
             cls.HEADER,
             '\n'.join([b64_s[i:i + chunk_size] for i in range(0, len(b64_s), chunk_size)]),

--- a/datahandling.py
+++ b/datahandling.py
@@ -599,10 +599,12 @@ class SmokeyTransfer:
 
     @classmethod
     def load(cls, s, merge=False):
-        s = s.strip()
-        if not (s.startswith(cls.HEADER + "\n") and s.endswith("\n" + cls.ENDING)):
+        try:
             # While it generates a blank line after the header and before the ending,
             # it should also accept data that does not contain the blank lines
+            lbound, rbound = s.index(cls.HEADER + "\n"), s.rindex("\n" + cls.ENDING)
+            s = s[lbound + len(cls.HEADER):rbound].strip()
+        except ValueError:
             raise ValueError("Invalid data (invalid header or ending)")
         s = ''.join(s.split())  # Clear whitespaces
 

--- a/datahandling.py
+++ b/datahandling.py
@@ -567,10 +567,21 @@ class SmokeyTransfer:
     @classmethod
     def dump(cls):
         # Trust Python's GIL here
-        data = {'version': 0}  # Reserve a version key here in case it'll be useful
+        data = {'_metadata': {
+            'time': time.time(),
+            'location': GlobalVars.location,
+            'rev': GlobalVars.commit['id_full'],
+            'lengths': {},  # can be used for validation
+        }}  # some metadata, in case they're useful
         for item_info in cls.ITEMS:
             key, obj, attr, *_ = item_info
-            data[key] = getattr(obj, attr)
+            item = getattr(obj, attr)
+            data[key] = item
+            try:
+                length = len(item)
+            except TypeError:
+                length = None  # len() is inapplicable
+            data['_metadata']['lengths']['key'] = length
 
         # hopefully the pickle won't be more than a few MiB
         raw_data = pickle.dumps(data, protocol=pickle.HIGHEST_PROTOCOL)

--- a/datahandling.py
+++ b/datahandling.py
@@ -614,8 +614,19 @@ class SmokeyTransfer:
                 raise ValueError("Invalid data (data type is not dict)")
 
             # happy extracting
+            warnings = []
             for item_info in cls.ITEMS:
                 key, obj, attr, *_ = item_info
-                setattr(obj, attr, data[key])
+                item = data[key]
+                try:
+                    length = len(item)
+                except TypeError:
+                    length = None
+                if length != data['_metadata']['lengths'][key]:
+                    warnings.append("Length of {!r} mismatch (recorded {}, actual {})".format(
+                        key, data['_metadata']['lengths'][key], length))
+                setattr(obj, attr, item)
+            if warnings:
+                raise Warning("Warning: " + ', '.join(warnings))
         except ValueError as e:
             raise e from None

--- a/datahandling.py
+++ b/datahandling.py
@@ -557,11 +557,11 @@ class SmokeyTransfer:
     ENDING = "-----END SMOKEY DATA BLOCK-----"
 
     ITEMS = [
-        # (dict_key, object, attr[, type, post_processing])
-        ('blacklisted_users', GlobalVars, 'blacklisted_users'),
-        ('whitelisted_users', GlobalVars, 'whitelisted_users'),
-        ('ignored_posts', GlobalVars, 'ignored_posts'),
-        ('notifications', GlobalVars, 'notifications'),
+        # (dict_key, object, attr, type, post_processing)
+        ('blacklisted_users', GlobalVars, 'blacklisted_users', None, None),
+        ('whitelisted_users', GlobalVars, 'whitelisted_users', None, None),
+        ('ignored_posts', GlobalVars, 'ignored_posts', None, None),
+        ('notifications', GlobalVars, 'notifications', None, None),
     ]
 
     @classmethod
@@ -574,7 +574,7 @@ class SmokeyTransfer:
             'lengths': {},  # can be used for validation
         }}  # some metadata, in case they're useful
         for item_info in cls.ITEMS:
-            key, obj, attr, *_ = item_info
+            key, obj, attr, obj_type, _ = item_info
             item = getattr(obj, attr)
             data[key] = item
             try:
@@ -618,7 +618,7 @@ class SmokeyTransfer:
             # happy extracting
             warnings = []
             for item_info in cls.ITEMS:
-                key, obj, attr, *_ = item_info
+                key, obj, attr, obj_type, proc = item_info
                 if key not in data:
                     continue  # Allow partial transfer
                 item = data[key]

--- a/datahandling.py
+++ b/datahandling.py
@@ -557,10 +557,11 @@ class SmokeyTransfer:
     ENDING = "-----END SMOKEY DATA BLOCK-----"
 
     ITEMS = [
-        # (dict_key, object, attr[, post_processing])
+        # (dict_key, object, attr[, type, post_processing])
         ('blacklisted_users', GlobalVars, 'blacklisted_users'),
         ('whitelisted_users', GlobalVars, 'whitelisted_users'),
         ('ignored_posts', GlobalVars, 'ignored_posts'),
+        ('notifications', GlobalVars, 'notifications'),
     ]
 
     @classmethod

--- a/datahandling.py
+++ b/datahandling.py
@@ -619,6 +619,8 @@ class SmokeyTransfer:
             warnings = []
             for item_info in cls.ITEMS:
                 key, obj, attr, *_ = item_info
+                if key not in data:
+                    continue  # Allow partial transfer
                 item = data[key]
                 try:
                     length = len(item)

--- a/datahandling.py
+++ b/datahandling.py
@@ -581,7 +581,7 @@ class SmokeyTransfer:
                 length = len(item)
             except TypeError:
                 length = None  # len() is inapplicable
-            data['_metadata']['lengths']['key'] = length
+            data['_metadata']['lengths'][key] = length
 
         # hopefully the pickle won't be more than a few MiB
         raw_data = pickle.dumps(data, protocol=pickle.HIGHEST_PROTOCOL)
@@ -609,8 +609,8 @@ class SmokeyTransfer:
         s = ''.join(s.split())  # Clear whitespaces
 
         try:
-            z_data = s[len(cls.HEADER):-len(cls.ENDING)].strip().encode('ascii')
-            raw_data = zlib.uncompress(z_data)
+            z_data = base64.b64decode(s.encode('ascii'))
+            raw_data = zlib.decompress(z_data)
             data = pickle.loads(raw_data, encoding='utf-8')
             if type(data) is not dict:
                 raise ValueError("Invalid data (data type is not dict)")
@@ -630,5 +630,5 @@ class SmokeyTransfer:
                 setattr(obj, attr, item)
             if warnings:
                 raise Warning("Warning: " + ', '.join(warnings))
-        except ValueError as e:
-            raise e from None
+        except (ValueError, zlib.error) as e:
+            raise ValueError(str(e)) from None

--- a/datahandling.py
+++ b/datahandling.py
@@ -564,12 +564,12 @@ class SmokeyTransfer:
     ]
 
     @classmethod
-    def create_data_for_transfer(cls):
+    def dump(cls):
         # Trust Python's GIL here
         data = {'version': 0}  # Reserve a version key here in case it'll be useful
-        data['blacklisted_users'] = GlobalVars.blacklisted_users
-        data['whitelisted_users'] = GlobalVars.whitelisted_users
-        data['ignored_posts'] = GlobalVars.ignored_posts
+        for item_info in cls.ITEMS:
+            key, obj, attr, *_ = item_info
+            data[key] = getattr(obj, attr)
 
         # hopefully the pickle won't be more than a few MiB
         raw_data = pickle.dumps(data, protocol=pickle.HIGHEST_PROTOCOL)
@@ -586,12 +586,13 @@ class SmokeyTransfer:
         return s
 
     @classmethod
-    def restore_data_from_transfer(cls, s, merge=False):
+    def load(cls, s, merge=False):
         s = s.strip()
         if not (s.startswith(cls.HEADER + "\n") and s.endswith("\n" + cls.ENDING)):
             # While it generates a blank line after the header and before the ending,
             # it should also accept data that does not contain the blank lines
             raise ValueError("Invalid data (invalid header or ending)")
+        s = ''.join(s.split())  # Clear whitespaces
 
         try:
             z_data = s[len(cls.HEADER):-len(cls.ENDING)].strip().encode('ascii')
@@ -603,6 +604,6 @@ class SmokeyTransfer:
             # happy extracting
             for item_info in cls.ITEMS:
                 key, obj, attr, *_ = item_info
-                setattr(obj, attr, data)
+                setattr(obj, attr, data[key])
         except ValueError as e:
             raise e from None

--- a/datahandling.py
+++ b/datahandling.py
@@ -595,7 +595,7 @@ class SmokeyTransfer:
             cls.HEADER,
             '\n'.join([b64_s[i:i + chunk_size] for i in range(0, len(b64_s), chunk_size)]),
             cls.ENDING)
-        return s
+        return s, data['_metadata']
 
     @classmethod
     def load(cls, s, merge=False):

--- a/rooms.yml
+++ b/rooms.yml
@@ -136,6 +136,7 @@ stackexchange.com:
     
     msg_types:
       - direct
+      - dump
 
   65945:  # Charcoal Test
     commands: true

--- a/test/test_datahandling.py
+++ b/test/test_datahandling.py
@@ -1,9 +1,31 @@
 # -*- coding: utf-8 -*-
 
-from datahandling import append_pings
+from datahandling import append_pings, SmokeyTransfer
+from globalvars import GlobalVars
+import pytest
 
 
 # noinspection PyMissingTypeHints
 def test_append_pings():
     assert append_pings("foo", ["user1", "some user"]) == "foo (@user1 @someuser)"
     assert append_pings("foo", [u"Doorknob 冰"]) == u"foo (@Doorknob冰)"
+
+
+def test_smokey_transfer(monkeypatch):
+    mp = monkeypatch
+    blacklisted_users = {1: (2, 3), 4: (5, 6)}
+    mp.setattr(GlobalVars, 'blacklisted_users', blacklisted_users)
+
+    s = SmokeyTransfer.dump()
+    assert s.startswith(SmokeyTransfer.HEADER + "\n\n")
+    assert s.endswith("\n\n" + SmokeyTransfer.ENDING)
+    print(s)
+    SmokeyTransfer.load(s, False)
+    assert GlobalVars.blacklisted_users == blacklisted_users
+
+    with pytest.raises(ValueError) as e:
+        SmokeyTransfer.load("hahaha")
+    assert "invalid data" in str(e).lower()
+
+    with pytest.raises(ValueError):
+        SmokeyTransfer.load(SmokeyTransfer.HEADER + "\nmmmmmm\n" + SmokeyTransfer.ENDING)

--- a/test/test_datahandling.py
+++ b/test/test_datahandling.py
@@ -16,9 +16,10 @@ def test_smokey_transfer(monkeypatch):
     blacklisted_users = {1: (2, 3), 4: (5, 6)}
     mp.setattr(GlobalVars, 'blacklisted_users', blacklisted_users)
 
-    s = SmokeyTransfer.dump()
+    s, metadata = SmokeyTransfer.dump()
     assert s.startswith(SmokeyTransfer.HEADER + "\n\n")
     assert s.endswith("\n\n" + SmokeyTransfer.ENDING)
+    assert isinstance(metadata['lengths'], dict)
     print(s)
     SmokeyTransfer.load(s, False)
     assert GlobalVars.blacklisted_users == blacklisted_users


### PR DESCRIPTION
Implements and closes #2511, the Smokey Pickle Transfer Protocol

### Data

It should pack selected data into a `dict` and pickle that dict, then compress the pickled data to reduce size, and base64-encode the compressed data so it's suitable to be posted as a chat message. A header line and an ending line similar to PGP armored data are also added. A loader function does the reverse thing, with some data validation in place.

Example data (try to break the CI test and it'll show up in stdout):

```
-----BEGIN SMOKEY DATA BLOCK-----

eNpVjz1OAzEQhfOz/BOh3MAdKVDEbgjJFhSIAkU+AUUUeXfH6xEbG63HiShAFCiV
O8zVOAo1m6RipCnme6On9z6i77t2azdvYeBPFksgUQgSYXtGhEsIj/c/v18Xq893
f1yZXBAaHfzTg9GE2hln2UwTlPVOGLKZZK/GXdbALADqkpFCe8XyGgQBEyw3WmLJ
JFbA1kiKWaGbX3JSMtQMKfhuDavgByJNiySB0TQdJ9Miza7jOE7GtyIdT+BGTmEi
s1FWxJPgjyrQJSm7C93PKpE/V2gJioWzUNvAO76/Vkjwn7Z8D0tt6oa8GEt7og2h
xH3NLXFOnTa2vM07vLsJPOIH/HATnDqbB3XebG8e3PAPT7x00A==

-----END SMOKEY DATA BLOCK-----
```

Further improvement may include a merging process so local data isn't overwritten directly.

Currently included data:

- blacklisted / whitelisted users
- ignored posts
- notification configuration (this is what user complains the most about not being synced)

This list can be easily expanded by adding entries to `SmokeyTransfer.ITEMS` with the format shown in the comment.

### Transmission

Two new chat commands. One of them tells Smokey to post the generated data as a chat message somewhere ([Charcoal Test](https://chat.stackexchange.com/rooms/65945) or [Socket Science](https://chat.stackexchange.com/rooms/84821), current implementation uses the latter), and the other tells Smokey to load data from a particular chat message. To keep a baseline of security, Smokey will reject to load from messages that are not posted by itself, though this can be extended to trusted users if needed (hand-crafting those messages? well do it if you can `:)`)

`!!/dump-data` dumps the data and posts a chat message to all rooms with role `dump`, and `!!/load-data <message ID>` loads data from message with the given ID. Proper check is in place before loading.

### More ideas

- Provide a way to merge data instead of overwriting existing data (will do this later)
  - Potentially we'll have trouble really deleting something (like removing a user from blacklist) if the merge method can't resolve deletion
- Automate the dumping and loading (very difficult)
- CI tests for these functions, where applicable
- Create a CLI tool for manually analyzing pickles and SPTP data
  - Extend the message owner check to allow loading from messages posted by authorized users

More TBA?