### PR TITLE
Split "customer support phrase in {}" and "scam aimed at customers in {}" from bad keywords

### DIFF
--- a/bad_keywords.txt
+++ b/bad_keywords.txt
@@ -44,7 +44,7 @@ service\W?solahart
 junisse
 profactor\W?t
 (?:fake|novelty|quality|buy(?:ing)?|sell(?:ing)?|offer|comprar|fabricante|vender|venta).{0,20}(?:passport|driver'?s? licen[cs]e|ID card|green card|residence permit|toefl|Ielts|pasaportes|licencias[\W_]*+de[\W_]*+conducir|tarjetas[\W_]*+de[\W_]*+identificación)s?
-(?:support|service|helpline)(?:[\W_]*+phone)?[\W_]*+numbers?+(?<=^.{0,225})(?#If this is changed, it also needs to be changed in findspam.py)
+(?:support|service|helpline)(?:[\W_]*+phone)?[\W_]*+numbers?+(?<=^.{0,225})(?#If this is changed, it also needs to be changed in findspam.py customer_support_phrase)
 [a-z_]*+(?:1_*+)?866[\W_]*+978[\W_]*+(?:6819|6762)[a-z_]*+
 (?:mcafee|hotmail|gmail|outlook|yahoo|lexmark (?:printer)?) ?(?:password(?: recovery)?|tech)? ?(?:(?:customer|technical) (?:support|service))? (?:support|contact|telephone|help(?:line)?|phone) numbers?
 kitchen for sale

--- a/bad_keywords.txt
+++ b/bad_keywords.txt
@@ -44,7 +44,7 @@ service\W?solahart
 junisse
 profactor\W?t
 (?:fake|novelty|quality|buy(?:ing)?|sell(?:ing)?|offer|comprar|fabricante|vender|venta).{0,20}(?:passport|driver'?s? licen[cs]e|ID card|green card|residence permit|toefl|Ielts|pasaportes|licencias[\W_]*+de[\W_]*+conducir|tarjetas[\W_]*+de[\W_]*+identificación)s?
-(?:support|service|helpline)(?:[\W_]*+phone)?[\W_]*+numbers?+(?<=^.{0,225})
+(?:support|service|helpline)(?:[\W_]*+phone)?[\W_]*+numbers?+(?<=^.{0,225})(?#If this is changed, it also needs to be changed in findspam.py)
 [a-z_]*+(?:1_*+)?866[\W_]*+978[\W_]*+(?:6819|6762)[a-z_]*+
 (?:mcafee|hotmail|gmail|outlook|yahoo|lexmark (?:printer)?) ?(?:password(?: recovery)?|tech)? ?(?:(?:customer|technical) (?:support|service))? (?:support|contact|telephone|help(?:line)?|phone) numbers?
 kitchen for sale

--- a/findspam.py
+++ b/findspam.py
@@ -776,14 +776,29 @@ def check_watched_numbers(s, site):
 
 
 # noinspection PyUnusedLocal,PyMissingTypeHints
-@create_rule("bad keyword in {}")
-def has_customer_service(s, site):  # flexible detection of customer service
+@create_rule("customer support phrase in {}", all=False, sites=[
+    "askubuntu.com", "webapps.stackexchange.com", "webmasters.stackexchange.com"])
+def customer_support_phrase(s, site):  # flexible detection of customer service
+    shortened = s[0:300].lower()   # if applied to body, the beginning should be enough: otherwise many false positives
+    shortened = regex.sub(r"[^A-Za-z0-9\s]", "", s)   # deobfuscate
+    phrase = regex.compile(r"(tech(nical)? support)|((support|service|contact|help(line)?) (telephone|phone|"
+                           r"number))").search(shortened)
+    # We don't want to double-detect phrases which the bad keywords list already detects.
+    excluded = regex.compile(r"(?is)(?:^|\b|(?w:\b))(?:{})(?:\b|(?w:\b)|$)".format(
+        "|".join([
+            # This list contains entries from the bad keywords list which we shouldn't double-detect.
+            r"(?:support|service|helpline)(?:[\W_]*+phone)?[\W_]*+numbers?+(?<=^.{0,225})",
+        ]))).search(s)
+    if phrase and not excluded:
+        return True, u"Key phrase: *{}*".format(phrase.group(0))
+    return False, ""
+
+
+# noinspection PyUnusedLocal,PyMissingTypeHints
+@create_rule("scam aimed at customers in {}")
+def scam_aimed_at_customers(s, site):  # Scams aimed at customers of specific companies or industries
     s = s[0:300].lower()   # if applied to body, the beginning should be enough: otherwise many false positives
     s = regex.sub(r"[^A-Za-z0-9\s]", "", s)   # deobfuscate
-    phrase = regex.compile(r"(tech(nical)? support)|((support|service|contact|help(line)?) (telephone|phone|"
-                           r"number))").search(s)
-    if phrase and site in ["askubuntu.com", "webapps.stackexchange.com", "webmasters.stackexchange.com"]:
-        return True, u"Key phrase: *{}*".format(phrase.group(0))
     business = regex.compile(
         r"(?i)\b(airlines?|apple|AVG|BT|netflix|dell|Delta|epson|facebook|gmail|google|hotmail|hp|"
         r"lexmark|mcafee|microsoft|norton|out[l1]ook|quickbooks|sage|windows?|yahoo)\b").search(s)
@@ -793,7 +808,7 @@ def has_customer_service(s, site):  # flexible detection of customer service
                                  r"contact|tech|technical|telephone|number)\b").findall(s)
         if len(set(keywords)) >= 2:
             matches = ", ".join(["".join(match) for match in keywords])
-            return True, u"Scam aimed at *{}* customers. Keywords: *{}*".format(business.group(0), matches)
+            return True, u"Targeting *{}* customers. Keywords: *{}*".format(business.group(0), matches)
     return False, ""
 
 

--- a/findspam.py
+++ b/findspam.py
@@ -776,7 +776,7 @@ def check_watched_numbers(s, site):
 
 
 # noinspection PyUnusedLocal,PyMissingTypeHints
-@create_rule("customer support phrase in {}", all=False, sites=[
+@create_rule("potentially bad keyword in {}", all=False, sites=[
     "askubuntu.com", "webapps.stackexchange.com", "webmasters.stackexchange.com"])
 def customer_support_phrase(s, site):  # flexible detection of customer service
     shortened = s[0:300].lower()   # if applied to body, the beginning should be enough: otherwise many false positives


### PR DESCRIPTION
These do different things than what's in bad keywords. Importantly, they both also have a dramatically different %TP than what we target for bad keywords, which makes it inappropriate for us to be lumping them in with the bad keywords detection.

#### "scam aimed at customers in {}"
* "scam aimed at customers in" is [734 Total / 250 TP (34.06% TP) / 426 FP / 69 NAA](https://metasmoke.erwaysoftware.com/search?utf8=%E2%9C%93&why_is_regex=1&why=Scam+aimed+at). 34%TP is **way** under what we target seeing for bad keywords.

#### "customer support phrase in {}" added to "potentially bad keyword in {}"
This PR will move it from under "bad keyword in", where it's wildly under the target %TP, to "potentially bad keyword in". The combination of very low detection volume and mid-level %TP doesn't justify having this as a separate named detection.

Without excluding the duplicate detection with bad keywords (this detection was changed such that those detections are now excluded):
* "customer support phrase in" is [193 Total / 156 TP (80.83% TP) / 31 FP / 6 NAA](https://metasmoke.erwaysoftware.com/search?utf8=%E2%9C%93&why_is_regex=1&why=Key+phrase).

However, when the detections which are duplicated by bad keywords (i.e. detecting the same phrase, not just something else in the post), it drops to (about):
* No duplicates with "bad keyword in": [28 Total / 13 TP (46.43% TP) / 13 FP / 2 NAA](https://metasmoke.erwaysoftware.com/search?utf8=%E2%9C%93&why_is_regex=1&why=%28%3Fis%29Bad+keyword+in+%5B%5E-%5D*-+Key+phrase%3A%28%3F%21.*Bad+keyword+in+%5B%5E%3A%5D*%3A+%5B%5E%5Cr%5Cn%5D*%5Cb%28%3F%3A%28%3F%3Asupport%7Cservice%7Chelpline%29%28%3F%3A%5B%5CW_%5D*%2Bphone%29%3F%5B%5CW_%5D*%2Bnumbers%3F%2B%29%28%3F%3A%5Cb%7C%24%29%29).

That's just not enough to justify having a separate detection. If it was a separate detection, it would take a year and a half to
accumulate the 20 detections needed for it to have a weight which isn't locked to zero.