### PR TITLE
Rebalance checks for trolling-type spam

### DIFF
--- a/findspam.py
+++ b/findspam.py
@@ -1516,31 +1516,10 @@ def strip_urls_and_tags(s):
     return URL_REGEX.sub("", TAG_REGEX.sub("", s))
 
 
-@create_rule("mostly dots in {}", max_rep=50, sites=["codegolf.stackexchange.com"])
-def mostly_dots(s, site):
-    if not s:
-        return False, ""
-
-    # Strip code blocks here rather than with `stripcodeblocks` so we get the length of the whole post
-    body = regex.sub(r"(?s)<pre([\w=\" -]*)?>.*?</pre>", "", s)
-    body = regex.sub(r"(?s)<code>.*?</code>", "", body)
-
-    body = TAG_REGEX.sub("", body)
-
-    s = TAG_REGEX.sub("", s)
-    if not s:
-        return False, ""
-
-    dot_count = body.count(".")
-    if dot_count / len(s) >= 0.4:
-        return True, u"Post contains {} dots out of {} characters".format(dot_count, len(s))
-    else:
-        return False, ""
-
-
-@create_rule("mostly punctuation marks in {}",
-             sites=["math.stackexchange.com", "mathoverflow.net"])
+@create_rule("mostly punctuation marks in {}", max_rep=50,
+             sites=["math.stackexchange.com", "mathoverflow.net", "codegolf.stackexchange.com"])
 def mostly_punctuations(s, site):
+    # Strip code blocks here rather than with `stripcodeblocks` so we get the length of the whole post in s
     body = regex.sub(r"(?s)<pre([\w=\" -]*)?>.*?</pre>", "", s)
     body = regex.sub(r"(?s)<code>.*?</code>", "", body)
     body = strip_urls_and_tags(body)
@@ -1549,39 +1528,35 @@ def mostly_punctuations(s, site):
         return False, ""
 
     punct_re = regex.compile(r"[[:punct:]]")
-    all_punc = punct_re.findall(body.replace(".", ""))
+    all_punc = punct_re.findall(body)
     if not all_punc:
         return False, ""
 
-    all_punc_set = list(set(all_punc))  # Remove duplicate
-    all_counts = [all_punc.count(punc) for punc in all_punc_set]
-    count = max(all_counts)
-    frequency = count / len(s)
-    max_punc = all_punc_set[all_counts.index(count)]
+    num_punc = len(all_punc)
+    all_punc_set = list(set(all_punc))  # Remove duplicates
+    overall_frequency = num_punc / len(s)
 
-    if frequency >= PUNCTUATION_RATIO:
-        return True, u"Post contains {} marks of {!r} out of {} characters".format(count, max_punc, len(s))
+    if overall_frequency >= PUNCTUATION_RATIO:
+        return True, u"Post contains {} marks of {!r} out of {} characters".format(num_punc,
+                                                                                   "".join(all_punc_set), len(s))
     else:
         return False, ""
 
 
-# TODO: split this function into two
-def no_whitespace(s, site, body=True):
-    if (not body) and regex.compile(r"(?is)^[0-9a-z]{20,}\s*$").match(s):
-        return True, "No whitespace or formatting in title"
-    elif body and regex.compile(r"(?is)^<p>[0-9a-z]+</p>\s*$").match(s):
-        return True, "No whitespace or formatting in body"
-    return False, ""
-
-
 @create_rule("no whitespace in {}", body=False, max_rep=10000, max_score=10000)
 def no_whitespace_title(s, site):
-    return no_whitespace(s, site, body=False)
+    if regex.compile(r"(?is)^[0-9a-z]{20,}\s*$").match(s):
+        return True, "No whitespace or formatting in title"
+    else:
+        return False, ""
 
 
 @create_rule("no whitespace in {}", title=False, max_rep=10000, max_score=10000)
 def no_whitespace_body(s, site):
-    return no_whitespace(s, site, body=True)
+    if regex.compile(r"(?is)^<p>[0-9a-z]+</p>\s*$").match(s):
+        return True, "No whitespace or formatting in body"
+    else:
+        return False, ""
 
 
 def toxic_check(post):
