### PR TITLE
Rescan certains posts again after a short period

### DIFF
--- a/bodyfetcher.py
+++ b/bodyfetcher.py
@@ -336,8 +336,8 @@ class BodyFetcher:
                     if GlobalVars.flovis is not None and 'question_id' in post:
                         GlobalVars.flovis.stage('bodyfetcher/api_response/spam', site, post['question_id'],
                                                 {'post': pnb, 'check_if_spam': [is_spam, reason, why]})
-                    if should_rescan_later(post_, reasons, why):
-                        rescan_later(post_, reasons, why)
+                    if should_rescan_later(post_, reason, why):
+                        rescan_later(post_, reason, why)
                     else:
                         handle_spam(post=post_, reasons=reason, why=why)
                 except Exception as e:

--- a/bodyfetcher.py
+++ b/bodyfetcher.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-from spamhandling import handle_spam, check_if_spam
+from spamhandling import handle_spam, check_if_spam, should_rescan_later, rescan_later
 from datahandling import (add_or_update_api_data, clear_api_data, store_bodyfetcher_queue, store_bodyfetcher_max_ids,
                           store_queue_timings)
 from chatcommunicate import tell_rooms_with
@@ -336,9 +336,10 @@ class BodyFetcher:
                     if GlobalVars.flovis is not None and 'question_id' in post:
                         GlobalVars.flovis.stage('bodyfetcher/api_response/spam', site, post['question_id'],
                                                 {'post': pnb, 'check_if_spam': [is_spam, reason, why]})
-                    handle_spam(post=post_,
-                                reasons=reason,
-                                why=why)
+                    if should_rescan_later(post_, reasons, why):
+                        rescan_later(post_, reasons, why)
+                    else:
+                        handle_spam(post=post_, reasons=reason, why=why)
                 except Exception as e:
                     log('error', "Exception in handle_spam:", e)
             elif GlobalVars.flovis is not None and 'question_id' in post:

--- a/datahandling.py
+++ b/datahandling.py
@@ -181,9 +181,7 @@ def is_code_privileged(site, user_id):
 
 def update_reason_weights():
     d = {'last_updated': datetime.utcnow().date()}
-    items = metasmoke.Metasmoke.get_reason_weights()
-    if not items:
-        return  # No update
+    items = metasmoke.Metasmoke.get_reason_weights() or {}
     for item in items:
         d[item['reason_name'].lower()] = item['weight']
     GlobalVars.reason_weights = d

--- a/spamhandling.py
+++ b/spamhandling.py
@@ -116,7 +116,7 @@ def should_rescan_later(post, reasons, why):
 def rescan_later(previous_post, previous_reasons, previous_why, time=30):
     # TODO: populate this function
     def rescan():
-        nonlocal previous_post, previous_reasons, previous_why, timeout
+        nonlocal previous_post, previous_reasons, previous_why, time
         post = api_get_post(previous_post.post_url)
         if not post:
             # Something wrong, handle previous result

--- a/spamhandling.py
+++ b/spamhandling.py
@@ -91,7 +91,6 @@ def check_if_spam(post):
     # This is required because !!/report will check for 3rd tuple item to decide if it's not spam or spam but ignored
 
 
-
 # noinspection PyMissingTypeHints
 def check_if_spam_json(json_data):
     try:
@@ -118,7 +117,7 @@ def rescan_later(previous_post, previous_reasons, previous_why, time=30):
     # TODO: populate this function
     def rescan():
         nonlocal previous_post, previous_reasons, previous_why, timeout
-        post = api_get_post(post.post_url)
+        post = api_get_post(previous_post.post_url)
         if not post:
             # Something wrong, handle previous result
             handle_spam(previous_post, previous_reasons, previous_why)

--- a/spamhandling.py
+++ b/spamhandling.py
@@ -108,7 +108,7 @@ def should_rescan_later(post, reasons, why):
     # Whether a post should be re-scanned later, see https://github.com/Charcoal-SE/metasmoke/issues/565
     if post.post_site == "wordpress.stackexchange.com" and not post.is_answer and \
             "bad keyword in body" in reasons and "manually reported question" not in reasons and \
-            sum_weight(reasons) <= 100:
+            0 < sum_weight(reasons) <= 100:
         if 2 <= datetime.utcnow().hour <= 14:  # Extended "spam hour"
             return True
     return False
@@ -120,14 +120,14 @@ def rescan_later(previous_post, previous_reasons, previous_why, time=30):
         nonlocal previous_post, previous_reasons, previous_why, timeout
         post = api_get_post(post.post_url)
         if not post:
-            # Something wrong
+            # Something wrong, handle previous result
             handle_spam(previous_post, previous_reasons, previous_why)
         if post.title == previous_post.title and post.body == previous_post.body:
-            # Nothing changed
+            # Nothing changed, save some CPU
             handle_spam(previous_post, previous_reasons, previous_why)
         is_spam, reasons, why = check_if_spam(post)
         if is_spam:
-            why = why.rstrip("\n") + "\n\nPost is edited in grace period\nPreviously caught for reasons: " + \
+            why = why.rstrip("\n") + "\n\nPost is edited in grace period\nPreviously caught for: " + \
                 ", ".join(previous_reasons).capitalize()
             handle_spam(post, reasons, why)
     return Tasks.later(rescan, after=time)


### PR DESCRIPTION
See Charcoal-SE/metasmoke#565 for more info.

Rescans a post instead of handling scan results directly if it meets certain criteria:

- is a question
- is on WordPress Development
- caught for "bad keyword in body"
- has an aggregate reason weight of no more than 100 for its initial version
- during spam hour (extended to 2 AM to 2 PM UTC - 2 hours before and after typical spam hour)