### PR TITLE
nutra in bad_keywords_nwb: reduce non-TP by 50%

### DIFF
--- a/findspam.py
+++ b/findspam.py
@@ -1222,7 +1222,7 @@ class FindSpam:
         r"male\Wperf(?!ormer)", "anti[- ]?aging", "(ultra|berry|body)[ -]?ketone",
         "(cogni|oro)[ -]?(lift|plex)",
         "(skin|face|eye)[- ]?(serum|therapy|hydration|tip|renewal|gel|lotion|cream)",
-        r"\bnutra",
+        r"\bnutra(?!l(?:|y|ity|i[sz]ing|i[sz]ed?)s?\b)",
         r"contact (me|us)\W*<a ", "ecoflex",
         r"\brsgold",
         "packers.{0,15}(movers|logistic)(?:.{,25}</a>)",


### PR DESCRIPTION
This reduces the non-TP for this entry by 50% without missing any of the TP.

[Search on MS for current entry](https://metasmoke.erwaysoftware.com/search?utf8=%E2%9C%93&body_is_regex=1&body=%5Cbnutra): 765/719/41/3
[Search on MS for updated entry in this PR](https://metasmoke.erwaysoftware.com/search?utf8=%E2%9C%93&body_is_regex=1&body=%5Cbnutra%28%3F%21l%28%3F%3A%7Cy%7City%7Ci%5Bsz%5Ding%7Ci%5Bsz%5Ded%3F%29s%3F%5Cb%29): 743/719/22/0
