### PR TITLE
Revert limit to regex package version; Testing: compile watch and blacklist regexes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ pytest>=4.1.0
 phonenumbers>=8.8.11
 flake8~=3.8.0
 pep8-naming==0.7.0
-regex==2022.3.2
+regex>=2020.10.23
 termcolor>=1.1.0
 sh>=1.12.14
 typing>=3.6.4

--- a/watched_keywords.txt
+++ b/watched_keywords.txt
@@ -23432,7 +23432,7 @@
 1602984312	Jeff Schaller	yucagahz\.xyz
 1602984357	Jeff Schaller	bennettp123\.org
 1602995041	Ryan M	daftarmaindomino\.co
-1603007119	Makyen	open-(?P<openfilequotes>\w+)-file\/"">open-\k<openfilequotes>-file
+1603007119	Makyen	open-(?P<openfilequotes>\w+)-file\/"">open-\g<openfilequotes>-file
 1603007602	Makyen	primepornreview\.com
 1603007619	Makyen	primepornreview(?!\.com)
 1603009830	Mast	knownoverthinker\.wordpress\.com


### PR DESCRIPTION
* Revert `regex` package version limit.
   After investigation, the CI failures which we had upon updating the regex package to 2022.3.15 were cause by the regex package now raising an exception when it encounters a backslash escape which it doesn't understand. This is a change in how the regex package handles such issues. As I understand it, the regex package now supports Python 3.6 as the lowest Python version it's compatible with. The author of the regex packed explained that the `re` regular  expression package was changed in 3.6 to also raise exceptions in such cases. 
* Add compiling each regex as a part of `blacklist_integrity_check()`. This should more clearly identify similar issues in the future and also more clearly identify such issues when the lists are edited through PRs/commits, rather than using SD commands.
* Change the watch regex which was not compiling with the new version of the regex package. It turns out that the regex package implements `\g` the way that PCRE uses `\k` and doesn't implement `\k`.