### PR TITLE
Check for whitespace at beginning of a watch pattern, requiring -force to continue

### DIFF
--- a/chatcommands.py
+++ b/chatcommands.py
@@ -364,7 +364,7 @@ def do_blacklist(blacklist_type, msg, force=False):
         has_u202d = (
             "The pattern contains an invisible U+202D whitespace character;"
             " - in most cases, you don't want that")
-    
+
     has_leading_whitespace = ""
     if regex.search(r"^\s+", pattern):
         has_leading_whitespace = (
@@ -405,11 +405,13 @@ def do_blacklist(blacklist_type, msg, force=False):
             if reasons:
                 has_u202d = "; in addition, " + has_u202d.lower() if has_u202d else ""
                 has_unescaped_dot = "; in addition, " + has_unescaped_dot.lower() if has_unescaped_dot else ""
-                has_leading_whitespace = "; in addition, " + has_leading_whitespace.lower() if has_leading_whitespace else ""
+                has_leading_whitespace = (
+                    "; in addition, " + has_leading_whitespace.lower()) if has_leading_whitespace else ""
                 raise CmdException(
                     "That pattern looks like it's already caught by " +
-                    format_blacklist_reasons(reasons) + has_unescaped_dot + has_u202d + has_leading_whitespace + append_force_to_do)
-        
+                    format_blacklist_reasons(reasons) + has_unescaped_dot + has_u202d + 
+                    has_leading_whitespace + append_force_to_do)
+
         if has_leading_whitespace:
             raise CmdException(has_leading_whitespace + has_unescaped_dot + has_u202d + append_force_to_do)
 

--- a/chatcommands.py
+++ b/chatcommands.py
@@ -409,7 +409,7 @@ def do_blacklist(blacklist_type, msg, force=False):
                     "; in addition, " + has_leading_whitespace.lower()) if has_leading_whitespace else ""
                 raise CmdException(
                     "That pattern looks like it's already caught by " +
-                    format_blacklist_reasons(reasons) + has_unescaped_dot + has_u202d + 
+                    format_blacklist_reasons(reasons) + has_unescaped_dot + has_u202d +
                     has_leading_whitespace + append_force_to_do)
 
         if has_leading_whitespace:

--- a/chatcommands.py
+++ b/chatcommands.py
@@ -364,6 +364,12 @@ def do_blacklist(blacklist_type, msg, force=False):
         has_u202d = (
             "The pattern contains an invisible U+202D whitespace character;"
             " - in most cases, you don't want that")
+    
+    has_leading_whitespace = ""
+    if regex.search(r"^\s+", pattern):
+        has_leading_whitespace = (
+            "That pattern starts with whitespace;"
+            " in most cases, you don't want that")
 
     has_unescaped_dot = ""
     if "number" not in blacklist_type:
@@ -399,9 +405,13 @@ def do_blacklist(blacklist_type, msg, force=False):
             if reasons:
                 has_u202d = "; in addition, " + has_u202d.lower() if has_u202d else ""
                 has_unescaped_dot = "; in addition, " + has_unescaped_dot.lower() if has_unescaped_dot else ""
+                has_leading_whitespace = "; in addition, " + has_leading_whitespace.lower() if has_leading_whitespace else ""
                 raise CmdException(
                     "That pattern looks like it's already caught by " +
-                    format_blacklist_reasons(reasons) + has_unescaped_dot + has_u202d + append_force_to_do)
+                    format_blacklist_reasons(reasons) + has_unescaped_dot + has_u202d + has_leading_whitespace + append_force_to_do)
+        
+        if has_leading_whitespace:
+            raise CmdException(has_leading_whitespace + has_unescaped_dot + has_u202d + append_force_to_do)
 
         if has_u202d:
             raise CmdException(has_u202d + has_unescaped_dot + append_force_to_do)


### PR DESCRIPTION
I recently [accidentally watched an expression with a space at the beginning](https://chat.stackexchange.com/transcript/11540?m=57953326) completely unintentionally, as I was copy-pasting off of a list. In chat, this looks as though everything worked correctly and there is nothing wrong, but there's actually some hidden leading whitespace there.

This isn't the first time I've run into this problem. I've approved #5921 and #5789 ([knowingly](https://chat.stackexchange.com/transcript/message/57130415), I'll add) just to see if they would work, because the watch commands as viewed from chat would lead one to believe it was entered correctly. Naturally, the watches did not catch their intended targets in these instances.

**What this PR does:**
This addition checks for leading white space against the currently proposed pattern. If it's found, it throws a similar message at the user that #5114 introduced, and allows `-force` to be used to override.

I know of no real reason why anyone would want to start a watch with whitespace, but given that SE chat shaves off leading whitespace visually (but does not functionally) it's 99 times out of 100 a mistake, and in my opinion, should warn the user about what they're doing while still preserving the ability to force the change through if thou happen-est to be that 1 user out of 100.

**Potential improvements:**
- Implement something akin to what Makyen [explains here](https://github.com/Charcoal-SE/SmokeDetector/pull/5114#issuecomment-726330001), which would probably be more useful to the user.
- Display the raw pattern to the user in the reply, so they can see the source of the message they sent, and thus why Smokey found it problematic.

**Did you even test this?**
Yep, [I did!](https://chat.stackexchange.com/transcript/message/57971618) I didn't have a spare sock so I just threw this against my own user and fired away. As a note, for this test there were two differences. One, I used `pattern.startswith(" ")`, which I changed to use regex considering #5928 did something similar and used regex (and this regex covers various whitespace characters, not just a "regular" space.) Two, the error message was very slightly different, and even then, only in punctuation and grammar (looks cleaner now, imo)

Feel free to adjust this PR as fitting with the code practices used by Charcoalers, or request that I do so.