### PR TITLE
Create DNS comparison command for privileged users.

### DIFF
--- a/chatcommands.py
+++ b/chatcommands.py
@@ -2344,7 +2344,7 @@ def dnscheck(domain) -> str:
     :return: A comparison of domain data if data doesn't match, or "No discrepancy"
     """
     # Initialize Google resolver
-    google = dns.resolver.Resolve(configure=False)
+    google = dns.resolver.Resolver(configure=False)
     google.nameservers = ['8.8.8.8', '8.8.4.4']
     google.cache = None
 


### PR DESCRIPTION
Back when we had a discrepancy in DNS results, we were afraid SmokeDetector might be a part of it.  Which is what let ArtOfCode to create the `dig` command, so we could look at DNS results returned by SmokeDetector.

With the recent changes done to SmokeDetector with #6541, we now have the capacity to customize SmokeDetector's DNS settings and configurations.  Which means that having a customizable DNS means we need a mechanism to compare DNS output from SmokeDetector's DNS settings and a reliable DNS server.  In this case, I chose Google DNS as a comparative server for our use to compare against whatever DNS setup is done on SmokeDetector instances, whether system configured DNS or customized DNS with individual SD instances.