### PR TITLE
Tell user why pattern is invalid

### DIFF
--- a/chatcommands.py
+++ b/chatcommands.py
@@ -323,7 +323,8 @@ def do_blacklist(blacklist_type, msg, force=False):
     try:
         pattern = rebuild_str(msg.content_source.split(" ", 1)[1])
     except IndexError:
-        raise CmdException("An invalid pattern was provided, please check your command.")
+        raise CmdException("An invalid pattern was provided, please check your command." +
+                           " The pattern is: {}".format(msg.content_source))
 
     has_unescaped_dot = ""
     if "number" not in blacklist_type:


### PR DESCRIPTION
Adjusted CmdException message for do_blacklist(), to show what pattern it is processing that triggered the error, for debug reasons. Theoretically, this error should never be triggered, as the command requires one argument and hence must be in the form "!!/blacklist-* some_regex", and hence the split() call will return two items and item [1] can be accessed as usual. The fact that an IndexError is raised indicates that msg.content_source contains no whitespace, which means that no argument is provided (hence there is some bug in other part of the code, likely in chatcommunicate.py)