### PR TITLE
Make an !!/approve command to merge PRs

### DIFF
--- a/chatcommands.py
+++ b/chatcommands.py
@@ -401,6 +401,19 @@ def unblacklist(msg, item, alias_used="unwatch"):
     return result
 
 
+@command(int, privileged=True, whole_msg=True)
+def approve(msg, pr_id):
+    code_permissions = is_code_privileged(msg._client.host, msg.owner.id)
+    if not code_permissions:
+        raise CmdException("You need code privileges to approve pull requests")
+
+    # Forward this, because checks are better placed in gitmanager.py
+    try:
+        return GitManager.merge_pull_request(msg, pr_id)
+    except Exception as e:
+        return str(e)
+
+
 @command(privileged=True, aliases=["remote-diff", "remote_diff"])
 def remotediff():
     will_require_full_restart = "SmokeDetector will require a full restart to pull changes: " \

--- a/chatcommands.py
+++ b/chatcommands.py
@@ -409,8 +409,10 @@ def approve(msg, pr_id):
 
     # Forward this, because checks are better placed in gitmanager.py
     try:
-        message = GitManager.merge_pull_request(pr_id)
-        if code_permissions and only_blacklists_changed(GitManager.get_local_diff()):
+        message_url = "https://chat.{}/transcript/{}?m={}".format(msg._client.host, msg.room.id, msg.id)
+        commit_msg = "Approved by {} in {}\n{}".format(msg.owner.name, msg.room.name, message_url)
+        message = GitManager.merge_pull_request(pr_id, commit_msg)
+        if only_blacklists_changed(GitManager.get_local_diff()):
             try:
                 if not GlobalVars.on_master:
                     # Restart if HEAD detached

--- a/gitmanager.py
+++ b/gitmanager.py
@@ -257,7 +257,7 @@ class GitManager:
         return True, 'Removed `{}` from {}'.format(item, list_type)
 
     @classmethod
-    def merge_pull_request(cls, pr_id):
+    def merge_pull_request(cls, pr_id, commit_msg=""):
         response = requests.get("https://api.github.com/repos/{}/pulls/{}".format(GlobalVars.bot_repo_slug, pr_id))
         if not response:
             raise ConnectionError("Cannot connect to GitHub API")
@@ -277,7 +277,8 @@ class GitManager:
 
             git.fetch('origin', '+refs/pull/{}/merge'.format(pr_id))
             git.merge('FETCH_HEAD', '--no-ff', '-m', 'Merge pull request #{} from {}/{} --autopull'.format(
-                pr_id, GlobalVars.bot_repo_slug.split("/")[0], ref))
+                      pr_id, GlobalVars.bot_repo_slug.split("/")[0], ref),
+                      '-m', commit_msg)
             git.push()
             return "Merged pull request [#{0}](https://github.com/{1}/pulls/{0}).".format(
                 pr_id, GlobalVars.bot_repo_slug)

--- a/gitmanager.py
+++ b/gitmanager.py
@@ -256,6 +256,35 @@ class GitManager:
         # With no exception raised, list_type should be set
         return True, 'Removed `{}` from {}'.format(item, list_type)
 
+    @classmethod
+    def merge_pull_request(cls, pr_id):
+        try:
+            cls.gitmanager_lock.acquire()
+            status, message = cls.prepare_git_for_operation()
+            if not status:
+                raise OSError(message)
+
+            response = requests.get("https://api.github.com/repos/{}/pulls/{}".format(GlobalVars.bot_repo_slug, pr_id))
+            if not response:
+                raise ConnectionError("Cannot connect to GitHub API")
+            pr_info = response.json()
+            if pr_info["user"]["login"] != "SmokeDetector":
+                raise ValueError("PR {} is not created by me, so I can't approve it".format(pr_id))
+            if "<!-- METASMOKE-BLACKLIST" not in pr_info["body"]:
+                raise ValueError("PR description is malformed. Blame a developer")
+            ref = pr_info['head']['ref']
+
+            # Good to go here
+            git.fetch('origin', '+refs/pull/{}/merge'.format(pr_id))
+            git.merge('FETCH_HEAD', '--no-ff', '-m', 'Merge pull request #{} from {}/{} --autopull'.format(
+                pr_id, GlobalVars.bot_repo_slug.split("/")[0], ref))
+            git.push()
+            return "Merged pull request [#{0}](https://github.com/{1}/pulls/{0}).".format(
+                pr_id, GlobalVars.bot_repo_slug)
+        finally:
+            git.checkout('deploy')
+            cls.gitmanager_lock.release()
+
     @staticmethod
     def prepare_git_for_operation(blacklist_file_name):
         git.checkout('master')

