### PR TITLE
Tentative async approve/reject

### DIFF
--- a/chatcommands.py
+++ b/chatcommands.py
@@ -558,6 +558,12 @@ def approve(msg, pr_id):
         raise CmdException(str(e))
 
 
+@command(int, privileged=True, whole_msg=True)
+def aapprove(msg, pr_id):
+    threading.Thread(name="async-approve", target=approve.__func__, args=(msg, pr_id)).start
+    return "Job started asynchronously."
+
+
 @command(str, privileged=True, whole_msg=True, give_name=True, aliases=["close", "reject-force", "close-force"])
 def reject(msg, args, alias_used="reject"):
     argsraw = args.split(' "', 1)
@@ -599,6 +605,12 @@ def reject(msg, args, alias_used="reject"):
         return message
     except Exception as e:
         raise CmdException(str(e))
+
+
+@command(str, privileged=True, whole_msg=True, give_name=True, aliases=["aclose", "areject-force", "aclose-force"])
+def areject(msg, args, alias_used="areject"):
+    threading.Thread(name="async-reject", target=reject.__func__, args=(msg, args, alias_used[1:])).start
+    return "Job started asynchronously."
 
 
 @command(privileged=True, aliases=["remote-diff"])

--- a/chatcommands.py
+++ b/chatcommands.py
@@ -560,7 +560,7 @@ def approve(msg, pr_id):
 
 @command(int, privileged=True, whole_msg=True)
 def aapprove(msg, pr_id):
-    threading.Thread(name="async-approve", target=approve.__func__, args=(msg, pr_id)).start
+    threading.Thread(name="async-approve", target=approve.__func__, args=(msg, pr_id)).start()
     return "Job started asynchronously."
 
 
@@ -609,7 +609,7 @@ def reject(msg, args, alias_used="reject"):
 
 @command(str, privileged=True, whole_msg=True, give_name=True, aliases=["aclose", "areject-force", "aclose-force"])
 def areject(msg, args, alias_used="areject"):
-    threading.Thread(name="async-reject", target=reject.__func__, args=(msg, args, alias_used[1:])).start
+    threading.Thread(name="async-reject", target=reject.__func__, args=(msg, args, alias_used[1:])).start()
     return "Job started asynchronously."
 
 


### PR DESCRIPTION
This is an attempt to solve #4291 . The observation of SD behaviour is that it randomly loses connection to CHQ after an approve/reject command is issued. I suspect therefore that this is due to the git operation hanging up the entire command listener thread, as SD is still able to post 'Goodbye, cruel world' message to CHQ but not accept any command. This is an attempt to make approve/reject asynchronous, in order to verify the cause of the bug.

Note: I am not sure what magic is happening for thread raising exceptions. Hence, I am not sure whether the code is exception-safe.