### PR TITLE
Run network-based spam checks in an alternate thread

### DIFF
--- a/findspam.py
+++ b/findspam.py
@@ -301,21 +301,24 @@ class FindSpam:
         result = []
         why_title, why_username, why_body = [], [], []
 
-        def alternate_job():
+        def alternate_job(rule):
             nonlocal result, why_title, why_username, why_body
-            for rule in FindSpam.rules_alt:
-                title, username, body = rule.match(post)
-                if title[0]:
-                    result.append(title[1])
-                    why_title.append(title[2])
-                if username[0]:
-                    result.append(username[1])
-                    why_username.append(username[2])
-                if body[0]:
-                    result.append(body[1])
-                    why_body.append(body[2])
-        alt_thread = Thread(target=alternate_job)
-        alt_thread.start()
+            title, username, body = rule.match(post)
+            if title[0]:
+                result.append(title[1])
+                why_title.append(title[2])
+            if username[0]:
+                result.append(username[1])
+                why_username.append(username[2])
+            if body[0]:
+                result.append(body[1])
+                why_body.append(body[2])
+
+        alt_threads = []
+        for rule in FindSpam.rules_alt:
+            thread = Thread(target=alternate_job)
+            alt_threads.append(thread)
+            thread.start()
 
         for rule in FindSpam.rules:
             title, username, body = rule.match(post)
@@ -328,7 +331,9 @@ class FindSpam:
             if body[0]:
                 result.append(body[1])
                 why_body.append(body[2])
-        alt_thread.join()
+
+        for thread in alt_threads:
+            thread.join()
 
         result = list(set(result))
         result.sort()

--- a/findspam.py
+++ b/findspam.py
@@ -297,6 +297,22 @@ class FindSpam:
     def test_post(post):
         result = []
         why_title, why_username, why_body = [], [], []
+        def alternate_job():
+            nonlocal result, why_title, why_username, why_body
+            for rule in FindSpam.rules_alt:
+                title, username, body = rule.match(post)
+                if title[0]:
+                    result.append(title[1])
+                    why_title.append(title[2])
+                if username[0]:
+                    result.append(username[1])
+                    why_username.append(username[2])
+                if body[0]:
+                    result.append(body[1])
+                    why_body.append(body[2])
+        alt_thread = Thread(target=alternate_job)
+        alt_thread.start()
+
         for rule in FindSpam.rules:
             title, username, body = rule.match(post)
             if title[0]:
@@ -308,18 +324,8 @@ class FindSpam:
             if body[0]:
                 result.append(body[1])
                 why_body.append(body[2])
-        # TODO: get the following for-loop to run in an alternate thread
-        for rule in FindSpam.rules_alt:
-            title, username, body = rule.match(post)
-            if title[0]:
-                result.append(title[1])
-                why_title.append(title[2])
-            if username[0]:
-                result.append(username[1])
-                why_username.append(username[2])
-            if body[0]:
-                result.append(body[1])
-                why_body.append(body[2])
+        alt_thread.join()
+
         result = list(set(result))
         result.sort()
         why = "\n".join(why_title + why_username + why_body).strip()

--- a/findspam.py
+++ b/findspam.py
@@ -12,6 +12,7 @@ from datetime import datetime
 import time
 import os
 import os.path as path
+from threading import Thread
 
 # noinspection PyPackageRequirements
 import tld
@@ -299,6 +300,7 @@ class FindSpam:
         start_time = time.time()
         result = []
         why_title, why_username, why_body = [], [], []
+
         def alternate_job():
             nonlocal result, why_title, why_username, why_body
             for rule in FindSpam.rules_alt:
@@ -1016,7 +1018,8 @@ def bad_ns_for_url_domain(s, site):
 # This applies to all answers, and non-SO questions
 @create_rule("potentially bad NS for domain in {}", body_summary=True, stripcodeblocks=True, answer=False,
              sites=["stackoverflow.com"], alternate=True)
