### PR TITLE
Allow admins to merge all PRs

### DIFF
--- a/chatcommands.py
+++ b/chatcommands.py
@@ -541,7 +541,7 @@ def approve(msg, pr_id):
     # Forward this, because checks are better placed in gitmanager.py
     try:
         has_code_permissions = msg.owner.id in [62118, 66258, 73046, 121520, 145827, 156050] \
-                               and msg._client.host == "stackexchange.com"
+            and msg._client.host == "stackexchange.com"
         message_url = "https://chat.{}/transcript/{}?m={}".format(msg._client.host, msg.room.id, msg.id)
         chat_user_profile_link = "https://chat.{}/users/{}".format(
             msg._client.host, msg.owner.id)

--- a/chatcommands.py
+++ b/chatcommands.py
@@ -540,7 +540,7 @@ def approve(msg, pr_id):
 
     # Forward this, because checks are better placed in gitmanager.py
     try:
-        has_code_permissions = msg.owner.id in [62118, 66258, 73046, 121520, 145827, 156050]
+        has_code_permissions = msg.owner.id in [62118, 66258, 73046, 121520, 145827, 156050] and msg._client.host == "stackexchange.com"
         message_url = "https://chat.{}/transcript/{}?m={}".format(msg._client.host, msg.room.id, msg.id)
         chat_user_profile_link = "https://chat.{}/users/{}".format(
             msg._client.host, msg.owner.id)

--- a/chatcommands.py
+++ b/chatcommands.py
@@ -540,7 +540,8 @@ def approve(msg, pr_id):
 
     # Forward this, because checks are better placed in gitmanager.py
     try:
-        has_code_permissions = msg.owner.id in [62118, 66258, 73046, 121520, 145827, 156050] and msg._client.host == "stackexchange.com"
+        has_code_permissions = msg.owner.id in [62118, 66258, 73046, 121520, 145827, 156050] \
+                               and msg._client.host == "stackexchange.com"
         message_url = "https://chat.{}/transcript/{}?m={}".format(msg._client.host, msg.room.id, msg.id)
         chat_user_profile_link = "https://chat.{}/users/{}".format(
             msg._client.host, msg.owner.id)

--- a/chatcommands.py
+++ b/chatcommands.py
@@ -540,6 +540,7 @@ def approve(msg, pr_id):
 
     # Forward this, because checks are better placed in gitmanager.py
     try:
+        has_code_permissions = msg.owner.id in [62118, 66258, 73046, 121520, 145827, 156050]
         message_url = "https://chat.{}/transcript/{}?m={}".format(msg._client.host, msg.room.id, msg.id)
         chat_user_profile_link = "https://chat.{}/users/{}".format(
             msg._client.host, msg.owner.id)
@@ -548,7 +549,7 @@ def approve(msg, pr_id):
             # The image of (blacklisters|approved) from PullApprove
             "https://camo.githubusercontent.com/7d7689a88a6788541a0a87c6605c4fdc2475569f/68747470733a2f2f696d672e"
             "736869656c64732e696f2f62616467652f626c61636b6c6973746572732d617070726f7665642d627269676874677265656e")
-        message = GitManager.merge_pull_request(pr_id, comment)
+        message = GitManager.merge_pull_request(pr_id, comment, has_code_permissions)
         if only_blacklists_changed(GitManager.get_local_diff()):
             try:
                 if not GlobalVars.on_branch:

--- a/gitmanager.py
+++ b/gitmanager.py
@@ -336,7 +336,7 @@ class GitManager:
         return True, 'Removed `{}` from {}'.format(item, list_type)
 
     @classmethod
-    def merge_pull_request(cls, pr_id, has_code_permissions=False, comment=""):
+    def merge_pull_request(cls, pr_id, comment="", has_code_permissions=False):
         response = requests.get("https://api.github.com/repos/{}/pulls/{}".format(GlobalVars.bot_repo_slug, pr_id))
         if not response:
             raise ConnectionError("Cannot connect to GitHub API")

--- a/gitmanager.py
+++ b/gitmanager.py
@@ -336,15 +336,13 @@ class GitManager:
         return True, 'Removed `{}` from {}'.format(item, list_type)
 
     @classmethod
-    def merge_pull_request(cls, pr_id, comment=""):
+    def merge_pull_request(cls, pr_id, has_code_permissions=False, comment=""):
         response = requests.get("https://api.github.com/repos/{}/pulls/{}".format(GlobalVars.bot_repo_slug, pr_id))
         if not response:
             raise ConnectionError("Cannot connect to GitHub API")
         pr_info = response.json()
-        if pr_info["user"]["login"] != "SmokeDetector":
+        if pr_info["user"]["login"] != "SmokeDetector" and not has_code_permissions:
             raise ValueError("PR #{} is not created by me, so I can't approve it.".format(pr_id))
-        if "<!-- METASMOKE-BLACKLIST" not in pr_info["body"]:
-            raise ValueError("PR description is malformed. Blame a developer.")
         if pr_info["state"] != "open":
             raise ValueError("PR #{} is not currently open, so I won't merge it.".format(pr_id))
         ref = pr_info['head']['ref']


### PR DESCRIPTION
I have frequently seen admins trying to merge PRs which are code changes. Because these weren't created by SmokeDetector they can't be merged from chat. This PR checks the user ID of the user who sent the `approve` command and if they are a admin (this check is done through matching the user ID against a hard-coded list of all the admins ID's) it allows them to merge all PRs, even those which aren't created by SmokeDetector.