### PR TITLE
Change code_admin to blacklist_manager

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -8,7 +8,7 @@ group_defaults:
     enabled: true
 
 groups:
-  code-admins:
+  blacklisters:
     required: 1
     users:
       - angussidney

--- a/chatcommands.py
+++ b/chatcommands.py
@@ -1354,11 +1354,14 @@ def willbenotified(msg, room_id, se_site):
     return "No, you won't be notified for that site in that room."
 
 
-RETURN_NAMES = {"admin": ["admin", "admins"], "code_admin": ["code admin", "code admins"]}
+RETURN_NAMES = {"admin": ["admin", "admins"], "blacklist_manager": ["blacklist manager", "blacklist manager"]}
 VALID_ROLES = {"admin": "admin",
-               "code_admin": "code_admin",
+               "code_admin": "blacklist_manager",
                "admins": "admin",
-               "codeadmins": "code_admin"}
+               "codeadmins": "blacklist_manager",
+               "blacklist_manager": "blacklist_manager",
+               "blacklister": "blacklist_manager",
+               "blacklisters": "blacklist_manager"}
 
 
 # noinspection PyIncorrectDocstring,PyMissingTypeHints

--- a/gitmanager.py
+++ b/gitmanager.py
@@ -221,10 +221,10 @@ class GitManager:
     def remove_from_blacklist(cls, item, username, blacklist_type="", code_privileged=False, metasmoke_down=False):
         if not code_privileged:
             if metasmoke_down:
-                return False, "MS is offline, and I can't determine if you are a code admin or not. " \
-                              "If you are a code admin, then wait for MS to be back up before running this command."
+                return False, "MS is offline, and I can't determine if you are a blacklist manager or not. " \
+                              "If you are a blacklist manager, then wait for MS to be back up before running this command."
             else:
-                return False, "Ask a code admin to run that for you. Use `!!/whois blacklister` to find out who's here."
+                return False, "Ask a blacklist manager to run that for you. Use `!!/whois blacklister` to find out who's here."
 
         try:
             cls.gitmanager_lock.acquire()

--- a/gitmanager.py
+++ b/gitmanager.py
@@ -222,9 +222,11 @@ class GitManager:
         if not code_privileged:
             if metasmoke_down:
                 return False, "MS is offline, and I can't determine if you are a blacklist manager or not. " \
-                              "If you are a blacklist manager, then wait for MS to be back up before running this command."
+                              "If you are a blacklist manager, then wait for MS to be back up before running " \
+                              "this command."
             else:
-                return False, "Ask a blacklist manager to run that for you. Use `!!/whois blacklister` to find out who's here."
+                return False, "Ask a blacklist manager to run that for you. Use `!!/whois blacklister` to find " \
+                              "out who's here."
 
         try:
             cls.gitmanager_lock.acquire()

--- a/gitmanager.py
+++ b/gitmanager.py
@@ -224,7 +224,7 @@ class GitManager:
                 return False, "MS is offline, and I can't determine if you are a code admin or not. " \
                               "If you are a code admin, then wait for MS to be back up before running this command."
             else:
-                return False, "Ask a code admin to run that for you. Use `!!/whois code_admin` to find out who's here."
+                return False, "Ask a code admin to run that for you. Use `!!/whois blacklisters` to find out who's here."
 
         try:
             cls.gitmanager_lock.acquire()

--- a/gitmanager.py
+++ b/gitmanager.py
@@ -224,7 +224,7 @@ class GitManager:
                 return False, "MS is offline, and I can't determine if you are a code admin or not. " \
                               "If you are a code admin, then wait for MS to be back up before running this command."
             else:
-                return False, "Ask a code admin to run that for you. Use `!!/whois blacklisters` to find out who's here."
+                return False, "Ask a code admin to run that for you. Use `!!/whois blacklister` to find out who's here."
 
         try:
             cls.gitmanager_lock.acquire()


### PR DESCRIPTION
Ref: Charcoal-SE/metasmoke#682, Charcoal-SE/metasmoke#683.

Surprisingly few changes actually required in Smokey code to make this work. I haven't tested this, because I don't have a live instance available at the moment, but I have replaced or discounted all instances of `code_admin`. Code privilege checks come via the metasmoke v1 API, which should still return the correct results because its backing has been updated by metasmoke#682.

PR'd for sanity checking.