### PR TITLE
Upgrade Flake8 to 3.8

### DIFF
--- a/chatcommands.py
+++ b/chatcommands.py
@@ -1332,23 +1332,23 @@ def bisect_number(msg, s):
         normalized_match.remove(verbatim_match)
         if normalized_match:
             l, f = verbatim_match
-            response = "Matched verbatim on line {} of {}, and also normalized on".format(l, f)
+            response = "Matched verbatim on line {0} of {1}, and also normalized on".format(l, f)
             for l, f in normalized_match:
-                response += "\n- line {} of {}".format(l, f)
+                response += "\n- line {0} of {1}".format(l, f)
             return response
         else:
             l, f = verbatim_match
-            return "Matched verbatim on [line {1} of {2}](https://github.com/{3}/blob/{4}/{2}#L{1})".format(
-                "", l, f, GlobalVars.bot_repo_slug, GlobalVars.commit.id)
+            return "Matched verbatim on [line {0} of {1}](https://github.com/{2}/blob/{3}/{1}#L{0})".format(
+                l, f, GlobalVars.bot_repo_slug, GlobalVars.commit.id)
     else:
         if len(normalized_match) == 1:
             l, f = normalized_match[0]
             return "Not matched verbatim, but normalized on " \
-                   "[line {1} of {2}](https://github.com/{3}/blob/{4}/{2}#L{1})".format(
-                       "", l, f, GlobalVars.bot_repo_slug, GlobalVars.commit.id)
+                   "[line {0} of {1}](https://github.com/{2}/blob/{3}/{1}#L{0})".format(
+                       l, f, GlobalVars.bot_repo_slug, GlobalVars.commit.id)
         response = "Not matched verbatim, but normalized on"
         for l, f in normalized_match:
-            response += "\n- line {} of {}".format(l, f)
+            response += "\n- line {0} of {1}".format(l, f)
         return response
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ websocket-client>=0.54.0
 coverage>=4.5.1
 pytest>=4.1.0
 phonenumbers>=8.8.11
-flake8~=3.6.0
+flake8~=3.8.0
 pep8-naming==0.7.0
 regex>=2018.2.21
 termcolor>=1.1.0

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 # Here's a good reference: https://lintlyci.github.io/Flake8Rules/
 ignore =
     E402,  # Module-level import not at top
+    E741,  # Ambiguous variable name (lowercase L)
     F401,  # Imported but unused
     F403,  # from import *
     F405,  # Same as above

--- a/ws.py
+++ b/ws.py
@@ -47,7 +47,7 @@ if os.path.isfile("plugin.py"):
         import plugin
     except Exception:
         exc_type, exc_obj, exc_tb = sys.exc_info()
-        error_msg = "{}: {}\n".format(exc_type.__name__, exc_obj, traceback.format_tb(exc_tb))
+        error_msg = "{}: {}\n{}".format(exc_type.__name__, exc_obj, traceback.format_tb(exc_tb))
         log('warning', "Error while importing plugin:\n" + error_msg)
         # Ignore and move on
 


### PR DESCRIPTION
As the title says

New complaints (from 3.6 to 3.8):

```text
./chatcommands.py:1336:17: E741 ambiguous variable name 'l'
./chatcommands.py:1341:20: F523 '...'.format(...) has unused arguments at position(s): 0
./chatcommands.py:1346:20: F523 '...'.format(...) has unused arguments at position(s): 0
./chatcommands.py:1350:13: E741 ambiguous variable name 'l'
./ws.py:50:21: F523 '...'.format(...) has unused arguments at position(s): 2
./findspam.py:1220:9: E741 ambiguous variable name 'l'
```

F523's are fixed, while E741's are ignored (we're using lowercase L as variable names for a good reason, could fix but not interested).