### PR TITLE
Correct casing of coffee and tea names to fix grammar in replies

### DIFF
--- a/chatcommands.py
+++ b/chatcommands.py
@@ -749,7 +749,7 @@ def brownie():
     return "Brown!"
 
 
-COFFEES = ['Espresso', 'Macchiato', 'Ristretto', 'Americano', 'Latte', 'Cappuccino', 'Mocha', 'Affogato', 'jQuery']
+COFFEES = ['espresso', 'macchiato', 'ristretto', 'Americano', 'latte', 'cappuccino', 'mocha', 'affogato', 'jQuery']
 
 
 # noinspection PyIncorrectDocstring
@@ -778,7 +778,7 @@ def lick():
     return "*licks ice cream cone*"
 
 
-TEAS = ['earl grey', 'green', 'chamomile', 'lemon', 'darjeeling', 'mint', 'jasmine', 'passionfruit']
+TEAS = ['Earl Grey', 'green', 'chamomile', 'lemon', 'Darjeeling', 'mint', 'jasmine', 'passionfruit']
 
 
 # noinspection PyIncorrectDocstring


### PR DESCRIPTION
Previously, the names in the "COFFEE" list were all capitalized, while the names in the "TEAS" list were all lowercase. Grammatically, in the context of SmokeDetector's reply, lowercase is correct, so all names have been converted to lowercase, except where a particular name is a proper noun, in which case, it is correctly rendered in uppercase.