### PR TITLE
.pullapprove.yml: add cigien

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -33,6 +33,7 @@ groups:
       - angussidney
       - bertiebaggio # Rob Hallam
       - bwDraco
+      - cigien
       - double-beep
       - ferrybig
       - honnza  # Jan Dvorak


### PR DESCRIPTION
To enable @cigien as blacklister.

Sent invitation to Charcoal team on Github and clicked blacklister on metasmoke account. (In fact, I guess somebody else did the latter already.)