### PR TITLE
Move Smokey back to RPG General Chat

### DIFF
--- a/rooms.yml
+++ b/rooms.yml
@@ -314,8 +314,8 @@ stackexchange.com:
     msg_types:
       - site-magento.stackexchange.com
 
-  13848: # Not A Bar (RPG.SE)
-    commands: true
+  11:     # Role-Playing Games General Chat
+    commands: false
     msg_types:
       - site-rpg.stackexchange.com
 


### PR DESCRIPTION
During a concentrated June/July spam wave, Smokey was moved to a separate overflow chat from the main RPG General Chat room. Now that the spam wave has died down we can move Smokey back to RPG General Chat.

(I'm one of the RPG.SE diamond moderators.)