### PR TITLE
globalvars.py: Use ConfigParser instead of RawConfigParser

### DIFF
--- a/globalvars.py
+++ b/globalvars.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from html.parser import HTMLParser
 from html import unescape
 from hashlib import md5
-from configparser import NoOptionError, RawConfigParser
+from configparser import NoOptionError, ConfigParser
 import threading
 # noinspection PyCompatibility
 import regex
@@ -161,7 +161,7 @@ class GlobalVars:
                 GlobalVars.PostScanStat.num_posts_scanned = 0
                 GlobalVars.PostScanStat.post_scan_time = 0
 
-    config_parser = RawConfigParser()
+    config_parser = ConfigParser(interpolation=None)
 
     if os.path.isfile('config') and "pytest" not in sys.modules:
         config_parser.read('config')


### PR DESCRIPTION
According to the documentation for `configparser.RawConfigParser` (https://docs.python.org/3/library/configparser.html#configparser.RawConfigParser), this is a **legacy** API call that allows for non-string section names, option names, and values via the unsafe `add_section` and `set` methods.  We don't use those methods, but it's overall still a legacy compatibility and should be avoided.

The documentation suggests that instead of using `RawConfigParser`, we should use `ConfigParser` and set `interpolation=None` at instantiation instead.