### PR TITLE
GH Actions: Push current ref to deploy branch after test success

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,3 +62,12 @@ jobs:
       run: |
         echo -e "## Coverage Report\n" >> "$GITHUB_STEP_SUMMARY"
         coverage report --format=markdown -m >> "$GITHUB_STEP_SUMMARY"
+
+  release:
+    if: ${{ github.ref == 'master' }}
+    needs: build
+    steps:
+    - uses: actions/checkout@v7
+    - name: Push to deploy
+      run: |
+        git push origin +HEAD:deploy

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,5 +69,6 @@ jobs:
     steps:
     - uses: actions/checkout@v7
     - name: Push to deploy
+      continue-on-error: true
       run: |
-        git push origin +HEAD:deploy
+        git push origin HEAD:deploy


### PR DESCRIPTION
So we don't rely MS on updating the deploy branch (we still rely it on notifying running Smokey instances).

The "deploy" job only runs after the "build" job succeeds (i.e. the whole build matrix succeeds). Since MS is also relying on CI success (webhook), this should make no difference in terms of software integrity.