### PR TITLE
Add capability for "valid_detection_reasons" list in the config file

### DIFF
--- a/config.sample
+++ b/config.sample
@@ -36,3 +36,12 @@ location=location_here
 dns_resolver=system
 dns_cache_enabled=True
 dns_cache_cleanup_interval=300.0
+
+# Run only the following specified detection reasons.
+# "valid_detection_reasons" is a semicolon separated list of detections which are permitted to run.
+# If the rule's "reason" has an exact match in the following list, then the rule is run. If the
+# rule's "reason" is not in the list, then it's not run.
+# Currently, "blacklisted user" is run separately, so is always run, regardless of it not
+# being in the list. If no list is specified, then all detections are run.
+# Whitespace is not trimmed from the entries in the list.
+# valid_detection_reasons:potentially bad keyword in {};potentially bad IP for hostname in {}

--- a/findspam.py
+++ b/findspam.py
@@ -647,6 +647,10 @@ def create_rule(reason, regex=None, func=None, *, all=True, sites=[],
     if not isinstance(reason, str):
         raise ValueError("reason must be a string")
 
+    if GlobalVars.valid_detection_reasons is not None and reason not in GlobalVars.valid_detection_reasons:
+        # There was a list of reasons provided in the config file as valid and this detection reason isn't in that list.
+        disabled = True
+
     if not (body or body_summary or username):  # title-only
         answer = False  # answers have no titles, this saves some loops
     post_filter = PostFilter(all_sites=all, sites=sites, max_score=max_score, max_rep=max_rep,

--- a/globalvars.py
+++ b/globalvars.py
@@ -294,6 +294,12 @@ class GlobalVars:
         if id:
             config_blacklisters.add(("stackoverflow.com", int(id)))
 
+    # If the config has it, get a list of the detection reasons which are considered valid.
+    # The list is semicolon separated.
+    valid_detection_reasons = config.get("valid_detection_reasons", None)
+    if valid_detection_reasons is not None:
+        valid_detection_reasons = valid_detection_reasons.split(";")
+
     # environ_or_none replaced by os.environ.get (essentially dict.get)
     bot_name = os.environ.get("SMOKEDETECTOR_NAME", git_name)
     bot_repo_slug = os.environ.get("SMOKEDETECTOR_REPO", git_user_repo)


### PR DESCRIPTION
This adds an optional "valid_detection_reasons" entry in the config file. When used, only the specified detection rules are run. The entries in the list must exactly match the `reason` which was specified in the detection rule. This is primarily for testing/development. The intent is that it allows testing to focus on a new or changed detection without running all of the other detections on every post.