### PR TITLE
Added lock protection

### DIFF
--- a/bodyfetcher.py
+++ b/bodyfetcher.py
@@ -248,6 +248,7 @@ class BodyFetcher:
         self.api_data_lock.release()
 
         message_hq = ""
+        GlobalVars.apiquota_rw_lock.acquire()
         if "quota_remaining" in response:
             if response["quota_remaining"] - GlobalVars.apiquota >= 5000 and GlobalVars.apiquota >= 0:
                 tell_rooms_with("debug", "API quota rolled over with {0} requests remaining. "
@@ -272,6 +273,7 @@ class BodyFetcher:
             GlobalVars.apiquota = response["quota_remaining"]
         else:
             message_hq = "The quota_remaining property was not in the API response."
+        GlobalVars.apiquota_rw_lock.release()
 
         if "error_message" in response:
             message_hq += " Error: {} at {} UTC.".format(response["error_message"], time_request_made)

--- a/chatcommands.py
+++ b/chatcommands.py
@@ -949,9 +949,9 @@ def apiquota():
     Report how many API hits remain for the day
     :return: A string
     """
-    GlobalVars.api_request_lock.acquire()
+    GlobalVars.apiquota_rw_lock.acquire()
     current_apiquota = GlobalVars.apiquota
-    GlobalVars.api_request_lock.release()
+    GlobalVars.apiquota_rw_lock.release()
 
     return "The current API quota remaining is {}.".format(current_apiquota)
 

--- a/chatcommands.py
+++ b/chatcommands.py
@@ -952,7 +952,7 @@ def apiquota():
     GlobalVars.api_request_lock.acquire()
     current_apiquota = GlobalVars.apiquota
     GlobalVars.api_request_lock.release()
-    
+
     return "The current API quota remaining is {}.".format(current_apiquota)
 
 

--- a/chatcommands.py
+++ b/chatcommands.py
@@ -949,7 +949,11 @@ def apiquota():
     Report how many API hits remain for the day
     :return: A string
     """
-    return "The current API quota remaining is {}.".format(GlobalVars.apiquota)
+    GlobalVars.api_request_lock.acquire()
+    current_apiquota = GlobalVars.apiquota
+    GlobalVars.api_request_lock.release()
+    
+    return "The current API quota remaining is {}.".format(current_apiquota)
 
 
 # noinspection PyIncorrectDocstring

--- a/globalvars.py
+++ b/globalvars.py
@@ -128,6 +128,7 @@ class GlobalVars:
     no_se_activity_scan = False
 
     api_request_lock = threading.Lock()
+    apiquota_rw_lock = threading.Lock()
 
     num_posts_scanned = 0
     post_scan_time = 0

--- a/globalvars.py
+++ b/globalvars.py
@@ -127,12 +127,12 @@ class GlobalVars:
     standby_mode = False
     no_se_activity_scan = False
 
-    api_request_lock = threading.Lock()
-    apiquota_rw_lock = threading.Lock()
+    api_request_lock = threading.Lock() # Get this lock before making API requests
+    apiquota_rw_lock = threading.Lock() # Get this lock before reading/writing apiquota
 
     num_posts_scanned = 0
     post_scan_time = 0
-    posts_scan_stats_lock = threading.Lock()
+    posts_scan_stats_lock = threading.Lock() # Get this lock before reading/writing the above two
 
     config_parser = RawConfigParser()
 

--- a/globalvars.py
+++ b/globalvars.py
@@ -127,12 +127,12 @@ class GlobalVars:
     standby_mode = False
     no_se_activity_scan = False
 
-    api_request_lock = threading.Lock() # Get this lock before making API requests
-    apiquota_rw_lock = threading.Lock() # Get this lock before reading/writing apiquota
+    api_request_lock = threading.Lock()  # Get this lock before making API requests
+    apiquota_rw_lock = threading.Lock()  # Get this lock before reading/writing apiquota
 
     num_posts_scanned = 0
     post_scan_time = 0
-    posts_scan_stats_lock = threading.Lock() # Get this lock before reading/writing the above two
+    posts_scan_stats_lock = threading.Lock()  # Get this lock before reading/writing the above two
 
     config_parser = RawConfigParser()
 

--- a/metasmoke.py
+++ b/metasmoke.py
@@ -399,9 +399,9 @@ class Metasmoke:
             log('warning', "Metasmoke is down, not sending statistics")
             return
         # Get current apiquota from globalvars
-        GlobalVars.api_request_lock.acquire()
+        GlobalVars.apiquota_rw_lock.acquire()
         current_apiquota = GlobalVars.apiquota
-        GlobalVars.api_request_lock.release()
+        GlobalVars.apiquota_rw_lock.release()
 
         GlobalVars.posts_scan_stats_lock.acquire()
         if GlobalVars.post_scan_time != 0:

--- a/metasmoke.py
+++ b/metasmoke.py
@@ -398,16 +398,20 @@ class Metasmoke:
         if GlobalVars.metasmoke_down:
             log('warning', "Metasmoke is down, not sending statistics")
             return
-
+        # Get current apiquota from globalvars
+        GlobalVars.api_request_lock.acquire()
+        current_apiquota = GlobalVars.apiquota
+        GlobalVars.api_request_lock.release()
+        
         GlobalVars.posts_scan_stats_lock.acquire()
         if GlobalVars.post_scan_time != 0:
             posts_per_second = GlobalVars.num_posts_scanned / GlobalVars.post_scan_time
             payload = {'key': GlobalVars.metasmoke_key,
-                       'statistic': {'posts_scanned': GlobalVars.num_posts_scanned, 'api_quota': GlobalVars.apiquota,
+                       'statistic': {'posts_scanned': GlobalVars.num_posts_scanned, 'api_quota': current_apiquota,
                                      'post_scan_rate': posts_per_second}}
         else:
             payload = {'key': GlobalVars.metasmoke_key,
-                       'statistic': {'posts_scanned': GlobalVars.num_posts_scanned, 'api_quota': GlobalVars.apiquota}}
+                       'statistic': {'posts_scanned': GlobalVars.num_posts_scanned, 'api_quota': current_apiquota}}
 
         GlobalVars.post_scan_time = 0
         GlobalVars.num_posts_scanned = 0

--- a/metasmoke.py
+++ b/metasmoke.py
@@ -402,7 +402,7 @@ class Metasmoke:
         GlobalVars.api_request_lock.acquire()
         current_apiquota = GlobalVars.apiquota
         GlobalVars.api_request_lock.release()
-        
+
         GlobalVars.posts_scan_stats_lock.acquire()
         if GlobalVars.post_scan_time != 0:
             posts_per_second = GlobalVars.num_posts_scanned / GlobalVars.post_scan_time


### PR DESCRIPTION
Added lock protection to metasmoke.py and chatcommands.py regarding to the read operation of apiquota from GlobalVars.apiquota. The lock may be needed as the write operation in bodyfetcher.py may not be atomic, and hence without lock, half-written and corrupted data may be read - the same reason why metasmoke.py in method send_statistics acquired posts_scan_stats_lock before reading post scan statistics.