### PR TITLE
Anchor blacklisted website

### DIFF
--- a/chatcommands.py
+++ b/chatcommands.py
@@ -341,7 +341,7 @@ def get_test_text_from_regex(pattern):
     return pattern
 
 
-def do_blacklist(blacklist_type, msg, force=False):
+def do_blacklist(blacklist_type, msg, force=False, direct=False):
     """
     Adds a string to the website blacklist and commits/pushes to GitHub
     :param raw_pattern:
@@ -408,6 +408,7 @@ def do_blacklist(blacklist_type, msg, force=False):
 
     _status, result = GitManager.add_to_blacklist(
         blacklist=blacklist_type,
+        is_direct=direct,
         item_to_blacklist=pattern,
         username=msg.owner.name,
         chat_profile_link=chat_user_profile_link,
@@ -437,9 +438,11 @@ def do_blacklist(blacklist_type, msg, force=False):
 
 # noinspection PyIncorrectDocstring
 @command(str, whole_msg=True, privileged=True, give_name=True, aliases=["blacklist-keyword",
+                                                                        "blacklist-website-direct",
                                                                         "blacklist-website",
                                                                         "blacklist-username",
                                                                         "blacklist-number",
+                                                                        "blacklist-website-direct-force",
                                                                         "blacklist-keyword-force",
                                                                         "blacklist-website-force",
                                                                         "blacklist-username-force",
@@ -452,8 +455,9 @@ def blacklist_keyword(msg, pattern, alias_used="blacklist-keyword"):
     :return: A string
     """
 
-    parts = alias_used.split("-")
-    return do_blacklist(parts[1], msg, force=len(parts) > 2)
+    # force == blacklist even if already caught
+    # direct == no processing on the blacklist expr
+    return do_blacklist(parts[1], msg, force="force" in alias_used, direct="direct" in alias_used)
 
 
 # noinspection PyIncorrectDocstring

--- a/gitmanager.py
+++ b/gitmanager.py
@@ -70,7 +70,8 @@ class GitManager:
             return "origin"
 
     @classmethod
-    def add_to_blacklist(cls, blacklist='', item_to_blacklist='', username='', chat_profile_link='',
+    def add_to_blacklist(cls, blacklist='', is_direct=False, item_to_blacklist='',
+                         username='', chat_profile_link='',
                          code_permissions=False, metasmoke_down=False):
         if blacklist == "":
             return (False, 'GitManager: blacklist is not defined. Blame a developer.')
@@ -119,6 +120,10 @@ class GitManager:
             else:
                 op = 'blacklist'
                 item = item_to_blacklist
+                if blacklist_type == Blacklist.WEBSITES and not is_direct:
+                    # Blacklist website and is not direct -> anchor expr
+                    item = r"\b" + item + r"\b"
+                    item_to_blacklist = item
 
             exists, line = blacklister.exists(item_to_blacklist)
             if exists:

--- a/gitmanager.py
+++ b/gitmanager.py
@@ -122,7 +122,7 @@ class GitManager:
                 item = item_to_blacklist
                 if blacklist_type == Blacklist.WEBSITES and not is_direct:
                     # Blacklist website and is not direct -> anchor expr
-                    item = r"\b" + item + r"\b"
+                    item = r"\b(?<![^\W_]-)" + item + r"(?![.-][^\W_])\b"
                     item_to_blacklist = item
 
             exists, line = blacklister.exists(item_to_blacklist)


### PR DESCRIPTION
Implements: #2796 

`!!/blacklist-website` will now anchor its expr. An unanchored version, `!!/blacklist-website-direct`, is provided.  
There is no test performed for now.
