### PR TITLE
Minor changes in chatcommands.py: Added comments for threads

### DIFF
--- a/chatcommands.py
+++ b/chatcommands.py
@@ -1360,6 +1360,9 @@ def threads():
     :return: A string
     """
 
+    # Note: One may see multiple threads named "message_sender", and they are started by ChatExchange,
+    # one for each chat server.
+    # The one started by SmokeDetector is named "message sender", without the underscore.
     threads_list = ["{ident}: {name}".format(ident=t.ident, name=t.name) for t in threading.enumerate()]
 
     return "\n".join(threads_list)


### PR DESCRIPTION
Added comments for threads, so next time someone runs this command, they do not need to figure all this out again.
"message sender" is started by SD.
"message_sender" is started by CE, one for each server.