### PR TITLE
Reenable DNS tests, catch on dns.resolver.NoNameservers (fix #3793)

### DIFF
--- a/blacklists.py
+++ b/blacklists.py
@@ -293,6 +293,10 @@ class YAMLParserNS(YAMLParserCIDR):
                     soa = dns.resolver.query(ns, 'soa')
                     log('debug', '{0} has no A record; SOA is {1}'.format(
                         ns, ';'.join(s.to_text() for s in soa)))
+            except dns.resolver.NoNameservers:
+                if not item.get('pass', None):
+                    log('debug', '{0} has no available servers to service DNS '
+                                 'request.'.format(ns))
             return True
 
         host_regex = regex.compile(r'^([a-z0-9][-a-z0-9]*\.){2,}$')

--- a/blacklists.py
+++ b/blacklists.py
@@ -295,7 +295,7 @@ class YAMLParserNS(YAMLParserCIDR):
                         ns, ';'.join(s.to_text() for s in soa)))
             except dns.resolver.NoNameservers:
                 if not item.get('pass', None):
-                    log('debug', '{0} has no available servers to service DNS '
+                    log('warn', '{0} has no available servers to service DNS '
                                  'request.'.format(ns))
             return True
 

--- a/blacklists.py
+++ b/blacklists.py
@@ -296,7 +296,7 @@ class YAMLParserNS(YAMLParserCIDR):
             except dns.resolver.NoNameservers:
                 if not item.get('pass', None):
                     log('warn', '{0} has no available servers to service DNS '
-                                 'request.'.format(ns))
+                                'request.'.format(ns))
             return True
 
         host_regex = regex.compile(r'^([a-z0-9][-a-z0-9]*\.){2,}$')

--- a/test/test_blacklists.py
+++ b/test/test_blacklists.py
@@ -60,8 +60,6 @@ def test_yaml_blacklist():
     assert '3.4.5.6' not in blacklist.parse()
     unlink('test_ip.yml')
 
-    # Temporarily disable to work aroud #3793
-    return None
     yaml_validate_existing('blacklisted_cidrs.yml', YAMLParserCIDR)
     yaml_validate_existing('watched_cidrs.yml', YAMLParserCIDR)
 
@@ -94,13 +92,9 @@ def test_yaml_asn():
     assert '345' not in blacklist.parse()
     unlink('test_asn.yml')
 
-    # Temporarily disable to work aroud #3793
-    return None
     yaml_validate_existing('watched_asns.yml', YAMLParserASN)
 
 
 def test_yaml_nses():
-    # Temporarily disable to work around #3793
-    return None
     yaml_validate_existing('blacklisted_nses.yml', YAMLParserNS)
     yaml_validate_existing('watched_nses.yml', YAMLParserNS)


### PR DESCRIPTION
This should fix #3793 as it now handles and catches upon the unhandled `dns.resolver.NoNameservers` error that was breaking CI when DNS SERVFAILs are encountered.