### PR TITLE
vision[\W_]*+20 removed from blacklist

### DIFF
--- a/bad_keywords.txt
+++ b/bad_keywords.txt
@@ -2287,7 +2287,6 @@ veyomax(?:[\W_]*+rx)?
 hemp[\W_]*+max[\W_]*+lab
 trim[\W_]*+fast[\W_]*+keto(?:[\W_]*+(?:australia|au|shark|tank|\d++|[\da-f]{4,}+))*
 ketokor
-vision[\W_]*+20
 vir?maxryn(?:[\W_]*+(?:review|malep?|enhancement|upgrade|\d++|[\da-f]{4,}+)s?)*
 Priest Ade
 arovanti(?:[\W_]*+(?:cream|creme|review|\d++|[\da-f]{4,}+))*


### PR DESCRIPTION
vision[\W_]*+20 removed for low accuracy 0.389. Should be moved to watchlist.