### PR TITLE
Add blacklisters to config file for testing

### DIFF
--- a/config.sample
+++ b/config.sample
@@ -21,3 +21,8 @@ location=location_here
 
 # Perspective API key
 # perspective_key=some_key
+
+# Manually add blacklist privileged users (primarily for testing):
+# se_blacklisters=<comma separated list of user IDs on chat.stackexchange>
+# mse_blacklisters=<comma separated list of user IDs on meta.chat.stackexchange>
+# so_blacklisters=<comma separated list of user IDs on chat.stackoverflow>

--- a/datahandling.py
+++ b/datahandling.py
@@ -179,6 +179,14 @@ def is_auto_ignored_post(postid_site_tuple):
 
 def update_code_privileged_users_list():
     metasmoke.Metasmoke.update_code_privileged_users_list()
+    # GlobalVars.code_privileged_users can now be a set, or may still be None.
+    if GlobalVars.code_privileged_users is None:
+        if len(GlobalVars.config_blacklisters) > 0:
+            # Only change away from None if there are pre-configured blacklisters
+            GlobalVars.code_privileged_users = set(GlobalVars.config_blacklisters)
+    else:
+        # Add the users in the config file, if any
+        GlobalVars.code_privileged_users.update(GlobalVars.config_blacklisters)
     _dump_pickle("codePrivileges.p", GlobalVars.code_privileged_users)
 
 

--- a/globalvars.py
+++ b/globalvars.py
@@ -258,6 +258,25 @@ class GlobalVars:
     # Miscellaneous
     log_time_format = config.get("log_time_format", "%H:%M:%S")
 
+    # Blacklist privileged users from config
+    se_blacklisters = regex.sub(r"[^\d,]", "", config.get("se_blacklisters", "")).split(",")
+    mse_blacklisters = regex.sub(r"[^\d,]", "", config.get("mse_blacklisters", "")).split(",")
+    so_blacklisters = regex.sub(r"[^\d,]", "", config.get("so_blacklisters", "")).split(",")
+
+    # Create a set of blacklisters equivalent to what's used in code_privileged_users.
+    config_blacklisters = set()
+    for id in se_blacklisters:
+        if id:
+            config_blacklisters.add(("stackexchange.com", int(id)))
+
+    for id in mse_blacklisters:
+        if id:
+            config_blacklisters.add(("meta.stackexchange.com", int(id)))
+
+    for id in so_blacklisters:
+        if id:
+            config_blacklisters.add(("stackoverflow.com", int(id)))
+
     # environ_or_none replaced by os.environ.get (essentially dict.get)
     bot_name = os.environ.get("SMOKEDETECTOR_NAME", git_name)
     bot_repo_slug = os.environ.get("SMOKEDETECTOR_REPO", git_user_repo)


### PR DESCRIPTION
One of the things that's hampered testing is that it's necessary to connect to MS to get a list of blacklist manager approved users. This has been handled in a few cases by copying a codePrivileges.p file around. That's a bit clunky.

This PR adds 3 new optional values to the config file:
* `se_blacklisters`
* `mse_blacklisters`
* `so_blacklisters`
Each value is a comma separated list of IDs which are to be blacklist manager approved on the respective chat server. If there is an existing list of blacklist managers available from MS, then the IDs are added to it. If there is no list of blacklist managers available from MS (i.e. there's no MS key), then the lists that are provided in the config file by chat server are used alone.