### PR TITLE
Use plural when blacklist managers are 2 or more

### DIFF
--- a/chatcommands.py
+++ b/chatcommands.py
@@ -1354,7 +1354,7 @@ def willbenotified(msg, room_id, se_site):
     return "No, you won't be notified for that site in that room."
 
 
-RETURN_NAMES = {"admin": ["admin", "admins"], "blacklist_manager": ["blacklist manager", "blacklist manager"]}
+RETURN_NAMES = {"admin": ["admin", "admins"], "blacklist_manager": ["blacklist manager", "blacklist managers"]}
 VALID_ROLES = {"admin": "admin",
                "code_admin": "blacklist_manager",
                "admins": "admin",


### PR DESCRIPTION
There's only singular for the blacklist manager role, which results in [this](https://chat.stackexchange.com/transcript/message/52254964#52254964) chat message.