### PR TITLE
Add "accept" as an alias for the "approve" command

### DIFF
--- a/chatcommands.py
+++ b/chatcommands.py
@@ -532,7 +532,7 @@ def unblacklist(msg, item, alias_used="unwatch"):
     return result
 
 
-@command(int, privileged=True, whole_msg=True)
+@command(int, privileged=True, whole_msg=True, aliases=["accept"])
 def approve(msg, pr_id):
     code_permissions = is_code_privileged(msg._client.host, msg.owner.id)
     if not code_permissions:


### PR DESCRIPTION
Per [Thomas Ward's slight annoyance here](https://chat.stackexchange.com/transcript/message/56600773) ... And [here](https://chat.stackexchange.com/transcript/11540?m=55625359) ... And [here](https://chat.stackexchange.com/transcript/11540?m=55478132) ... and tripleee's [attempt here](https://chat.stackexchange.com/transcript/11540?m=55435758), `accept` seems like a pretty **accept**able alias for `approve`.

Thomas Ward also [mentioned he was going to add this anyway](https://chat.stackexchange.com/transcript/message/56601228), so I figured I would save him the keystrokes. :)