### PR TITLE
[gitmanager] Fix deadlock caused by leak in reject_pull_request

### DIFF
--- a/gitmanager.py
+++ b/gitmanager.py
@@ -392,16 +392,16 @@ class GitManager:
         if comment:  # yay we have comments now
             GitHubManager.comment_on_thread(pr_id, comment)
 
-        cls.gitmanager_lock.acquire()
-        origin_or_auth = cls.get_origin_or_auth()
-        git.fetch(origin_or_auth, '+refs/pull/{}/head'.format(pr_id))
-        payload = {"state": "closed"}
-        response = GitHubManager.update_pull_request(pr_id, payload)
-        if response:
-            if response.json()["state"] == "closed":
-                git.push('-d', origin_or_auth, ref)
-                return "Closed pull request [#{0}](https://github.com/{1}/pull/{0}).".format(
-                    pr_id, GlobalVars.bot_repo_slug)
+        with cls.gitmanager_lock:
+            origin_or_auth = cls.get_origin_or_auth()
+            git.fetch(origin_or_auth, '+refs/pull/{}/head'.format(pr_id))
+            payload = {"state": "closed"}
+            response = GitHubManager.update_pull_request(pr_id, payload)
+            if response:
+                if response.json()["state"] == "closed":
+                    git.push('-d', origin_or_auth, ref)
+                    return "Closed pull request [#{0}](https://github.com/{1}/pull/{0}).".format(
+                        pr_id, GlobalVars.bot_repo_slug)
 
         raise RuntimeError("Closing pull request #{} failed. Manual operations required.".format(pr_id))
 


### PR DESCRIPTION
[Once again](https://github.com/Charcoal-SE/SmokeDetector/issues/565), leaked locks cause Smokey to randomly die.

In this case, the `!!/reject` command acquired the gitmanager lock but never released it. This means that when the *next* gitmanager operation attempts to acquire the lock, it deadlocks forever, permanently stalling the calling thread.

Resolves #4291 (or at least one possible cause of the issue).