### PR TITLE
Leave out reason when not provided

### DIFF
--- a/chatcommands.py
+++ b/chatcommands.py
@@ -587,9 +587,15 @@ def reject(msg, args, alias_used="reject"):
         message_url = "https://chat.{}/transcript/{}?m={}".format(msg._client.host, msg.room.id, msg.id)
         chat_user_profile_link = "https://chat.{}/users/{}".format(
             msg._client.host, msg.owner.id)
+        if comment != '':
         comment = "[Rejected]({}) by [{}]({}) in {}. Reason provided: '{}'\n\n![Rejected with SmokeyReject]({})".format(
             message_url, msg.owner.name, chat_user_profile_link, msg.room.name,
             reason,
+            "https://camo.githubusercontent.com/77d8d14b9016e415d36453f27ccbe06d47ef5ae2/68747470733a2f2f7261737465722e"
+            "736869656c64732e696f2f62616467652f626c61636b6c6973746572732d72656a65637465642d7265642e706e67")
+        else:
+            comment = "[Rejected]({}) by [{}]({}) in {}. No reason provided.\n\n![Rejected with SmokeyReject]({})".format(
+            message_url, msg.owner.name, chat_user_profile_link, msg.room.name,
             "https://camo.githubusercontent.com/77d8d14b9016e415d36453f27ccbe06d47ef5ae2/68747470733a2f2f7261737465722e"
             "736869656c64732e696f2f62616467652f626c61636b6c6973746572732d72656a65637465642d7265642e706e67")
         message = GitManager.reject_pull_request(pr_id, comment)

--- a/chatcommands.py
+++ b/chatcommands.py
@@ -583,18 +583,20 @@ def reject(msg, args, alias_used="reject"):
         raise CmdException("Please provide an adequate reason for rejection so the user"
                            " can learn from their mistakes. Use `-force` to force the reject")
     # Forward this, because checks are better placed in gitmanager.py
-    rejected_image = "https://camo.githubusercontent.com/77d8d14b9016e415d36453f27ccbe06d47ef5ae2/68747470733a"
-    "2f2f7261737465722e736869656c64732e696f2f62616467652f626c61636b6c6973746572732d72656a65637465642d7265642e706e67"
+    rejected_image = "https://camo.githubusercontent.com/" \
+                     "77d8d14b9016e415d36453f27ccbe06d47ef5ae2/68747470733a" \
+                     "2f2f7261737465722e736869656c64732e696f2f62616467652f626c6" \
+                     "1636b6c6973746572732d72656a65637465642d7265642e706e67"
     try:
         message_url = "https://chat.{}/transcript/{}?m={}".format(msg._client.host, msg.room.id, msg.id)
-        chat_user_profile_link = "https://chat.{}/users/{}".format(
-            msg._client.host, msg.owner.id)
-        if comment != '':
+        chat_user_profile_link = "https://chat.{}/users/{}".format(msg._client.host, msg.owner.id)
+        if reason != '':
             comment = "[Rejected]({}) by [{}]({}) in {}. Reason provided: '{}'\n\n![Rejected with SmokeyReject]({})"
-            .format(message_url, msg.owner.name, chat_user_profile_link, msg.room.name, reason, rejected_image)
+                .format(message_url, msg.owner.name, chat_user_profile_link, msg.room.name, reason, rejected_image)
         else:
-            comment = "[Rejected]({}) by [{}]({}) in {}. No reason provided.\n\n![Rejected with SmokeyReject]({})"
-            .format(message_url, msg.owner.name, chat_user_profile_link, msg.room.name, rejected_image)
+            comment = "[Rejected]({}) by [{}]({}) in {}. Reason provided: " \
+                      "'{}'\n\n![Rejected with SmokeyReject]({})".format(
+                message_url, msg.owner.name, chat_user_profile_link, msg.room.name, rejected_image)
         message = GitManager.reject_pull_request(pr_id, comment)
         return message
     except Exception as e:

--- a/chatcommands.py
+++ b/chatcommands.py
@@ -590,7 +590,7 @@ def reject(msg, args, alias_used="reject"):
     try:
         message_url = "https://chat.{}/transcript/{}?m={}".format(msg._client.host, msg.room.id, msg.id)
         chat_user_profile_link = "https://chat.{}/users/{}".format(msg._client.host, msg.owner.id)
