### PR TITLE
Include a [visit] link in SD reports

### DIFF
--- a/spamhandling.py
+++ b/spamhandling.py
@@ -169,7 +169,8 @@ def handle_spam(post, reasons, why):
 def build_message(post, reasons):
     # This is the main report format. Username and user link are deliberately not separated as with title and post
     # link, because we may want to use "by a deleted user" rather than a username+link.
-    message_format = "{prefix_ms} {{reasons}} ({reason_weight}): [{title}]({post_url}) by {user} on `{site}`"
+    message_format = "{prefix_ms} {{reasons}} ({reason_weight}): " + \
+                     "[{title}]({post_url}) [ [visit]({post_url}) ] by {user} on `{site}`"
 
     # Post URL, user URL, and site details are all easy - just data from the post object, transformed a bit
     # via datahandling.


### PR DESCRIPTION
According to stale issue #3738 

Implemented [visit] link in SD reports, which links to the post. This link can be useful when the title of the post is of zero or very narrow width when rendered/displayed.
