### PR TITLE
Multiple retries to initiate MS websocket

### DIFF
--- a/metasmoke.py
+++ b/metasmoke.py
@@ -82,7 +82,8 @@ class Metasmoke:
                 if not has_succeeded:
                     failed_connection_attempts += 1
                     if failed_connection_attempts > MAX_MS_WEBSOCKET_RETRIES:
-                        chatcommunicate.tell_rooms_with("debug", "Cannot initiate MS websocket. metasmoke_ws_t is now dead.")
+                        chatcommunicate.tell_rooms_with("debug", "Cannot initiate MS websocket." +
+                                                        "  metasmoke_ws_t is now dead.")
                         log('warning', "Cannot initiate MS websocket. metasmoke_ws_t is now dead.")
                         break
                     else:

--- a/metasmoke.py
+++ b/metasmoke.py
@@ -32,6 +32,7 @@ from socketscience import SocketScience
 import metasmoke_cache
 
 
+MAX_MS_WEBSOCKET_RETRIES = 5
 MAX_FAILURES = 10  # Preservative, 10 errors = MS down
 NO_ACTIVITY_PINGS_TO_STANDBY = 8
 NO_ACTIVITY_PINGS_TO_REPORT = 4
@@ -56,6 +57,7 @@ class Metasmoke:
     @staticmethod
     def init_websocket():
         has_succeeded = False
+        failed_connection_attemps = 0
         while GlobalVars.metasmoke_key != "":
             try:
                 Metasmoke.connect_websocket()
@@ -78,7 +80,13 @@ class Metasmoke:
                 GlobalVars.metasmoke_failures += 1
                 log('error', "Couldn't bind to MS websocket")
                 if not has_succeeded:
-                    break
+                    failed_connection_attempts += 1
+                    if failed_connection_attempts > MAX_MS_WEBSOCKET_RETRIES:
+                        log('warning', "Cannot initiate MS websocket. metasmoke_ws_t is now dead.")
+                        break
+                    else:
+                        #Wait and hopefully network issues will be solved
+                        time.sleep(10)
                 else:
                     time.sleep(10)
 

--- a/metasmoke.py
+++ b/metasmoke.py
@@ -83,8 +83,8 @@ class Metasmoke:
                     failed_connection_attempts += 1
                     if failed_connection_attempts > MAX_MS_WEBSOCKET_RETRIES:
                         chatcommunicate.tell_rooms_with("debug", "Cannot initiate MS websocket." +
-                                                        "  metasmoke_ws_t is now dead.")
-                        log('warning', "Cannot initiate MS websocket. metasmoke_ws_t is now dead.")
+                                                        "  Manual `!!/reboot` is required once MS is up")
+                        log('warning', "Cannot initiate MS websocket. metasmoke_ws_t is terminating.")
                         break
                     else:
                         # Wait and hopefully network issues will be solved

--- a/metasmoke.py
+++ b/metasmoke.py
@@ -58,7 +58,7 @@ class Metasmoke:
     def init_websocket():
         has_succeeded = False
         failed_connection_attempts = 0
-        while GlobalVars.metasmoke_key != "":
+        while GlobalVars.metasmoke_key != "" and GlobalVars.metasmoke_ws_host != "":
             try:
                 Metasmoke.connect_websocket()
                 has_succeeded = True
@@ -82,6 +82,7 @@ class Metasmoke:
                 if not has_succeeded:
                     failed_connection_attempts += 1
                     if failed_connection_attempts > MAX_MS_WEBSOCKET_RETRIES:
+                        chatcommunicate.tell_rooms_with("debug", "Cannot initiate MS websocket. metasmoke_ws_t is now dead.")
                         log('warning', "Cannot initiate MS websocket. metasmoke_ws_t is now dead.")
                         break
                     else:

--- a/metasmoke.py
+++ b/metasmoke.py
@@ -84,7 +84,8 @@ class Metasmoke:
                     if failed_connection_attempts > MAX_MS_WEBSOCKET_RETRIES:
                         chatcommunicate.tell_rooms_with("debug", "Cannot initiate MS websocket." +
                                                         "  Manual `!!/reboot` is required once MS is up")
-                        log('warning', "Cannot initiate MS websocket. metasmoke_ws_t is terminating.")
+                        log('warning', "Cannot initiate MS websocket." +
+                            " init_websocket() in metasmoke.py is terminating.")
                         break
                     else:
                         # Wait and hopefully network issues will be solved

--- a/metasmoke.py
+++ b/metasmoke.py
@@ -57,7 +57,7 @@ class Metasmoke:
     @staticmethod
     def init_websocket():
         has_succeeded = False
-        failed_connection_attemps = 0
+        failed_connection_attempts = 0
         while GlobalVars.metasmoke_key != "":
             try:
                 Metasmoke.connect_websocket()
@@ -85,7 +85,7 @@ class Metasmoke:
                         log('warning', "Cannot initiate MS websocket. metasmoke_ws_t is now dead.")
                         break
                     else:
-                        #Wait and hopefully network issues will be solved
+                        # Wait and hopefully network issues will be solved
                         time.sleep(10)
                 else:
                     time.sleep(10)


### PR DESCRIPTION
According to [this](https://github.com/Charcoal-SE/SmokeDetector/pull/3850#issuecomment-629596302) message

Implemented multiple retries to initiate MS websocket rather than only one attempt. Also implemented logging when initiation failed.