### PR TITLE
Send post Markdown from SE API to MS

### DIFF
--- a/apigetpost.py
+++ b/apigetpost.py
@@ -63,7 +63,7 @@ def api_get_post(post_url):
     post_id, site, post_type = d
     if post_type == "answer":
         api_filter = r"!4z6S)cPO)zvpuDWsWTAUW(kaV6K6thsqi1tlYa"
-    elif post_type == "question"
+    elif post_type == "question":
         api_filter = r"!m)9.UaQrI5-DZXtlTpWhv2HroYRgS3dPhv.2vxV7fpGT*27rEHM.BKV1"
     else:
         raise ValueError("Unknown post type: {}".format(post_type))

--- a/apigetpost.py
+++ b/apigetpost.py
@@ -62,10 +62,11 @@ def api_get_post(post_url):
         return None
     post_id, site, post_type = d
     if post_type == "answer":
-        api_filter = r"!FdmhxNRjn0vYtGOu3FfS5xSwvL"
+        api_filter = r"!4z6S)cPO)zvpuDWsWTAUW(kaV6K6thsqi1tlYa"
+    elif post_type == "question"
+        api_filter = r"!m)9.UaQrI5-DZXtlTpWhv2HroYRgS3dPhv.2vxV7fpGT*27rEHM.BKV1"
     else:
-        assert post_type == "question"
-        api_filter = r"!DEPw4-PqDduRmCwMBNAxrCdSZl81364qitC3TebCzqyF4-y*r2L"
+        raise ValueError("Unknown post type: {}".format(post_type))
 
     request_url = "https://api.stackexchange.com/2.2/{}s/{}".format(post_type, post_id)
     params = {

--- a/bodyfetcher.py
+++ b/bodyfetcher.py
@@ -208,7 +208,7 @@ class BodyFetcher:
 
         url = "https://api.stackexchange.com/2.2/questions{}".format(question_modifier)
         params = {
-            'filter': '!*xq08dCDNr)PlxxXfaN8ntivx(BPlY_8XASyXLX-J7F-)VK*Q3KTJVkvp*',
+            'filter': '!1rs)sUKylwB)8isvCRk.xNu71LnaxjnPS12*pX*CEOKbPFwVFdHNxiMa7GIVgzDAwMa',
             'key': 'IAkbitmze4B8KpacUfLqkw((',
             'site': site
         }

--- a/chatcommands.py
+++ b/chatcommands.py
@@ -1731,7 +1731,7 @@ def allspam(msg, url):
         # Fetch posts
         request_url = "https://api.stackexchange.com/2.2/users/{}/posts".format(u_id)
         params = {
-            'filter': '!)Q4RrMH0DC96Y4g9yVzuwUrW',
+            'filter': '!*0S0--txpIwJHBnEqJR9px_-b(4TI_dAeSMiPUcCA',
             'key': api_key,
             'site': u_site
         }

--- a/classes/_Post.py
+++ b/classes/_Post.py
@@ -18,7 +18,7 @@ class Post:
 
         self._body = ""
         self._body_is_summary = False
-        self._markdown = ""
+        self._markdown = None
         self._is_answer = False
         self._owner_rep = 1
         self._parent = None  # If not None, _is_answer should be 'true' because there would then be a parent post.

--- a/classes/_Post.py
+++ b/classes/_Post.py
@@ -18,6 +18,7 @@ class Post:
 
         self._body = ""
         self._body_is_summary = False
+        self._markdown = ""
         self._is_answer = False
         self._owner_rep = 1
         self._parent = None  # If not None, _is_answer should be 'true' because there would then be a parent post.
@@ -115,6 +116,8 @@ class Post:
 
         self._title = html.unescape(response["title"])
         self._body = html.unescape(response["body"])
+        if "body_markdown" in response:
+            self._markdown = html.unescape(response["body_markdown"])
 
         if "IsAnswer" in response and response["IsAnswer"] is True:
             self._is_answer = True
@@ -193,6 +196,10 @@ class Post:
     @property
     def body_is_summary(self):
         return bool(self._body_is_summary)
+
+    @property
+    def markdown(self):
+        return str(self._markdown)
 
     @property
     def is_answer(self):

--- a/metasmoke.py
+++ b/metasmoke.py
@@ -301,7 +301,7 @@ class Metasmoke:
                 metasmoke_cache.MetasmokeCache.delete('whitelisted-domains')
 
     @staticmethod
-    def send_stats_on_post(title, link, reasons, body, username, user_link, why, owner_rep,
+    def send_stats_on_post(title, link, reasons, body, markdown, username, user_link, why, owner_rep,
                            post_score, up_vote_count, down_vote_count):
         if GlobalVars.metasmoke_host is None:
             log('info', 'Attempted to send stats but metasmoke_host is undefined. Ignoring.')
@@ -316,8 +316,8 @@ class Metasmoke:
             if len(why) > 4096:
                 why = why[:2048] + ' ... ' + why[-2043:]  # Basic maths
 
-            post = {'title': title, 'link': link, 'reasons': reasons,
-                    'body': body, 'username': username, 'user_link': user_link,
+            post = {'title': title, 'link': link, 'reasons': reasons, 'body': body, 'markdown': markdown,
+                    'username': username, 'user_link': user_link,
                     'why': why, 'user_reputation': owner_rep, 'score': post_score,
                     'upvote_count': up_vote_count, 'downvote_count': down_vote_count}
 

--- a/spamhandling.py
+++ b/spamhandling.py
@@ -131,8 +131,8 @@ def handle_spam(post, reasons, why):
             username = post.user_name.strip()
 
         Tasks.do(metasmoke.Metasmoke.send_stats_on_post,
-                 post.title_ignore_type, post_url, reasons, post.body, username,
-                 post.user_link, why, post.owner_rep, post.post_score,
+                 post.title_ignore_type, post_url, reasons, post.body, post.markdown,
+                 username, post.user_link, why, post.owner_rep, post.post_score,
                  post.up_vote_count, post.down_vote_count)
 
         offensive_mask = 'offensive title detected' in reasons


### PR DESCRIPTION
Context: Charcoal-SE/metasmoke#734

This PR implements the Smokey side of stuff. Apparently depends on the deployment of the target MS PR.

---

Changes to filters: Added `body_markdown` for questions and answers where `body` is already selected.