### PR TITLE
Improve response to SE main downtime

### DIFF
--- a/chatcommands.py
+++ b/chatcommands.py
@@ -2362,3 +2362,18 @@ def dnscheck(domain) -> str:
                    "{}".format(domain, sdres.rrset)
 
     return response
+
+
+# noinspection PyIncorrectDocstring,PyUnusedLocal
+@command(str, privileged=True)
+def no_se_websocket_activity(what):
+    """
+    Ignore or monitor when there is no SE WebSocket activity
+    :param what:
+    :return: A string
+    """
+
+    with GlobalVars.ignore_no_se_websocket_activity_lock:
+        GlobalVars.ignore_no_se_websocket_activity = what == 'ignore'
+        ignoring_or_monitoring = "ignoring" if GlobalVars.ignore_no_se_websocket_activity else "monitoring"
+    return "Now {} when there's no Stack Exchange WebSocket activity.".format(ignoring_or_monitoring)

--- a/globalvars.py
+++ b/globalvars.py
@@ -129,6 +129,9 @@ class GlobalVars:
     no_se_activity_scan = False
     no_deletion_watcher = False
 
+    ignore_no_se_websocket_activity_lock = threading.Lock()
+    ignore_no_se_websocket_activity = False
+
     api_request_lock = threading.Lock()  # Get this lock before making API requests
     apiquota_rw_lock = threading.Lock()  # Get this lock before reading/writing apiquota
 

--- a/metasmoke.py
+++ b/metasmoke.py
@@ -673,7 +673,11 @@ class Metasmoke:
             if GlobalVars.PostScanStat.get_stat() == Metasmoke.scan_stat_snapshot:
                 # There's been no actvity since the last ping.
                 Metasmoke.status_pings_since_scan_activity += 1
-                if Metasmoke.status_pings_since_scan_activity >= NO_ACTIVITY_PINGS_TO_REBOOT:
+                with GlobalVars.ignore_no_se_websocket_activity_lock:
+                    ignore_no_se_websocket_activity = GlobalVars.ignore_no_se_websocket_activity
+                if ignore_no_se_websocket_activity:
+                    pass
+                elif Metasmoke.status_pings_since_scan_activity >= NO_ACTIVITY_PINGS_TO_REBOOT:
                     # Assume something is very wrong. Report to debug rooms and go into standby mode.
                     reboot_or_standby("reboot")
                 elif Metasmoke.status_pings_since_scan_activity >= NO_ACTIVITY_PINGS_TO_STANDBY:


### PR DESCRIPTION
This PR does two things which should improve how SD handles SE main being in read-only mode (and some of the ways SE goes down).
1. Login to chat only using stored cookies is added such that SD doesn't require SE main to be in read/write mode in order to continue to use the cookies which SD already has. If logging in fails, SD still falls back to both older methods. If SD ends up falling back to having to log in via username and password, then it still needs SE main to be in read/write mode.  
   This should allow SD to communicate in chat after rebooting when SE is in read-only mode.

   This is is still a bit brittle, particularly with respect to ditching the stored cookies upon a single failure. Not deleting the cookies upon failure needs some additional testing in various SE failure modes prior to implementing it. Basically, in other testing, I've seen times where dropping the cookies and rebooting has helped. I expect this is resolvable. It just needs more testing/experimentation prior to being implemented in SD.

   What's implemented for this feature should be pushed into ChatExchange. I'll see if I can get that done. It's currently implemented within SD's code, because I wanted something that could be available for SE's scheduled maintenance which is in several hours. Changes to ChatExchange require coordination with the SD runners, as it's a requirement which isn't updated while SD is running.

2. Implement a `!!/no_se_websocket_activity ignore` command which toggles off SD monitoring for there having been no SE WebSocket activity after 3 or 4 status pings. In other words, when `!!/no_se_websocket_activity ignore`  is issued SD won't complain in chat or reboot when it's not seeing any activity on the SE WebSocket, as happens when SE is in read-only mode.