### PR TITLE
Stop posting to room 8089 Mempool

### DIFF
--- a/rooms.yml
+++ b/rooms.yml
@@ -213,12 +213,6 @@ stackexchange.com:
       - site-parenting.stackexchange.com
       - offensive-mask
 
-  8089:  # mempool
-    commands: false
-    msg_types:
-      - site-bitcoin.stackexchange.com
-      - offensive-mask
-
   468:  # V'dibarta Bam
     commands: false
     msg_types:


### PR DESCRIPTION
Hi, 
the Bitcoin folk is not particularly active on the SE chat and we mostly just remove whatever crops up with flags on the site long before we see it in the chat. So, I'd like to stop the smoke detector from posting to the mempool chat (the Bitcoin public chat room, 8089). Hope this PR does that. 

Thank you for your work!