### PR TITLE
Add Stephen Kennedy to Charcoal HQ

### DIFF
--- a/rooms.yml
+++ b/rooms.yml
@@ -135,8 +135,9 @@ stackexchange.com:
       - 214848   # Michael Dodd
       - 14688437 # double-beep
       - 8505551  # TuringTux
-      - 11311023   # avazula
-      - 11267045   # MEE the setup wizard
+      - 11311023 # avazula
+      - 11267045 # MEE the setup wizard
+      - 158319   # Stephen Kennedy
 
   65945:  # Charcoal Test
     commands: true


### PR DESCRIPTION
Creating a PR for visibility.

SOCVR room owner, over 1000 feedbacks in Metasmoke (1.13% invalid but none in the last month).