### PR TITLE
[bodyfetcher] Fix math error interpolating post IDs 

### DIFF
--- a/bodyfetcher.py
+++ b/bodyfetcher.py
@@ -278,7 +278,10 @@ class BodyFetcher:
                     GlobalVars.api_backoff_time = time.time() + response["backoff"]
 
         if len(message_hq) > 0 and "site is required" not in message_hq:
-            tell_rooms_with("debug", message_hq.strip())
+            message_hq = message_hq.strip()
+            if len(message_hq) > 500:
+                message_hq = "\n" + message_hq
+            tell_rooms_with("debug", message_hq)
 
         if "items" not in response:
             return

--- a/bodyfetcher.py
+++ b/bodyfetcher.py
@@ -158,7 +158,7 @@ class BodyFetcher:
                 # We don't want to go over the 100-post API cutoff, so take the last
                 # (100-len(new_post_ids)) from intermediate_posts
 
-                intermediate_posts = intermediate_posts[(100 - len(new_post_ids)):]
+                intermediate_posts = intermediate_posts[-(100 - len(new_post_ids)):]
 
                 # new_post_ids could contain edited posts, so merge it back in
                 combined = chain(intermediate_posts, new_post_ids)


### PR DESCRIPTION
The Stack Exchange API allows us to fetch a maximum of 100 posts in one request. Whenever we make a request, if we have less than 100 posts to fetch we fill the extra space with some "Hybrid Intermediate IDs" -- in other words, post IDs interpolated between the highest post IDs we've seen. (For example, if the highest post ID we've seen is 1000, and we suddenly see post 1050, we will pad out our next API request with post IDs in the range 1001-1049).

Well, at least that's the intention. There was an arithmetic error [when calculating the number of intermediate post IDs to include](https://github.com/Charcoal-SE/SmokeDetector/blob/84a139690eceb8a690e4705628446839662d26fa/bodyfetcher.py#L161):

    # We don't want to go over the 100-post API cutoff, so take the last
    # (100-len(new_post_ids)) from intermediate_posts

    intermediate_posts = intermediate_posts[(100 - len(new_post_ids)):]

This doesn't take the last `100-len` posts (like it says in the comment); instead, it skips the first `100-len` posts. This PR fixes the bug by simply negating the index.

---

The original revision of this code worked as intended but was written a bit counter-intuitively, and so [it was mistakenly "fixed"](https://github.com/Charcoal-SE/SmokeDetector/commit/f9bcfb88b0c93f0def86e3040871e16882965113) three and a half years ago. If there are too many intermediate posts, the erroneous calculation can result in an API request with more than 100 message IDs, which causes the entire batch to fail **and potentially results in missed posts.** We try to post an error message, but the request URL is too long to fit in a chat message so it is silently discarded (the error it's console-logged, but not errorlogged). This PR fixes that issue as well by posting a multi-line chat message if the error message is too long.