-        if comment != '':
+        if reason != '':
             comment = "[Rejected]({}) by [{}]({}) in {}. Reason provided: " \
                       "'{}'\n\n![Rejected with SmokeyReject]({})"
             comment = comment.format(

--- a/chatcommands.py
+++ b/chatcommands.py
@@ -583,20 +583,20 @@ def reject(msg, args, alias_used="reject"):
         raise CmdException("Please provide an adequate reason for rejection so the user"
                            " can learn from their mistakes. Use `-force` to force the reject")
     # Forward this, because checks are better placed in gitmanager.py
-    rejected_image="https://camo.githubusercontent.com/77d8d14b9016e415d36453f27ccbe06d47ef5ae2/68747470733a2f2f726173746"
-        "5722e736869656c64732e696f2f62616467652f626c61636b6c6973746572732d72656a65637465642d7265642e706e67"
+    rejected_image = "https://camo.githubusercontent.com/77d8d14b9016e415d36453f27ccbe06d47ef5ae2/68747470733a"
+        "2f2f7261737465722e736869656c64732e696f2f62616467652f626c61636b6c6973746572732d72656a65637465642d7265642e706e67"
     try:
         message_url = "https://chat.{}/transcript/{}?m={}".format(msg._client.host, msg.room.id, msg.id)
         chat_user_profile_link = "https://chat.{}/users/{}".format(
             msg._client.host, msg.owner.id)
         if comment != '':
             comment = "[Rejected]({}) by [{}]({}) in {}. Reason provided: '{}'\n\n![Rejected with SmokeyReject]({})"
-                .format(message_url, msg.owner.name, chat_user_profile_link, msg.room.name,reason,rejected_image)
+                .format(message_url, msg.owner.name, chat_user_profile_link, msg.room.name, reason, rejected_image)
         else:
             comment = "[Rejected]({}) by [{}]({}) in {}. No reason provided.\n\n![Rejected with SmokeyReject]({})"
-                .format(message_url, msg.owner.name, chat_user_profile_link, msg.room.name,rejected_image)
-            message = GitManager.reject_pull_request(pr_id, comment)
-            return message
+                .format(message_url, msg.owner.name, chat_user_profile_link, msg.room.name, rejected_image)
+        message = GitManager.reject_pull_request(pr_id, comment)
+        return message
     except Exception as e:
         raise CmdException(str(e))
 

--- a/chatcommands.py
+++ b/chatcommands.py
@@ -556,15 +556,14 @@ def approve(msg, pr_id):
     except Exception as e:
         raise CmdException(str(e))
 
-
 @command(str, privileged=True, whole_msg=True, give_name=True, aliases=["close", "reject-force", "close-force"])
 def reject(msg, args, alias_used="reject"):
     argsraw = args.split(' "', 1)
     try:
-        pr_id = int(argsraw[0].split(' ')[0])
+        pr_id=int(argsraw[0].split(' ')[0])
     except ValueError:
-        reason = ''
-        pr_id = int(args.split(' ')[2])
+        reason=''
+        pr_id=int(args.split(' ')[2])
     try:
         # Custom handle trailing quotation marks at the end of the custom reason, which could happen.
         if argsraw[1][-1] == '"':
@@ -572,42 +571,32 @@ def reject(msg, args, alias_used="reject"):
         else:
             reason = argsraw[1]
     except IndexError:
-        reason = ''
-
-    message_url = "https://chat.{0}/transcript/{1}?m={2}".format(msg._client.host, msg.room.id, msg.id)
-    force = alias_used.split("-")[-1] == "force"
+        reason = '' 
+    force=alias_used.split("-")[-1] == "force"
     code_permissions = is_code_privileged(msg._client.host, msg.owner.id)
     if not code_permissions:
         raise CmdException("You need blacklist manager privileges to reject pull requests")
-    if len(reason) < 20 and not force:
-        raise CmdException("Please provide an adequate reason for rejection so the user"
+    if len(reason)<20 and not force:
+        raise CmdException("Please provide an adequate reason for rejection so the user"\
                            " can learn from their mistakes. Use `-force` to force the reject")
-    # Forward this, because checks are better placed in gitmanager.py
     rejected_image = "https://camo.githubusercontent.com/" \
                      "77d8d14b9016e415d36453f27ccbe06d47ef5ae2/68747470733a" \
                      "2f2f7261737465722e736869656c64732e696f2f62616467652f626c6" \
                      "1636b6c6973746572732d72656a65637465642d7265642e706e67"
+    message_url = "https://chat.{}/transcript/{}?m={}".format(msg._client.host, msg.room.id, msg.id)
+    chat_user_profile_link = "https://chat.{}/users/{}".format(msg._client.host, msg.owner.id)
+    rejected_by_text = "[Rejected]({}) by [{}]({}) in {}.".format(message_url, msg.owner.name,
+                                                                  chat_user_profile_link, msg.room.name)
+    reject_reason_text = " No rejection reason was provided.\n\n"
+    if reason:
+        reject_reason_text = " Reason: '{}'".format(reason)
+    reject_reason_image_text = "\n\n![Rejected with SmokeyReject]({})".format(rejected_image)
+    comment = rejected_by_text + reject_reason_text + reject_reason_image_text
     try:
-        message_url = "https://chat.{}/transcript/{}?m={}".format(msg._client.host, msg.room.id, msg.id)
-        chat_user_profile_link = "https://chat.{}/users/{}".format(msg._client.host, msg.owner.id)
-        if reason != '':
-            comment = "[Rejected]({}) by [{}]({}) in {}. Reason provided: " \
-                      "'{}'\n\n![Rejected with SmokeyReject]({})"
-            comment = comment.format(
-                message_url, msg.owner.name, chat_user_profile_link, msg.room.name, reason,
-                rejected_image
-            )
-        else:
-            comment = "[Rejected]({}) by [{}]({}) in {}. No reason provided.\n\n" \
-                      "![Rejected with SmokeyReject]({})"
-            comment = comment.format(
-                message_url, msg.owner.name, chat_user_profile_link, msg.room.name, rejected_image
-            )
         message = GitManager.reject_pull_request(pr_id, comment)
         return message
     except Exception as e:
         raise CmdException(str(e))
-
 
 @command(privileged=True, aliases=["remote-diff"])
 def remotediff():
@@ -2088,9 +2077,10 @@ def delete(msg):
     :return: None
     """
 
-    if msg.room.id == 11540:
-        return "Messages/reports from SmokeDetector in Charcoal HQ are generally kept "\
-               "as records. If you really need to delete a message, please use "\
+    post_data = get_report_data(msg)
+    if post_data and msg.room.id == 11540:
+        return "Reports from SmokeDetector in Charcoal HQ are generally kept "\
+               "as records. If you really need to delete a report, please use "\
                "`sd delete-force`. See [this note on message deletion]"\
                "(https://charcoal-se.org/smokey/Commands"\
                "#a-note-on-message-deletion) for more details."

--- a/chatcommands.py
+++ b/chatcommands.py
@@ -588,18 +588,18 @@ def reject(msg, args, alias_used="reject"):
         chat_user_profile_link = "https://chat.{}/users/{}".format(
             msg._client.host, msg.owner.id)
         if comment != '':
-        comment = "[Rejected]({}) by [{}]({}) in {}. Reason provided: '{}'\n\n![Rejected with SmokeyReject]({})".format(
-            message_url, msg.owner.name, chat_user_profile_link, msg.room.name,
-            reason,
-            "https://camo.githubusercontent.com/77d8d14b9016e415d36453f27ccbe06d47ef5ae2/68747470733a2f2f7261737465722e"
-            "736869656c64732e696f2f62616467652f626c61636b6c6973746572732d72656a65637465642d7265642e706e67")
+            comment = "[Rejected]({}) by [{}]({}) in {}. Reason provided: '{}'\n\n![Rejected with SmokeyReject]({})".format(
+                message_url, msg.owner.name, chat_user_profile_link, msg.room.name,
+                reason,
+                "https://camo.githubusercontent.com/77d8d14b9016e415d36453f27ccbe06d47ef5ae2/68747470733a2f2f7261737465722e"
+                "736869656c64732e696f2f62616467652f626c61636b6c6973746572732d72656a65637465642d7265642e706e67")
         else:
-            comment = "[Rejected]({}) by [{}]({}) in {}. No reason provided.\n\n![Rejected with SmokeyReject]({})".format(
-            message_url, msg.owner.name, chat_user_profile_link, msg.room.name,
-            "https://camo.githubusercontent.com/77d8d14b9016e415d36453f27ccbe06d47ef5ae2/68747470733a2f2f7261737465722e"
-            "736869656c64732e696f2f62616467652f626c61636b6c6973746572732d72656a65637465642d7265642e706e67")
-        message = GitManager.reject_pull_request(pr_id, comment)
-        return message
+            comment = "[Rejected]({}) by [{}]({}) in {}. No reason provided.\n\n![Rejected with SmokeyReject]({})"
+                .format(message_url, msg.owner.name, chat_user_profile_link, msg.room.name,
+                "https://camo.githubusercontent.com/77d8d14b9016e415d36453f27ccbe06d47ef5ae2/68747470733a2f2f7261737465722e"
+                "736869656c64732e696f2f62616467652f626c61636b6c6973746572732d72656a65637465642d7265642e706e67")
+            message = GitManager.reject_pull_request(pr_id, comment)
+            return message
     except Exception as e:
         raise CmdException(str(e))
 

--- a/chatcommands.py
+++ b/chatcommands.py
@@ -583,21 +583,18 @@ def reject(msg, args, alias_used="reject"):
         raise CmdException("Please provide an adequate reason for rejection so the user"
                            " can learn from their mistakes. Use `-force` to force the reject")
     # Forward this, because checks are better placed in gitmanager.py
+    rejected_image="https://camo.githubusercontent.com/77d8d14b9016e415d36453f27ccbe06d47ef5ae2/68747470733a2f2f726173746"
+        "5722e736869656c64732e696f2f62616467652f626c61636b6c6973746572732d72656a65637465642d7265642e706e67"
     try:
         message_url = "https://chat.{}/transcript/{}?m={}".format(msg._client.host, msg.room.id, msg.id)
         chat_user_profile_link = "https://chat.{}/users/{}".format(
             msg._client.host, msg.owner.id)
         if comment != '':
-            comment = "[Rejected]({}) by [{}]({}) in {}. Reason provided: '{}'\n\n![Rejected with SmokeyReject]({})".format(
-                message_url, msg.owner.name, chat_user_profile_link, msg.room.name,
-                reason,
-                "https://camo.githubusercontent.com/77d8d14b9016e415d36453f27ccbe06d47ef5ae2/68747470733a2f2f7261737465722e"
-                "736869656c64732e696f2f62616467652f626c61636b6c6973746572732d72656a65637465642d7265642e706e67")
+            comment = "[Rejected]({}) by [{}]({}) in {}. Reason provided: '{}'\n\n![Rejected with SmokeyReject]({})"
+                .format(message_url, msg.owner.name, chat_user_profile_link, msg.room.name,reason,rejected_image)
         else:
             comment = "[Rejected]({}) by [{}]({}) in {}. No reason provided.\n\n![Rejected with SmokeyReject]({})"
-                .format(message_url, msg.owner.name, chat_user_profile_link, msg.room.name,
-                "https://camo.githubusercontent.com/77d8d14b9016e415d36453f27ccbe06d47ef5ae2/68747470733a2f2f7261737465722e"
-                "736869656c64732e696f2f62616467652f626c61636b6c6973746572732d72656a65637465642d7265642e706e67")
+                .format(message_url, msg.owner.name, chat_user_profile_link, msg.room.name,rejected_image)
             message = GitManager.reject_pull_request(pr_id, comment)
             return message
     except Exception as e:

--- a/chatcommands.py
+++ b/chatcommands.py
@@ -584,17 +584,17 @@ def reject(msg, args, alias_used="reject"):
                            " can learn from their mistakes. Use `-force` to force the reject")
     # Forward this, because checks are better placed in gitmanager.py
     rejected_image = "https://camo.githubusercontent.com/77d8d14b9016e415d36453f27ccbe06d47ef5ae2/68747470733a"
-        "2f2f7261737465722e736869656c64732e696f2f62616467652f626c61636b6c6973746572732d72656a65637465642d7265642e706e67"
+    "2f2f7261737465722e736869656c64732e696f2f62616467652f626c61636b6c6973746572732d72656a65637465642d7265642e706e67"
     try:
         message_url = "https://chat.{}/transcript/{}?m={}".format(msg._client.host, msg.room.id, msg.id)
         chat_user_profile_link = "https://chat.{}/users/{}".format(
             msg._client.host, msg.owner.id)
         if comment != '':
             comment = "[Rejected]({}) by [{}]({}) in {}. Reason provided: '{}'\n\n![Rejected with SmokeyReject]({})"
-                .format(message_url, msg.owner.name, chat_user_profile_link, msg.room.name, reason, rejected_image)
+            .format(message_url, msg.owner.name, chat_user_profile_link, msg.room.name, reason, rejected_image)
         else:
             comment = "[Rejected]({}) by [{}]({}) in {}. No reason provided.\n\n![Rejected with SmokeyReject]({})"
-                .format(message_url, msg.owner.name, chat_user_profile_link, msg.room.name, rejected_image)
+            .format(message_url, msg.owner.name, chat_user_profile_link, msg.room.name, rejected_image)
         message = GitManager.reject_pull_request(pr_id, comment)
         return message
     except Exception as e:


### PR DESCRIPTION
Previously, when a reason was not provided, the reason in the comment will be left blank. Now it says "Reason not provided."