@@ -2127,10 +2102,6 @@ create_rule("numbers-only title",
             r"^(?=.*[0-9])[^\pL]*$",
             sites=["math.stackexchange.com"],
             body=False, max_rep=50, max_score=5)
-# One unique character in title
-create_rule("{} has only one unique char",
-            r"^(.)\1+$",
-            body=False, max_rep=1000000, max_score=10000)
 # Parenting troll
 create_rule("bad keyword in {}",
             r"(?i)\b(erica|jeff|er1ca|spam|moderator)\b",


### PR DESCRIPTION
These changes were prompted after [Samuel Liew](https://stackoverflow.com/users/584192/samuel-liew) flagged [this](https://metasmoke.erwaysoftware.com/post/170959) post for admin attention after it recieved 4 autoflags due to the title alone (!!!). After some investigation of our checks, it became clear that we have a fair bit of overlap between many of the rules.

Changes performed: 
### Disable 'title has only one unique character' rule

Any posts caught by this rule will *always* be caught by other existing reasons: mainly 'repeating characters in title', but also 'mostly punctuation in title', or 'mostly dots in title'. As such, this reason is artificially inflating the reason weight of many posts by 95. This is the main reason that the aforementioned post was incorrectly autoflagged (without it, the reason weight would have been only 121, which is pretty much outside autoflagging range)

### Merge 'mostly dots' rule into 'mostly punctuation' rule

These two reasons are almost identical: 'mostly punctuation' detects any post with a >42% proportion of any punctuation character other than `.` (a dot), whilst 'mostly dots' detects any post with a >40% proportion of dots. As such, the two reasons have been merged into 'mostly punctuation', using the 42% ratio from 'mostly punctuation', the rep limit from 'mostly dots', and excluded sites from both rules.

Side note: how on earth did we decide to make the threshold exactly *42* percent, not 40 or 45 or something like that? 

Side side note: it looks like the main reason that 'mostly dots' exists as a separate reason (as simple `..............................` posts are otherwise caught by 'repeating character') is for posts which attempt to obfuscate keywords by putting a dot between every letter ([e.g. 1](https://metasmoke.erwaysoftware.com/post/61694), [e.g. 2](https://metasmoke.erwaysoftware.com/post/106489)). The newly merged 'mostly punctuation' reason still successfully catches theses posts (or at least, still catches these two examples ;) ). 

Side side side note: [Relevant XKCD](https://xkcd.com/541/)

Side side side side note: does anyone remember the relevant xkcd comic about P.P.P.P.P.S etc?

### Make 'mostly punctuation' consider *all* punctuation characters, not just the most prominent

Although 'mostly punctuation' currently searches for *all* punctuation marks in a post.... it will only trigger if a *single* type of punctuation mark makes up more than 42% of the post (contrary to the reason name). Thus, `//;/;/,///[/[/'//;/'//'//[/l/,//` will be caught (because `/` has enough of a majority), whilst `/.,/;/].,/-./,.''];=,'/` will not (because no character has enough of a majority). I have modified this behaviour so that it better matches the reason name (i.e. if a post is comprised >42% of punctuation, then it will be caught).

**Question**: On short titles, do you think a threshold of 42% will accidentally catch a few programming questions on SO that have code in their title? Note that disabling this rule on titles is not an option, as it will stop titles like `.......................` from being caught (since there is no 'mostly dots' reason anymore).

### Refactor redundant helper function for 'no whitespace' checks

As per the `TODO` comment, I have split the function into it's constituents. Although the helper function saved 1 line of code, it also required an additional 2 lines of whitespace, so it doesn't really do anything useful. 

---

So, my questions before we merge this:

1. (as mentioned before) Do you think the new logic for 'mostly punctuation' will cause FPs on titles containing code? Does the threshold need to be changed?
2. In performing these changes have I accidentally introduced new overlap between reasons, or accidentally stopped a particular type of post from being caught?
3. Do any of the other similarly-targeted reasons also need to be adjusted? For reference, here is a quick list of some related reasons that I came across: 
    - Repeating characters
    - Repeating words
    - Few unique characters
    - No whitespace
    - Mostly non-latin
    - Chinese character in title (is this overlapping with the previous one?)
    - Hindi character in title (see above)
    - Non-latin link
    - Numbers-only title