### PR TITLE
chatcommunicate.py: Ignore reply command if provided too many arguments

### DIFF
--- a/chatcommunicate.py
+++ b/chatcommunicate.py
@@ -574,6 +574,9 @@ def dispatch_reply_command(msg, reply, full_cmd, comment=True):
         assert min_arity == 1
 
         if max_arity == 1:
+            if args:
+                # Ignore, as the reply is likely not intended as a command.
+                return None
             return func(msg, original_msg=reply, alias_used=cmd, quiet_action=quiet_action)
         elif max_arity == 2:
             return func(msg, args, original_msg=reply, alias_used=cmd, quiet_action=quiet_action)

--- a/test/test_chatcommunicate.py
+++ b/test/test_chatcommunicate.py
@@ -397,7 +397,7 @@ def test_on_msg(get_last_messages, post_msg):
             },
 
             "id": 1000,
-            "content": "@SmokeDetector why   "
+            "content": "@SmokeDetector why"
         }
     }, spec=chatcommunicate.events.MessageEdited)
 


### PR DESCRIPTION
Those replies are unlikely intended as actual commands.