### PR TITLE
Improve link unshortener function

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -209,7 +209,7 @@ def unshorten_link(url, request_type='GET', depth=10, explicitly_ignore_security
     for tries in range(depth):
         if response_code not in [301, 302, 303, 307, 308]:
             break
-        res = requests.request(request_type, url, headers=headers, stream=True)
+        res = requests.request(request_type, url, headers=headers, stream=True, allow_redirects=False)
         res.connection.close()  # Discard response body for GET requests
         response_code = res.status_code
         if 'Location' not in res.headers:

--- a/helpers.py
+++ b/helpers.py
@@ -203,6 +203,7 @@ def reload_modules():
 
 
 def unshorten_link(url, request_type='GET', depth=10, explicitly_ignore_security_warning=False):
+    orig_url = url
     response_code = 301
     headers = {'User-Agent': 'SmokeDetector/git (+https://github.com/Charcoal-SE/SmokeDetector)'}
     for tries in range(depth):
@@ -215,6 +216,8 @@ def unshorten_link(url, request_type='GET', depth=10, explicitly_ignore_security
             # No more redirects, stop
             break
         url = res.headers['Location']
+    else:
+        raise ValueError("Too many redirects ({}) for URL {!r}".format(depth, orig_url))
     return url
 
 

--- a/helpers.py
+++ b/helpers.py
@@ -202,28 +202,19 @@ def reload_modules():
     return result
 
 
-# FAIR WARNING: Sending HEAD requests to resolve a shortened link is generally okay - there aren't
-# as many exploits that work on just HEAD responses. If you specify sending a GET request, you
-# acknowledge that this will fetch the full, potentially unsafe response from the shortener.
-def unshorten_link(url, request_type='HEAD', explicitly_ignore_security_warning=False):
-    requesters = {
-        'GET': requests.get,
-        'HEAD': requests.head
-    }
-    if request_type not in requesters:
-        raise KeyError('Unavailable request_type {}'.format(request_type))
-    if request_type == 'GET' and not explicitly_ignore_security_warning:
-        raise SecurityError('Potentially unsafe request type GET not acknowledged')
-
-    requester = requesters[request_type]
+def unshorten_link(url, request_type='GET', depth=10, explicitly_ignore_security_warning=False):
     response_code = 301
     headers = {'User-Agent': 'SmokeDetector/git (+https://github.com/Charcoal-SE/SmokeDetector)'}
-    while response_code in {301, 302, 303, 307, 308}:
-        res = requester(url, headers=headers)
+    for tries in range(depth):
+        if response_code not in [301, 302, 303, 307, 308]:
+            break
+        res = requests.request(request_type, url, headers=headers, stream=True)
+        res.connection.close()  # Discard response body for GET requests
         response_code = res.status_code
-        if 'Location' in res.headers:
-            url = res.headers['Location']
-
+        if 'Location' not in res.headers:
+            # No more redirects, stop
+            break
+        url = res.headers['Location']
     return url
 
 

--- a/helpers.py
+++ b/helpers.py
@@ -202,12 +202,12 @@ def reload_modules():
     return result
 
 
-def unshorten_link(url, request_type='GET', depth=10, explicitly_ignore_security_warning=False):
+def unshorten_link(url, request_type='GET', depth=10):
     orig_url = url
     response_code = 301
     headers = {'User-Agent': 'SmokeDetector/git (+https://github.com/Charcoal-SE/SmokeDetector)'}
     for tries in range(depth):
-        if response_code not in [301, 302, 303, 307, 308]:
+        if response_code not in {301, 302, 303, 307, 308}:
             break
         res = requests.request(request_type, url, headers=headers, stream=True, allow_redirects=False)
         res.connection.close()  # Discard response body for GET requests


### PR DESCRIPTION
This patch includes the following fixes / improvements for the link unshortener helper

- Use GET requests

  Some link shortener servers reject HEAD requests or otherwise disregards the W3 specs for HEAD requests by returning something different (e.g. 200 OK, try `curl -I https://t.cn/blahblah`)

- Limit maximum redirect chain length

  Previous code would block if any url(s) in the chain loops and this function will unfortunately run forever. Now raises an exception instead. Default depth is 10 which should cover 99.9% of them. For reference, most browsers stop after 20 or so (see [this Stack Overflow answer](https://stackoverflow.com/a/36041063/5958455)).

- Allow arbitrary HTTP method (body is always discarded)

  Now that the response body is discarded (credits to [this answer](https://stackoverflow.com/a/23718527/5958455)), it's safe to use an arbitrary HTTP request method, though it's still potentially vulnerable if a server decides to send a lot of headers. ~~This remains unfixed however.~~ `requests` seems to limit this to 100 header lines and a total of 64 KiB for all headers by default, so we're not vulnerable.