### PR TITLE
Split link-at-beginning watch into new reason

### DIFF
--- a/findspam.py
+++ b/findspam.py
@@ -2265,6 +2265,14 @@ create_rule("potentially bad keyword in {}",
             all=False, sites=["workplace.stackexchange.com", "workplace.meta.stackexchange.com"],
             username=True, body_summary=False, body=False, title=False,
             max_rep=93, max_score=1)
-
+# Link at beginning of post; pulled from watchlist
+create_rule("link at beginning of {}",
+            r'^\s*<p>\s*(?:</?\w+/?>\s*)*<a href="(?!(?:[a-z]+:)?//(?:[^" >/.]*\.)*(?:(?:quora|medium'
+            r'|googleusercontent|youtube|microsoft|unity3d|wso|merriam-webster|oracle|magento|example'
+            r'l|apple|google|github|imgur|stackexchange|stackoverflow|serverfault|superuser|askubuntu)\.com'
+            r'|(?:(?:lvcharts|php|jsfiddle|mathoverflow)\.net)|github\.io|youtu\.be|edu|(?:(?:arxiv|drupal'
+            r'|python|isc|khronos|mongodb|open-std|dartlang|apache|pydata|gnu|js|wordpress|wikipedia)\.org))'
+            r'[/\"])\W*(?![\W\w]*?</(?:code|blockquote)>)',
+            title=False, username=False, body=True)
 
 FindSpam.reload_blacklists()

--- a/findspam.py
+++ b/findspam.py
@@ -2269,10 +2269,11 @@ create_rule("potentially bad keyword in {}",
 create_rule("link at beginning of {}",
             r'^\s*<p>\s*(?:</?\w+/?>\s*)*<a href="(?!(?:[a-z]+:)?//(?:[^" >/.]*\.)*(?:(?:quora|medium'
             r'|googleusercontent|youtube|microsoft|unity3d|wso|merriam-webster|oracle|magento|example'
-            r'l|apple|google|github|imgur|stackexchange|stackoverflow|serverfault|superuser|askubuntu)\.com'
+            r'|apple|google|github|imgur|stackexchange|stackoverflow|serverfault|superuser|askubuntu)\.com'
             r'|(?:(?:lvcharts|php|jsfiddle|mathoverflow)\.net)|github\.io|youtu\.be|edu|(?:(?:arxiv|drupal'
             r'|python|isc|khronos|mongodb|open-std|dartlang|apache|pydata|gnu|js|wordpress|wikipedia)\.org))'
             r'[/\"])\W*(?![\W\w]*?</(?:code|blockquote)>)',
-            title=False, username=False, body=True)
+            title=False, username=False, body=True,
+            max_re=32, max_score=1)
 
 FindSpam.reload_blacklists()

--- a/findspam.py
+++ b/findspam.py
@@ -2274,6 +2274,6 @@ create_rule("link at beginning of {}",
             r'|python|isc|khronos|mongodb|open-std|dartlang|apache|pydata|gnu|js|wordpress|wikipedia)\.org))'
             r'[/\"])\W*(?![\W\w]*?</(?:code|blockquote)>)',
             title=False, username=False, body=True,
-            max_re=32, max_score=1)
+            max_rep=32, max_score=1)
 
 FindSpam.reload_blacklists()

--- a/watched_keywords.txt
+++ b/watched_keywords.txt
@@ -6954,7 +6954,6 @@
 1544324468	Makyen	anonymous\W*(?:dot\W*)?squadd\W*(?:at\W*)?gmail\W*(?:dot\W*)?com(?#Obfuscated anonymous.squadd@gmail.com)
 1544337679	Shree	voodoospell\d*(?:@gmail\.com)
 1544351547	Makyen	^\s*<p>\s*(?:</?\w+/?>\s*)*<a href="(?:(?:[a-z]+:)?//(?:[^" >/.]*\.)*(?:youtube\.com|youtu\.be)[/"])\W*(?![\W\w]*?</(?:code|blockquote)>)(?#Separate start with youtube watch; lower TP rate, but most TP are not otherwise detected)
-1544351575	Makyen	^\s*<p>\s*(?:</?\w+/?>\s*)*<a href="(?!(?:[a-z]+:)?//(?:[^" >/.]*\.)*(?:(?:quora|medium|googleusercontent|youtube|microsoft|unity3d|wso|merriam-webster|oracle|magento|example|apple|google|github|imgur|stackexchange|stackoverflow|serverfault|superuser|askubuntu)\.com|(?:(?:lvcharts|php|jsfiddle|mathoverflow)\.net)|github\.io|youtu\.be|edu|(?:(?:arxiv|drupal|python|isc|khronos|mongodb|open-std|dartlang|apache|pydata|gnu|js|wordpress|wikipedia)\.org))[/"])\W*(?![\W\w]*?</(?:code|blockquote)>)
 1544398401	Makyen	swftoapkconverter\.com
 1544406739	Makyen	batikprasetyo\.com
 1544406846	Makyen	batikaqila\.com


### PR DESCRIPTION
[Discussed in CHQ](https://chat.stackexchange.com/transcript/11540?m=54586828#54586828). The reason has its own whitelist for now, until we have unified whitelist-checking.