### PR TITLE
Don't post the title in chat when it's been identified as offensive

### DIFF
--- a/spamhandling.py
+++ b/spamhandling.py
@@ -136,8 +136,12 @@ def handle_spam(post, reasons, why):
         # in a proper way in chat messages.
         sanitized_title = parsing.sanitize_title(post.title if not post.is_answer else post.parent.title)
         sanitized_title = escape_format(sanitized_title).strip()
+
         # Remove title if it is potentially offensive
-        message_title = sanitized_title if 'offensive title detected' not in reasons else '(Potentially offensive title -- see MS for details)'
+        if 'offensive title detected' not in reasons:
+            message_title = sanitized_title
+        else:
+            message_title = '(Potentially offensive title -- see MS for details)'
 
         prefix = u"[ [SmokeDetector](//git.io/vyDZv) ]"
         if GlobalVars.metasmoke_key:

--- a/spamhandling.py
+++ b/spamhandling.py
@@ -136,6 +136,8 @@ def handle_spam(post, reasons, why):
         # in a proper way in chat messages.
         sanitized_title = parsing.sanitize_title(post.title if not post.is_answer else post.parent.title)
         sanitized_title = escape_format(sanitized_title).strip()
+        # Remove title if it is potentially offensive
+        message_title = sanitized_title if 'offensive title detected' not in reasons else '(Potentially offensive title -- see MS for details)'
 
         prefix = u"[ [SmokeDetector](//git.io/vyDZv) ]"
         if GlobalVars.metasmoke_key:
@@ -148,13 +150,13 @@ def handle_spam(post, reasons, why):
         edited = '' if not post.edited else ' \u270F\uFE0F'
         if not post.user_name.strip() or (not poster_url or poster_url.strip() == ""):
             s = " {{}}{}: [{}]({}){} by a deleted user on `{}`".format(
-                reason_weight_s, sanitized_title, post_url, edited, shortened_site)
+                reason_weight_s, message_title, post_url, edited, shortened_site)
             username = ""
         else:
             username = post.user_name.strip()
             escaped_username = escape_format(parsing.escape_markdown(username))
             s = " {{}}{}: [{}]({}){} by [{}]({}) on `{}`".format(
-                reason_weight_s, sanitized_title, post_url, edited, escaped_username, poster_url, shortened_site)
+                reason_weight_s, message_title, post_url, edited, escaped_username, poster_url, shortened_site)
 
         Tasks.do(metasmoke.Metasmoke.send_stats_on_post,
                  post.title_ignore_type, post_url, reasons, post.body, username,

--- a/test/test_spamhandling.py
+++ b/test/test_spamhandling.py
@@ -115,7 +115,22 @@ def test_check_if_spam_json(data, match):
     assert not is_spam
 
 
-def test_handle_spam():
+def test_handle_spam_repeating_characters():
+    GlobalVars.deletion_watcher = MagicMock()  # Mock the deletion watcher in test
+    chatcommunicate.tell_rooms = MagicMock()
+    post = mock_post(title='aaaaaaaaaaaaaa')
+    is_spam, reasons, why = check_if_spam(post)
+    handle_spam(post, reasons, why)
+    chatcommunicate.tell_rooms.assert_called_once_with(
+        StringMatcher(containing='aaaaaaaaaaaaaa', without='Potentially offensive title'),
+        ANY,
+        ANY,
+        notify_site=ANY,
+        report_data=ANY
+    )
+
+
+def test_handle_spam_offensive_title():
     GlobalVars.deletion_watcher = MagicMock()  # Mock the deletion watcher in test
     chatcommunicate.tell_rooms = MagicMock()
     post = mock_post(title='fuck')

--- a/test/test_spamhandling.py
+++ b/test/test_spamhandling.py
@@ -122,7 +122,7 @@ def test_handle_spam():
     is_spam, reasons, why = check_if_spam(post)
     handle_spam(post, reasons, why)
     chatcommunicate.tell_rooms.assert_called_once_with(
-        StringMatcher(containing='Potentially offensive title', without='fucker'),
+        StringMatcher(containing='Potentially offensive title', without='fuck'),
         ANY,
         ANY,
         notify_site=ANY,

--- a/test/test_spamhandling.py
+++ b/test/test_spamhandling.py
@@ -18,6 +18,7 @@ with open("test/data_test_spamhandling.txt", "r", encoding="utf-8") as f:
     # noinspection PyRedeclaration
     test_data_inputs = f.readlines()
 
+
 class StringMatcher:
     def __init__(self, containing, without):
         self.containing = containing
@@ -26,11 +27,12 @@ class StringMatcher:
     def __eq__(self, other):
         return self.containing in other and self.without not in other
 
-def mock_post(title = '',
-              body = '',
-              site = 'stackoverflow.com',
-              link = 'https://stackoverflow.com/a/1732454',
-              owner = {'link': 'https://stackoverflow.com/users/102937/robert-harvey'}):
+
+def mock_post(title='',
+              body='',
+              site='stackoverflow.com',
+              link='https://stackoverflow.com/a/1732454',
+              owner={'link': 'https://stackoverflow.com/users/102937/robert-harvey'}):
     api_response = {
         "title": title,
         "body": body,
@@ -39,6 +41,7 @@ def mock_post(title = '',
         "owner": owner
     }
     return Post(api_response=api_response)
+
 
 # noinspection PyMissingTypeHints
 @pytest.mark.parametrize("title, body, username, site, match", [
@@ -98,6 +101,7 @@ def test_check_if_spam(title, body, username, site, match):
     is_spam, reason, _ = check_if_spam(post)
     assert match == is_spam
 
+
 # noinspection PyMissingTypeHints
 @pytest.mark.parametrize("data, match", [
     (test_data_inputs[0], False)
@@ -110,19 +114,21 @@ def test_check_if_spam_json(data, match):
     is_spam, reason, _ = check_if_spam_json(None)
     assert not is_spam
 
+
 def test_handle_spam():
-    GlobalVars.deletion_watcher = MagicMock() # Mock the deletion watcher in test
+    GlobalVars.deletion_watcher = MagicMock()  # Mock the deletion watcher in test
     chatcommunicate.tell_rooms = MagicMock()
-    post = mock_post(title = 'fuck')
+    post = mock_post(title='fuck')
     is_spam, reasons, why = check_if_spam(post)
     handle_spam(post, reasons, why)
     chatcommunicate.tell_rooms.assert_called_once_with(
-        StringMatcher(containing = 'Potentially offensive title', without = 'fucker'),
+        StringMatcher(containing='Potentially offensive title', without='fucker'),
         ANY,
         ANY,
-        notify_site = ANY,
-        report_data = ANY
+        notify_site=ANY,
+        report_data=ANY
     )
+
 
 @pytest.mark.skipif(os.path.isfile("blacklistedUsers.p"),
                     reason="shouldn't overwrite file")


### PR DESCRIPTION
This adds handling for #3321.

If the 'offensive title detected' reason is detected when handling a spam post, the built message will not feature the post's title, but instead `(Potentially offensive title -- see MS for details)`. A test has also been added to verify this behavior.

One question: I took a quick look, but are there any other reasons that should cause the post title to be left out of the message?