### PR TITLE
Move gratis to watch and exempt es.stackoverflow.com

### DIFF
--- a/findspam.py
+++ b/findspam.py
@@ -1418,10 +1418,11 @@ class FindSpam:
         {'method': what_is_this_pharma_title, 'all': True, 'sites': [], 'reason': 'Pattern-matching title',
          'title': True, 'body': False, 'username': False, 'stripcodeblocks': False, 'body_summary': False,
          'answers': False, 'max_rep': 1, 'max_score': 1},
-        # gratis at the beginning of post, SoftwareRecs is exempt
+        # gratis near the beginning of post or in title, SoftwareRecs and es.stackoverflow.com are exempt
         {'regex': r"(?is)(?<=^.{,200})\bgratis\b", 'all': True,
-         'sites': ['softwarerecs.stackexchange.com'], 'reason': "bad keyword in {}", 'title': True, 'body': True,
-         'username': False, 'stripcodeblocks': False, 'body_summary': True, 'max_rep': 11, 'max_score': 0},
+         'sites': ['softwarerecs.stackexchange.com', 'es.stackoverflow.com'],
+         'reason': "potentially bad keyword in {}", 'title': True, 'body': True, 'username': False,
+         'stripcodeblocks': False, 'body_summary': True, 'max_rep': 11, 'max_score': 0},
         # Bad keywords in titles and usernames, all sites
         {'regex': r"(?i)^(?:(?=.*?\b(?:online|hd)\b)(?=.*?(?:free|full|unlimited)).*?movies?\b)|(?=.*?\b(?:acai|"
                   r"kisn)\b)(?=.*?care).*products?\b|(?=.*?packer).*mover|(online|certification).*?training|"


### PR DESCRIPTION
This detection was [modified 3 months ago](https://github.com/Charcoal-SE/SmokeDetector/commit/a9ab576031737d8baed61b8750a53c3939a69467#diff-0763921f6af04c4a434786e1674a91c9L1127). Since then, it's had 7 FP and 1 TP, which is nowhere close to what's needed in a blacklisted item.  Even exempting es.stackoverflow.com would have resulted in 1 TP and 1 FP, which also doesn't justify a blacklist.

Prior to the change 3 months ago, the detection was broken. The regex used `\bgratis\b$`, which will never detect anything in bodies, due to SE never ending a post with text, but will detect in titles. However, even if we look at [just that detection in titles](https://metasmoke.erwaysoftware.com/search?utf8=%E2%9C%93&title_is_regex=1&title=%5Cbgratis%5Cb%24) it would be 2 TP and 3 FP, which again doesn't justify a blacklist.

It should be noted that leaving this active, as is, results in a watch on the entire ".gratis" TLD, which isn't clear that we actually want. I haven't changed it, as I'm unsure what the intent was. OTOH, [detections of the ".gratis" TLD are currently 3 TP 1 FP in MS](https://metasmoke.erwaysoftware.com/search?utf8=%E2%9C%93&body_is_regex=1&body=%5C.gratis%5Cb), but looking only at the last 30 days it's 1 TP and 1 FP. However, the FP could be eliminated by not looking within code blocks.