### PR TITLE
findspam.py: add alfa.com.tw to WHITELISTED_IP_HOSTNAMES

### DIFF
--- a/findspam.py
+++ b/findspam.py
@@ -126,6 +126,7 @@ ASN_WHITELISTED_WEBSITES = [
 # Hostnames should be all lowercase, as the hostnames are obtained from
 # urlparse().hostname, which lowercases the hostname.
 WHITELISTED_IP_HOSTNAMES = [
+    "alfa.com.tw",
     "angular.io",
     "api.flutter.dev",
     "bot.run",


### PR DESCRIPTION
Requested by Mast in chat:

https://chat.stackexchange.com/transcript/message/60458667#60458667