### PR TITLE
chatcommands.py: Implemented new commands stat and counter

### DIFF
--- a/REFDOC.md
+++ b/REFDOC.md
@@ -8,7 +8,7 @@
 > Note: methods return `None` unless noted otherwise.  
 
 > Note: for implementation details involving lock operations, `acquire ... release`
-may be implemented as either `acquire ... release`, `acquire try ... finally`, or `with ...`.
+is implemented using `with`  
 
 # File globalvars.py  
 ## Class GlobalVars.PostScanStat  
@@ -99,6 +99,8 @@ Automatically switch metasmoke status.
 - `ping_succeeded()`: Indicate a status ping success.
 - `enable_autoswitch(to_enable)`: Turn on or off auto switch.
 If `on` is `True`, auto switch is turned on. Otherwise auto switch is turned off.
+- `get_ping_failure()`: Get the count of consecutive ping failures.
+Negative value indicates consecutive ping successes.
 - `reset_switch()`: Reset class `Metasmoke.AutoSwitch` to default values.
 ### Thread safety  
 Yes.  
@@ -125,6 +127,7 @@ Decrease `ping_failure_counter` by `1`. Read `-ping_failure_counter` into `curre
 Decide if `current_counter` is greater than `MAX_SUCCESSES`, metasmoke status is down, and `current_auto` is `True`.
 If yes, issue a message to chat and call `ms_up()`.
 - `enable_autoswitch(to_enable)`: Obtain `rw_lock`. Set `autoswitch_is_on` to `to_enable`. Release `rw_lock`.
+- `get_ping_failure()`: Obtain `rw_lock`. Return `ping_failure_counter`. Release `rw_lock`.
 - `reset_switch()`: Obtain `rw_lock`. Set `ping_failure_counter` to `0`. Set `autoswitch_is_on` to `True`. Release `rw_lock`.
 #### Considerations  
 - Only status ping failures and successes should count for turning metasmoke on and off,

--- a/chatcommands.py
+++ b/chatcommands.py
@@ -785,6 +785,26 @@ def metasmoke(msg, alias_used):
            " Auto status switch: **{}abled**.".format("dis" if forced else "en")
 
 
+@command(aliases=["scan-stat", "statistics"])
+def stat():
+    """ Return post scan statistics. """
+    posts_scanned, scan_time, posts_per_second = GlobalVars.PostScanStat.get_stat()
+    stat_msg = "Posts scanned: {}; Scan time: {}".format(posts_scanned, scan_time)
+
+    rate_msg = ""
+    if posts_per_second:
+        rate_msg = "; Posts scanned per second: {}".format(posts_per_second)
+
+    return stat_msg + rate_msg
+
+
+@command(aliases=["counter", "internal-counter", "ping-failure"])
+def ping_failure_counter():
+    """ Return ping failure counter value of Metasmoke: AutoSwitch. """
+    counter = Metasmoke.AutoSwitch.get_ping_failure()
+    return "Current ping failure counter value: {}".format(counter)
+
+
 # noinspection PyIncorrectDocstring
 @command(aliases=["commands", "help"])
 def info():

--- a/metasmoke.py
+++ b/metasmoke.py
@@ -108,6 +108,12 @@ class Metasmoke:
                 chatcommunicate.tell_rooms_with("debug", switch_auto_msg)
 
         @staticmethod
+        def get_ping_failure():
+            """ Get ping failure count. Negative number is ping success count. """
+            with Metasmoke.AutoSwitch.rw_lock:
+                return Metasmoke.AutoSwitch.ping_failure_counter
+
+        @staticmethod
         def reset_switch():
             """ Reset class Metasmoke.AutoSwitch to default values """
             with Metasmoke.AutoSwitch.rw_lock:


### PR DESCRIPTION
Implemented new chat commands stat and counter.
- stat: get post scan statistics.
- counter: get metasmoke ping failure counter.

counter is to be distinguished from ms-status.