### PR TITLE
location command redirected to rev

### DIFF
--- a/chatcommands.py
+++ b/chatcommands.py
@@ -817,16 +817,6 @@ def welcome(msg, other_user):
         raise CmdException(w_msg.format(room=msg.room.name, user=" @" + other_user, me=GlobalVars.chatmessage_prefix))
 
 
-# noinspection PyIncorrectDocstring
-@command()
-def location():
-    """
-    Returns the current location the application is running from
-    :return: A string with current location
-    """
-    return GlobalVars.location
-
-
 # noinspection PyIncorrectDocstring,PyProtectedMember
 @command(privileged=True)
 def master():
@@ -1378,7 +1368,7 @@ def threads():
 
 
 # noinspection PyIncorrectDocstring
-@command(aliases=["rev", "ver"])
+@command(aliases=["rev", "ver", "location"])
 def version():
     """
     Returns the current version of the application

--- a/test/test_chatcommands.py
+++ b/test/test_chatcommands.py
@@ -64,10 +64,6 @@ def test_alive():
     assert chatcommands.alive() in chatcommands.ALIVE_MSG
 
 
-def test_location():
-    assert chatcommands.location() == GlobalVars.location
-
-
 def test_version():
     assert chatcommands.version() == '{id} [{commit_name}]({repository}/commit/{commit_code})'.format(
         id=GlobalVars.location, commit_name=GlobalVars.commit_with_author_escaped,


### PR DESCRIPTION
The latter is a super set of the former. Doing so may also reduce the work in future maintenance/refactoring/development, as LoC is reduced and there is one less place to search/replace in case there is a change.