### PR TITLE
Remove 1st version of watch testing link at start of post.

### DIFF
--- a/watched_keywords.txt
+++ b/watched_keywords.txt
@@ -7033,7 +7033,6 @@
 1543840054	Makyen	cloudways\.com
 1543860705	Makyen	dietplan1\.com
 1543864541	Makyen	dietplan[a-z0-9-]+\.(?<!usa\.)com(?#dietplan.com and dietplanusa.com are already blacklisted)
-1543873988	Makyen	^\s*<p>\s*?<a href="(?!(?:[a-z]+:)?//(?:[^/.]+\.)*(?:(?:example|apple|google|github|i\.stack\.imgur|stackexchange|stackoverflow|serverfault|superuser|askubuntu|stackapps)\.com|mathoverflow\.net|github\.io|edu|wikipedia\.org)[/"])\W*(?#Post begins with link; test for potential new detection; at watch 12649/12409/175/73)
 1543880555	Makyen	heavenmanga\.com
 1543886028	Tetsuya Yamamoto	captionandquote\.com
 1543886121	Tetsuya Yamamoto	airlinesticketvip\.com


### PR DESCRIPTION
For those posts found during the time it was being tested, the change to the already added updated version should reduce total FP and NAA to 40% of what they were.

This is being removed via a PR, because SD didn't permit me to `!!/unwatch` this entry. It [claimed the entry did not exist](https://chat.stackexchange.com/transcript/message/47966424#47966424).