### PR TITLE
autoflagged command update filter & use first report

### DIFF
--- a/metasmoke.py
+++ b/metasmoke.py
@@ -340,7 +340,7 @@ class Metasmoke:
         """
         payload = {
             'key': GlobalVars.metasmoke_key,
-            'filter': 'GKNJKLILHNFMJLFKINGJJHJOLGFHJF',  # id and autoflagged
+            'filter': 'GFGJGHFMHGOLMMJMJJJGHIGOMKFKKILF',  # id and autoflagged
             'urls': post_url
         }
         try:
@@ -349,9 +349,12 @@ class Metasmoke:
             log('error', e)
             return False, []
 
-        if len(response["items"]) > 0 and response["items"][0]["autoflagged"]:
+        # The first report of a URL is the only one that will be autoflagged. MS responses to the
+        # /posts/urls endpoint have the oldest report last.
+        first_report_index = len(response["items"]) - 1
+        if first_report_index > -1 and response["items"][first_report_index]["autoflagged"]:
             # get flagger names
-            id = str(response["items"][0]["id"])
+            id = str(response["items"][first_report_index]["id"])
             payload = {'key': GlobalVars.metasmoke_key}
 
             flags = Metasmoke.get("/api/v2.0/posts/" + id + "/flags", params=payload).json()


### PR DESCRIPTION
Update the filter used for the /posts/urls endpoint when fetching data for the `autoflaged` command.
Adjust the logic to use the oldest report for the URL, which is the only one that will be autoflagged.