### PR TITLE
For chat messages > 500 characters, don't drop, add a newline

### DIFF
--- a/chatcommunicate.py
+++ b/chatcommunicate.py
@@ -234,10 +234,9 @@ def send_messages():
     while True:
         room, msg, report_data = _msg_queue.get()
         if len(msg) > 500 and "\n" not in msg:
-            log('warn', 'Discarded the following message because it was over 500 characters')
+            log('warn', 'The following message was over 500 characters')
             log('warn', msg)
-            _msg_queue.task_done()
-            continue
+            msg = msg[:490] + "\n" + msg[490:]
 
         full_retries = 0
 


### PR DESCRIPTION
Currently, SD just drops any message which is > 500 characters and doesn't have a `\n` in it to make it multi-line. This change just forces adding a `\n` and posts the message as a multi-line chat message. At a minimum, this will let us see the messages, rather than only have them in the console log.