### PR TITLE
Less fp's

### DIFF
--- a/findspam.py
+++ b/findspam.py
@@ -606,7 +606,7 @@ def len_img_block(string):
 
 
 # max_score=2 to prevent voting fraud
-@create_rule("post is mostly images", title=False, max_rep=201, max_score=2)
+@create_rule("post is mostly images", title=False, max_rep=201, max_score=2, sites=["stackoverflow.com", "math.stackexchange.com", "mathoverflow.net", "stats.stackexchange.com"])
 def mostly_img(s, site):
     if len(s) == 0:
         return False, ""
@@ -1417,7 +1417,7 @@ def strip_urls_and_tags(s):
 
 
 @create_rule("mostly punctuation marks in {}", max_rep=52,
-             sites=["math.stackexchange.com", "mathoverflow.net", "codegolf.stackexchange.com"])
+             sites=["stats.stackexchange.com","math.stackexchange.com", "mathoverflow.net", "codegolf.stackexchange.com"])
 def mostly_punctuations(s, site):
     # Strip code blocks here rather than with `stripcodeblocks` so we get the length of the whole post in s.
     body = regex.sub(r"(?s)<pre([\w=\" -]*)?>.*?</pre>", "", s)

--- a/findspam.py
+++ b/findspam.py
@@ -1417,7 +1417,7 @@ def strip_urls_and_tags(s):
 
 
 @create_rule("mostly punctuation marks in {}", max_rep=52,
-             sites=["stats.stackexchange.com","math.stackexchange.com", "mathoverflow.net", "codegolf.stackexchange.com"])
+             sites=["stats.stackexchange.com", "math.stackexchange.com", "mathoverflow.net", "codegolf.stackexchange.com"])
 def mostly_punctuations(s, site):
     # Strip code blocks here rather than with `stripcodeblocks` so we get the length of the whole post in s.
     body = regex.sub(r"(?s)<pre([\w=\" -]*)?>.*?</pre>", "", s)

--- a/findspam.py
+++ b/findspam.py
@@ -606,7 +606,8 @@ def len_img_block(string):
 
 
 # max_score=2 to prevent voting fraud
-@create_rule("post is mostly images", title=False, max_rep=201, max_score=2, sites=["stackoverflow.com", "math.stackexchange.com", "mathoverflow.net", "stats.stackexchange.com"])
+@create_rule("post is mostly images", title=False, max_rep=201, max_score=2, sites=[
+    "stackoverflow.com", "math.stackexchange.com", "mathoverflow.net", "stats.stackexchange.com"])
 def mostly_img(s, site):
     if len(s) == 0:
         return False, ""
@@ -1416,8 +1417,9 @@ def strip_urls_and_tags(s):
     return URL_REGEX.sub("", TAG_REGEX.sub("", s))
 
 
-@create_rule("mostly punctuation marks in {}", max_rep=52,
-             sites=["stats.stackexchange.com", "math.stackexchange.com", "mathoverflow.net", "codegolf.stackexchange.com"])
+@create_rule("mostly punctuation marks in {}", max_rep=52, sites=[
+    "stats.stackexchange.com", "math.stackexchange.com",
+    "mathoverflow.net", "codegolf.stackexchange.com"])
 def mostly_punctuations(s, site):
     # Strip code blocks here rather than with `stripcodeblocks` so we get the length of the whole post in s.
     body = regex.sub(r"(?s)<pre([\w=\" -]*)?>.*?</pre>", "", s)

--- a/findspam.py
+++ b/findspam.py
@@ -607,7 +607,7 @@ def len_img_block(string):
 
 # max_score=2 to prevent voting fraud
 @create_rule("post is mostly images", title=False, max_rep=201, max_score=2, sites=[
-    "stackoverflow.com", "math.stackexchange.com", "mathoverflow.net", "stats.stackexchange.com"])
+    "math.stackexchange.com", "mathoverflow.net", "stats.stackexchange.com"])
 def mostly_img(s, site):
     if len(s) == 0:
         return False, ""

--- a/test/test_findspam.py
+++ b/test/test_findspam.py
@@ -72,9 +72,9 @@ from helpers import log
     ('Should not be caught: http://example.com', '', '', 'drupal.stackexchange.com', False, False, False),
     ('Should not be caught: https://www.example.com', '', '', 'drupal.stackexchange.com', False, False, False),
     ('Should not be caught: something@example.com', '', '', 'drupal.stackexchange.com', False, False, False),
-    ('Title here', '<img src="http://example.com/11111111111.jpg" alt="my image">', '', 'stackoverflow.com', False, False, True),
-    ('Title here', '<img src="http://example.com/11111111111111.jpg" alt="my image" />', '', 'stackoverflow.com', False, False, True),
-    ('Title here', '<a href="http://example.com/11111111111111.html">page</a>', '', 'stackoverflow.com', False, False, False),
+    ('Title here', '<img src="http://example.com/11111111111.jpg" alt="my image">', '', 'askubuntu.com', False, False, True),
+    ('Title here', '<img src="http://example.com/11111111111111.jpg" alt="my image" />', '', 'askubuntu.com', False, False, True),
+    ('Title here', '<a href="http://example.com/11111111111111.html">page</a>', '', 'askubuntu.com', False, False, False),
     ('Error: 2147467259', '', '', 'stackoverflow.com', False, False, False),
     ('Max limit on number of concurrent ajax request', """<p>Php java script boring yaaarrr <a href="http://www.price-buy.com/" rel="nofollow noreferrer">Price-Buy.com</a> </p>""", 'Price Buy', 'stackoverflow.com', True, True, True),
     ('Proof of onward travel in Japan?', """<p>The best solution to overcome the problem of your travel<a href="https://i.stack.imgur.com/eS6WQ.jpg" rel="nofollow noreferrer"><img src="https://i.stack.imgur.com/eS6WQ.jpg" alt="enter image description here"></a></p>


### PR DESCRIPTION
- Excludes StackOverflow, Maths, Mathoverflow and Cross Validated from the "post is mostly images" reason (since StackOverflow can have `<img>` code counted and the other 3 have a lot of MathJax used)
- Adds Cross Validated to the exclusion list for the "mostly punctuation marks in {}" reason (MathJax)

Statistics:

**Excluding StackOverflow, Maths, Mathoverflow and Cross Validated from the "post is mostly images" reason, will result in:**

- 31 fewer fp's
- 0 fewer tp's

The current accuracy of this reason is 17% (17)
New accuracy: 40% (40)

**Excluding Cross Validated from the "mostly punctuation marks in {}" reason, will result in:**

- 0 fewer tp's (all tp's caught by other reasons)
- 30 fewer fp's