--- a/gitmanager.py
+++ b/gitmanager.py
@@ -269,7 +269,7 @@ class GitManager:
                 raise ConnectionError("Cannot connect to GitHub API")
             pr_info = response.json()
             if pr_info["user"]["login"] != "SmokeDetector":
-                raise ValueError("PR {} is not created by me, so I can't approve it".format(pr_id))
+                raise ValueError("PR #{} is not created by me, so I can't approve it".format(pr_id))
             if "<!-- METASMOKE-BLACKLIST" not in pr_info["body"]:
                 raise ValueError("PR description is malformed. Blame a developer")
             ref = pr_info['head']['ref']

--- a/test/test_chatcommands.py
+++ b/test/test_chatcommands.py
@@ -195,7 +195,7 @@ def test_approve(monkeypatch):
     monkeypatch.setattr(GlobalVars, "code_privileged_users", [])
     assert chatcommands.approve(8888, original_msg=msg).startswith("You need code privileges")
 
-    monkeypatch.setattr(GlobalVars, "code_privileged_users", [1])
+    monkeypatch.setattr(GlobalVars, "code_privileged_users", [('stackexchange.com', 1)])
     with monkeypatch.context() as m:
         # Oh no GitHub is down
         m.setattr("requests.get", lambda *args, **kwargs: None)

--- a/test/test_chatcommands.py
+++ b/test/test_chatcommands.py
@@ -183,11 +183,11 @@ def test_approve(monkeypatch):
     msg = Fake({
         "_client": {
             "host": "stackexchange.com",
-            "get_user": lambda id: Fake({"name": "name", "id": id})
         },
+        "id": 88888888,
         "owner": {"name": "L'imperatore", "id": 1},
-        "room": {"id": 11540, "get_current_user_ids": lambda: []},
-        "content_source": '!!/approve -1'
+        "room": {"id": 11540, "name": "Continuous Integration", "_client": None},
+        "content_source": '!!/approve 8888',
     })
     msg.room._client = msg._client
 

--- a/test/test_chatcommands.py
+++ b/test/test_chatcommands.py
@@ -179,6 +179,30 @@ def test_watch(monkeypatch):
         git.checkout("master")
 
 
+def test_approve(monkeypatch):
+    msg = Fake({
+        "_client": {
+            "host": "stackexchange.com",
+            "get_user": lambda id: Fake({"name": "name", "id": id})
+        },
+        "owner": {"name": "L'imperatore", "id": 1},
+        "room": {"id": 11540, "get_current_user_ids": lambda: []},
+        "content_source": '!!/approve -1'
+    })
+    msg.room._client = msg._client
+
+    # Prevent from attempting to check privileges with Metasmoke
+    monkeypatch.setattr(GlobalVars, "code_privileged_users", [])
+    assert chatcommands.approve(8888, original_msg=msg).startswith("You need code privileges")
+
+    monkeypatch.setattr(GlobalVars, "code_privileged_users", [1])
+    with monkeypatch.context() as m:
+        # Oh no GitHub is down
+        m.setattr("requests.get", lambda *args, **kwargs: None)
+        assert chatcommands.approve(8888, original_msg=msg) == "Cannot connect to GitHub API"
+    assert chatcommands.approve(2518, original_msg=msg).startswith("PR #2518 is not created by me")
+
+
 @patch("chatcommands.handle_spam")
 def test_report(handle_spam):
     # Documentation: The process before scanning the post is identical regardless of alias_used.


### PR DESCRIPTION
This time it's just that I have a feeling this would be useful. E.g., when either MS or PullApprove is down.

### Summary

Code-privileged users can issue a command `!!/approve 8888` to approve pull request 8888. Necessary checks are performed before doing any Git operation. The checks include

- User is code-privileged
- The PR is created by Smokey itself
- The PR contains a valid description as used by MS

Operation for merging PR:

```
git checkout master
git fetch origin +refs/pull/8888/merge
git merge FETCH_HEAD --no-ff -m "Merge pull request #8888 from Charcoal-SE/{} --autopull"
git push
```

The fetch command is taken from Travis CI build logs (Travis builds PRs in that way), I have tested it briefly and it seems OK.

If you're wondering how can Smokey merge conflicts, read more >>> 3f5b3574e84ec1f793e14a8a7cfa6cbf8f2ec78c (note: the file has been updated to match the addition of number watchlist and blacklist, as well as what was [previously registered on MS][1])

  [1]: https://github.com/Charcoal-SE/metasmoke/blob/5d6e153073532e2a5b46ba8bfb7c2631dde6ae9c/app/controllers/github_controller.rb#L256-L261