### PR TITLE
Fix watch for v.ht

### DIFF
--- a/blacklisted_websites.txt
+++ b/blacklisted_websites.txt
@@ -2727,7 +2727,7 @@ machomanhealth\.com
 cryptoexchangescript\.com
 clickbank\.net(?!.*?</?code>)
 bullguard-support\.co\.uk
-v\.ht
+//v\.ht
 cutt\.us
 weblium\.com
 easyprintersupport\.com


### PR DESCRIPTION
v.ht currently has a high inaccuracy rate, and catches posts such as [this one](https://metasmoke.erwaysoftware.com/post/168765) where the URL contains an HTML file that ends with `v` (`https?://.*v\.html`). Prefixing the watch with `//` removes all the false positives.

It does also exclude 10 true positives that were caught for the same reason as several of the false positives: HTML file ending with v. These 10 posts can be viewed [here](https://metasmoke.erwaysoftware.com/search?body=%28%3F%3C%21http%3A%2F%2F%29v%5C.ht&body_is_regex=1&feedback_filter=tp&utf8=%E2%9C%93). I've also put up various watches for other patterns seen in the post as well, so this shouldn't reduce coverage