### PR TITLE
Blacklist frontlist.com

### DIFF
--- a/blacklisted_websites.txt
+++ b/blacklisted_websites.txt
@@ -4287,3 +4287,4 @@ peopleperhour\.com/hourlie/
 smartprivatekeyhack\.com
 clawscustomboxes\.co\.uk
 godofseo\.com
+frontlist\.com


### PR DESCRIPTION
This website was discovered from the following audit and is guaranteed to generate a high TPR when blacklisted.
https://stackoverflow.com/review/triage/30343229

For your information, I have carefully read the [Guidance for Blacklisting](https://charcoal-se.org/smokey/Guidance-for-Blacklisting-and-Watching). Although this website does not meet the [General TP&FP requirements](https://charcoal-se.org/smokey/Guidance-for-Blacklisting-and-Watching#general-true-positive-and-false-positive-requirements) as far as I know, this gambling/scam website can hardly be useful for any Stack Exchange site.