### PR TITLE
Remove dnspython depreciation warning

### DIFF
--- a/blacklists.py
+++ b/blacklists.py
@@ -298,12 +298,12 @@ class YAMLParserNS(YAMLParserCIDR):
             if item.get('disable', None):
                 return False
             try:
-                addr = dns.resolver.query(ns, 'a')
+                addr = dns.resolver.resolve(ns, 'a')
                 log('debug', '{0} resolved to {1}'.format(
                     ns, ','.join(x.to_text() for x in addr)))
             except (dns.resolver.NXDOMAIN, dns.resolver.NoAnswer):
                 if not item.get('pass', None):
-                    soa = dns.resolver.query(ns, 'soa')
+                    soa = dns.resolver.resolve(ns, 'soa')
                     log('debug', '{0} has no A record; SOA is {1}'.format(
                         ns, ';'.join(s.to_text() for s in soa)))
             except dns.resolver.NoNameservers:

--- a/findspam.py
+++ b/findspam.py
@@ -1035,7 +1035,9 @@ def dns_query(label, qtype):
         return DNS_CACHE[(label, qtype)]['result']
     try:
         starttime = datetime.utcnow()
-        answer = dns.resolver.query(label, qtype)
+        # Switched from dns.resolver.query
+        # See also https://github.com/rthalley/dnspython/issues/581
+        answer = dns.resolver.resolve(label, qtype)
     except dns.exception.DNSException as exc:
         if str(exc).startswith('None of DNS query names exist:'):
             log('debug', 'DNS label {0} not found; skipping'.format(label))


### PR DESCRIPTION
Where previously we used dns.resolver.query(), switch to d.r.resolve()

Complete compatibility would require d.r.resolve(search=True) but this works without it so far.

Perhaps see also https://github.com/rthalley/dnspython/issues/581