### PR TITLE
Enforce Python >= 3.5.0

### DIFF
--- a/nocrash.py
+++ b/nocrash.py
@@ -18,7 +18,11 @@ if on_windows:
 else:
     from sh.contrib import git
 
-# Set the Python Executable based on this being stored - we refer to this later on for subprocess calls.
+if tuple(int(x) for x in platform.python_version_tuple()) < (3, 5, 0):
+    raise RuntimeError("Requires Python version 3.5 or newer.")
+
+# Set the Python Executable based on this being stored - we refer to this later
+# on for subprocess calls.
 PY_EXECUTABLE = sys.executable
 
 # Log to errorlog.txt so that !!/errorlogs shows us restarts


### PR DESCRIPTION
Discussions today in Charcoal HQ were in favor of doing enforcement of Python version 3.5.0 or newer for the use of SmokeDetector.

In this implementation, we adjust the static-defined tuple `(3, 5, 0)` to the version we want to define as "minimum supported" - in the case of Python 3.7.4 if we wanted this to be enforced as needing that version we would have `(3, 7, 4)` for the Tuple comparison.

This also includes a singular no-op for line length on a comment underneath it; this is, however, a no-op that has no other functional bearing.

All SmokeDetectors on this using nocrash.py may need to be manually restarted to get this change.