### PR TITLE
chatcommands.py: trap U+202D invisible character

### DIFF
--- a/chatcommands.py
+++ b/chatcommands.py
@@ -359,6 +359,12 @@ def do_blacklist(blacklist_type, msg, force=False):
 
     pattern = get_pattern_from_content_source(msg)
 
+    has_u202d = ""
+    if '\u202d' in pattern:
+        has_u202d = (
+            "The pattern contains an invisible U+202D whitespace character;"
+            " - in most cases, you don't want that")
+
     has_unescaped_dot = ""
     if "number" not in blacklist_type:
         # Test for . without \., but not in comments.
@@ -391,10 +397,14 @@ def do_blacklist(blacklist_type, msg, force=False):
                 concretized_pattern, is_username=username, is_watchlist=is_watchlist, is_phone=is_phone)
 
             if reasons:
+                has_u202d = "; in addition, " + has_u202d.lower() if has_u202d else ""
                 has_unescaped_dot = "; in addition, " + has_unescaped_dot.lower() if has_unescaped_dot else ""
                 raise CmdException(
                     "That pattern looks like it's already caught by " +
-                    format_blacklist_reasons(reasons) + has_unescaped_dot + append_force_to_do)
+                    format_blacklist_reasons(reasons) + has_unescaped_dot + has_u202d + append_force_to_do)
+
+        if has_u202d:
+            raise CmdException(has_u202d + has_unescaped_dot + append_force_to_do)
 
         if has_unescaped_dot:
             raise CmdException(has_unescaped_dot + append_force_to_do)


### PR DESCRIPTION
Display a warning; require -force to override it.

For the record, I have repeatedly submitted commits to remove this character where it had slipped in; most recently, https://github.com/Charcoal-SE/SmokeDetector/commit/7c9aa02d9407dc110a934a44271a586a0c5d92ce