### PR TITLE
Per-site "experimental-site-<site domain>" setting for rooms.yml

### DIFF
--- a/chatcommunicate.py
+++ b/chatcommunicate.py
@@ -326,16 +326,22 @@ def tell_rooms(msg, has, hasnt, notify_site="", report_data=None):
     msg = msg.rstrip()
     target_rooms = set()
 
+    # Go through the list of properties in "has" and add all rooms which have any of those properties
+    # to the target_rooms set. _room_roles contains a list of rooms for each property.
     for prop_has in has:
         if isinstance(prop_has, tuple):
+            # If the current prop_has is a tuple, then it's assumed to be a descriptor of a specific room.
+            # The format is: (_client.host, room.id)
             target_rooms.add(prop_has)
 
         if prop_has not in _room_roles:
+            # No rooms have this property.
             continue
 
         for room in _room_roles[prop_has]:
             if all(map(lambda prop: prop not in _room_roles or room not in _room_roles[prop], hasnt)):
                 if room not in _rooms:
+                    # If SD is not already in the room, then join the room.
                     site, roomid = room
                     deletion_watcher = room in _watcher_rooms
 

--- a/rooms.yml
+++ b/rooms.yml
@@ -6,7 +6,7 @@ stackexchange.com:
       - debug
       - metasmoke
       - all-sites
-      - experimental
+      - experimental-all-sites
       - no-offensive-mask
 
     privileges:
@@ -385,7 +385,7 @@ meta.stackexchange.com:
     
     msg_types:
       - all-sites
-      - experimental
+      - experimental-all-sites
       - offensive-mask
     
     privileges:

--- a/rooms.yml
+++ b/rooms.yml
@@ -5,7 +5,7 @@ stackexchange.com:
     msg_types:
       - debug
       - metasmoke
-      - all
+      - all-sites
       - experimental
       - no-offensive-mask
 
@@ -325,7 +325,7 @@ meta.stackexchange.com:
     watcher: true
 
     msg_types:
-      - all
+      - all-sites
       - metatavern
       - delay
       - site-no-stackoverflow.com
@@ -384,7 +384,7 @@ meta.stackexchange.com:
     commands: true
     
     msg_types:
-      - all
+      - all-sites
       - experimental
       - offensive-mask
     

--- a/spamhandling.py
+++ b/spamhandling.py
@@ -148,7 +148,7 @@ def handle_spam(post, reasons, why):
 
         if set(reasons) - GlobalVars.experimental_reasons == set() and \
                 not why.startswith("Post manually "):
-            chatcommunicate.tell_rooms(message, ("experimental",),
+            chatcommunicate.tell_rooms(message, ("experimental-all-sites",),
                                        without_roles, notify_site=post.post_site, report_data=(post_url, poster_url))
         else:
             if offensive_mask:

--- a/spamhandling.py
+++ b/spamhandling.py
@@ -148,7 +148,7 @@ def handle_spam(post, reasons, why):
 
         if set(reasons) - GlobalVars.experimental_reasons == set() and \
                 not why.startswith("Post manually "):
-            chatcommunicate.tell_rooms(message, ("experimental-all-sites",),
+            chatcommunicate.tell_rooms(message, ("experimental-all-sites", "experimental-site-" + post.post_site),
                                        without_roles, notify_site=post.post_site, report_data=(post_url, poster_url))
         else:
             if offensive_mask:

--- a/spamhandling.py
+++ b/spamhandling.py
@@ -152,14 +152,14 @@ def handle_spam(post, reasons, why):
                                        without_roles, notify_site=post.post_site, report_data=(post_url, poster_url))
         else:
             if offensive_mask:
-                chatcommunicate.tell_rooms(message, ("all", "site-" + post.post_site),
+                chatcommunicate.tell_rooms(message, ("all-sites", "site-" + post.post_site),
                                            without_roles + ("offensive-mask",), notify_site=post.post_site,
                                            report_data=(post_url, poster_url))
-                chatcommunicate.tell_rooms(clean_message, ("all", "site-" + post.post_site),
+                chatcommunicate.tell_rooms(clean_message, ("all-sites", "site-" + post.post_site),
                                            without_roles + ("no-offensive-mask",), notify_site=post.post_site,
                                            report_data=(post_url, poster_url))
             else:
-                chatcommunicate.tell_rooms(message, ("all", "site-" + post.post_site),
+                chatcommunicate.tell_rooms(message, ("all-sites", "site-" + post.post_site),
                                            without_roles, notify_site=post.post_site,
                                            report_data=(post_url, poster_url))
     except Exception as e:


### PR DESCRIPTION
In rooms.yml under `msg_types`:
* Change `experimental` to `experimental-all-sites`, which indicates that reports with only experimental reasons will be sent to the room for all sites.
* Add `experimental-site-<site domain>` (e.g. `experimental-site-stackoverflow.com`). This is similar to the format of the `site-<site domain>` entries which already exist.
* Change `all` to `all-sites`, so it's clearer the setting indicates the room accepts reports for all sites. "All sites" is the current actual meaning of `all`. Unfortunately, `all` within `msg_types` could be interpreted in various ways. Personally, when I see just `all`, I assume it means that the room should receive every single chat message type, not that it means just "all sites".

Implements #3768