### PR TITLE
Add optional "valid_rule_ids" in config, similar to "valid_detection_reasons"

### DIFF
--- a/globalvars.py
+++ b/globalvars.py
@@ -300,6 +300,12 @@ class GlobalVars:
     if valid_detection_reasons is not None:
         valid_detection_reasons = valid_detection_reasons.split(";")
 
+    # If the config has it, get a list of the detection IDs which are considered valid.
+    # The list is semicolon separated.
+    valid_rule_ids = config.get("valid_rule_ids", None)
+    if valid_rule_ids is not None:
+        valid_rule_ids = valid_rule_ids.split(";")
+
     # environ_or_none replaced by os.environ.get (essentially dict.get)
     bot_name = os.environ.get("SMOKEDETECTOR_NAME", git_name)
     bot_repo_slug = os.environ.get("SMOKEDETECTOR_REPO", git_user_repo)


### PR DESCRIPTION
Similar to [Add capability for "valid_detection_reasons" list in the config file](https://github.com/Charcoal-SE/SmokeDetector/pull/6771), this PR adds an optional `valid_rule_ids` entry to the config file, which can be used to to restrict the rules used by the SmokeDetector instance. This will be useful for testing. In working on the number detections, I found I needed to be able to target specific rules for enabling, rather than detection reasons, due to there being multiple rules with the `reason` of "potentially bad keyword in {}".

If a rule has a `rule_id`, then it's required to be unique. I haven't gone through and added `rule_id` properties to every rule.