### PR TITLE
Run commands asynchronously

### DIFF
--- a/chatcommands.py
+++ b/chatcommands.py
@@ -23,6 +23,7 @@ import os
 import time
 import collections
 import subprocess
+import traceback
 from html import unescape
 from ast import literal_eval
 # noinspection PyCompatibility
@@ -1434,6 +1435,26 @@ def threads():
     threads_list = ["{ident}: {name}".format(ident=t.ident, name=t.name) for t in threading.enumerate()]
 
     return "\n".join(threads_list)
+
+
+# noinspection PyIncorrectDocstring
+@command(int, whole_msg=True, aliases=["traceback"])
+def backtrace(msg, thread_id):
+    """
+    Returns the backtrace of a given thread, for debugging
+    :return: A string
+    """
+
+    try:
+        # We can't post a code-formatted reply, so post a code-formatted message
+        # followed by a reply.
+        response = "\n".join(traceback.format_stack(sys._current_frames()[thread_id]))
+        response = "    " + response.replace("\n", "\n    ")
+        tell_rooms(response, ((msg._client.host, msg.room.id),), ())
+        return "^"
+    except KeyError:
+        raise CmdException("No such thread " + str(thread_id) + "; use !!/threads for a list " +
+                           " of running threads.")
 
 
 # noinspection PyIncorrectDocstring

--- a/chatcommunicate.py
+++ b/chatcommunicate.py
@@ -627,13 +627,16 @@ def async_dispatch_command(msg, room_data, func, *args, **kwargs):
         tell_rooms(warning_msg, ((msg._client.host, msg.room.id),), ())
 
     def command_callback():
-        result = func(*args, **kwargs)
+        try:
+            result = func(*args, **kwargs)
 
-        if result:
-            s = ":{}\n{}" if "\n" not in result and len(result) >= 488 else ":{} {}"
-            _msg_queue.put((room_data, s.format(msg.id, result), None))
-
-        timer.cancel()
+            if result:
+                s = ":{}\n{}" if "\n" not in result and len(result) >= 488 else ":{} {}"
+                _msg_queue.put((room_data, s.format(msg.id, result), None))
+        except:
+            raise
+        finally:
+            timer.cancel()
 
     timer = threading.Timer(60, timer_callback)
     cmd_thread = threading.Thread(name="command " + msg.content, daemon=True, target=command_callback)

--- a/chatcommunicate.py
+++ b/chatcommunicate.py
@@ -633,7 +633,7 @@ def async_dispatch_command(msg, room_data, func, *args, **kwargs):
             if result:
                 s = ":{}\n{}" if "\n" not in result and len(result) >= 488 else ":{} {}"
                 _msg_queue.put((room_data, s.format(msg.id, result), None))
-        except:
+        except Exception:
             raise
         finally:
             timer.cancel()

--- a/test/test_chatcommunicate.py
+++ b/test/test_chatcommunicate.py
@@ -220,6 +220,7 @@ def test_on_msg(get_last_messages, post_msg):
     all_timers = []
     timeout_immediately = False
     orig_timer = threading.Timer
+
     def create_timer(*args, **kwargs):
         if timeout_immediately:
             # replace interval argument with 0.1s
@@ -292,7 +293,7 @@ def test_on_msg(get_last_messages, post_msg):
                 "content": "!!/a_command",
                 "_client": client
             }
-        }, spec=chatcommunicate.events.MessagePosted) 
+        }, spec=chatcommunicate.events.MessagePosted)
         mock_command = Mock(side_effect=lambda *_, **kwargs: "hi" if not kwargs["quiet_action"] else "")
         chatcommunicate._prefix_commands["a-command"] = (mock_command, (0, 0))
 

--- a/test/test_chatcommunicate.py
+++ b/test/test_chatcommunicate.py
@@ -441,7 +441,7 @@ def test_on_msg(get_last_messages, post_msg):
         }, spec=chatcommunicate.events.MessageEdited)
 
         chatcommunicate._reply_commands["why"] = (mock_command, (0, 0))
-         
+
         # threading.excepthook is only available on python >= 3.8. Just skip
         # this part of the test if we're running on an earlier version, since
         # we'll test the later version anyway in CI.


### PR DESCRIPTION
Run each command on its own thread instead of blocking the chat watcher thread. This way, commands that freeze/deadlock won't render Smokey unresponsive. If a command runs for more than 60 seconds without completing, a warning message is printed.

Also adds a `!!/traceback`/`!!/backtrace` command which prints a traceback for a given thread ID; intended to ease debugging of deadlocks.