-@create_rule("potentially bad NS for domain in {}", body_summary=True, stripcodeblocks=True, question=False, alternate=True)
+@create_rule("potentially bad NS for domain in {}", body_summary=True, stripcodeblocks=True, question=False,
+             alternate=True)
 def watched_ns_for_url_domain(s, site):
     return ns_for_url_domain(s, site, [
         # Don't forget the trailing dot on the resolved name here either!
@@ -1106,7 +1109,7 @@ def asn_for_url_host(s, site, asn_list):
     return False, ""
 
 
-@create_rule("potentially bad ASN for hostname in {}", body_summary=True, stripcodeblocks=Truealternate=True)
+@create_rule("potentially bad ASN for hostname in {}", body_summary=True, stripcodeblocks=True, alternate=True)
 def watched_asn_for_url_hostname(s, site):
     return asn_for_url_host(
         s, site,

--- a/findspam.py
+++ b/findspam.py
@@ -962,7 +962,8 @@ def ns_for_url_domain(s, site, nslist):
     return False, ""
 
 
-@create_rule("potentially problematic NS configuration in {}", stripcodeblocks=True, body_summary=True)
+@create_rule("potentially problematic NS configuration in {}", stripcodeblocks=True, body_summary=True,
+             alternate=True)
 def ns_is_host(s, site):
     '''
     Check if the host name in a link resolves to the same IP address
@@ -987,7 +988,7 @@ def ns_is_host(s, site):
     return False, ''
 
 
-@create_rule("bad NS for domain in {}", body_summary=True, stripcodeblocks=True)
+@create_rule("bad NS for domain in {}", body_summary=True, stripcodeblocks=True, alternate=True)
 def bad_ns_for_url_domain(s, site):
     return ns_for_url_domain(s, site, [
         # Don't forget the trailing dot on the resolved name!
@@ -1014,8 +1015,8 @@ def bad_ns_for_url_domain(s, site):
 
 # This applies to all answers, and non-SO questions
 @create_rule("potentially bad NS for domain in {}", body_summary=True, stripcodeblocks=True, answer=False,
-             sites=["stackoverflow.com"])
-@create_rule("potentially bad NS for domain in {}", body_summary=True, stripcodeblocks=True, question=False)
+             sites=["stackoverflow.com"], alternate=True)
+@create_rule("potentially bad NS for domain in {}", body_summary=True, stripcodeblocks=True, question=False, alternate=True)
 def watched_ns_for_url_domain(s, site):
     return ns_for_url_domain(s, site, [
         # Don't forget the trailing dot on the resolved name here either!
@@ -1105,7 +1106,7 @@ def asn_for_url_host(s, site, asn_list):
     return False, ""
 
 
-@create_rule("potentially bad ASN for hostname in {}", body_summary=True, stripcodeblocks=True)
+@create_rule("potentially bad ASN for hostname in {}", body_summary=True, stripcodeblocks=Truealternate=True)
 def watched_asn_for_url_hostname(s, site):
     return asn_for_url_host(
         s, site,
@@ -1484,7 +1485,8 @@ def toxic_check(post):
 
 
 if GlobalVars.perspective_key:  # don't bother if we don't have a key, since it's expensive
-    toxic_check = create_rule("toxic {} detected", func=toxic_check, whole_post=True, max_rep=101, max_score=2)
+    toxic_check = create_rule("toxic {} detected", func=toxic_check, whole_post=True, max_rep=101, max_score=2,
+                              alternate=True)
 
 
 @create_rule("body starts with title and ends in URL", whole_post=True, answer=False,


### PR DESCRIPTION
We have a few network-based checks like "bad NS", "bad ASN", "problematic NS config" and Google Perspective. Network is usually slow compared to calculation tasks like RegEx matching. As we're currently applying all checks on a post using a single `for` loop, the overall time taken to scan a post would likely be affect a lot by network instability. Moving all these network-based checks to an alternate thread should give the overall time taken a boost, assuming all these network request functions releases the GIL when making the requests.

I'll pull this on my backup instance and run it for a few days to gather some statistics and see how it actually performs. The code in this PR should be always good to merge once CI passes.