### PR TITLE
Increase YAMLParserNS _validate() DNS lookup timeout to 15s during CI testing.

### DIFF
--- a/blacklists.py
+++ b/blacklists.py
@@ -4,6 +4,7 @@ from typing import Union
 import regex
 import yaml
 import dns.resolver
+import sys
 
 from globalvars import GlobalVars
 from helpers import log
@@ -298,7 +299,11 @@ class YAMLParserNS(YAMLParserCIDR):
             if item.get('disable', None):
                 return False
             try:
-                addr = dns.resolver.resolve(ns, 'a', search=True)
+                # Extenmd lifetime if we are running a test
+                extra_params = dict()
+                if "pytest" in sys.modules:
+                    extra_params['lifetime'] = 15
+                addr = dns.resolver.resolve(ns, 'a', search=True, **extra_params)
                 # Outputing for every resolved entry makes it harder to find the actual error,
                 # due to being swamped with data in the error output.
                 # log('debug', '{0} resolved to {1}'.format(

--- a/blacklists.py
+++ b/blacklists.py
@@ -299,7 +299,7 @@ class YAMLParserNS(YAMLParserCIDR):
             if item.get('disable', None):
                 return False
             try:
-                # Extenmd lifetime if we are running a test
+                # Extend lifetime if we are running a test
                 extra_params = dict()
                 if "pytest" in sys.modules:
                     extra_params['lifetime'] = 15

--- a/findspam.py
+++ b/findspam.py
@@ -1273,7 +1273,7 @@ def dns_query(label, qtype):
     # If there's no cache then assume *now* is important
     try:
         starttime = datetime.utcnow()
-        # Extenmd lifetime if we are running a test
+        # Extend lifetime if we are running a test
         extra_params = dict()
         if "pytest" in sys.modules:
             extra_params['lifetime'] = 60


### PR DESCRIPTION
 For CI testing of YAML based lists, we get a lot of random CI failures in DNS testing. These appear to go away if retested. It appears that these are caused by a timeout. This increases the timeout from 5s to 15s.

This uses code coped from [this commit](8a8efa80190cf64e82c14d088dab7c0bffdff3d6).