### PR TITLE
Catch exceptions in generator and fetch

### DIFF
--- a/metasmoke_cache.py
+++ b/metasmoke_cache.py
@@ -3,6 +3,7 @@ import datahandling
 import metasmoke
 import globalvars
 import tasks
+from helpers import log
 
 
 class MetasmokeCache:


### PR DESCRIPTION
According to issue #3631 

Added exception handler in generator() and fetch().
The handler in generator() will log the exception, and re-raise it
The handler in fetch() will terminate fetch() and return None, 'MISS-NOGEN'

This change may help to solve the problem, as the log message provided [here](https://chat.stackoverflow.com/transcript/message/48175386) indicates that the problem was caused by an uncaught exception repeatedly terminating SD, and hence triggering reversion before request_sender() in metasmoke.py was able to turn off MS.