### PR TITLE
Improve CI testing speed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,9 +6,18 @@ jobs:
     branches:
       ignore: deploy
     steps:
-      - checkout
       - restore_cache:
-          key: deps-cimg-python3.8-{{ .Branch }}-{{ checksum "requirements.txt" }}
+          # Restore a basic .git to prevent needing to download the whole thing.
+          keys:
+            - git-cimg-python3.8-{{ .Branch }}
+            - git-cimg-python3.8
+      - checkout
+      - save_cache:
+          key: git-cimg-python3.8-{{ .Branch }}
+          paths:
+            - ".git"
+      - restore_cache:
+          key: env-cimg-python3.8-{{ .Branch }}-{{ checksum "requirements.txt" }}
       - run:
           name: install python dependencies in venv
           command: |
@@ -17,7 +26,7 @@ jobs:
             env/bin/pip3 install -r requirements.txt --upgrade
             env/bin/pip3 install -r user_requirements.txt --upgrade
       - save_cache:
-          key: deps-cimg-python3.8-{{ .Branch }}-{{ checksum "requirements.txt" }}
+          key: env-cimg-python3.8-{{ .Branch }}-{{ checksum "requirements.txt" }}
           paths:
             - "env"
       - run:
@@ -36,4 +45,6 @@ jobs:
             git config user.email "smokey@erwaysoftware.com"
       - run:
           name: Pytest
+          # Use 5 processes is intended to allow one DNS lookup bound long running test run
+          # in parallel with most of the other tests which generally consume more CPU.
           command: env/bin/python3 -W default::Warning -m pytest -n 5 --dist loadgroup test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: deps-{{ .Branch }}-{{ checksum "requirements.txt" }}
+          key: deps-cimg-python3.8-{{ .Branch }}-{{ checksum "requirements.txt" }}
       - run:
           name: install python dependencies in venv
           command: |
@@ -17,7 +17,7 @@ jobs:
             env/bin/pip3 install -r requirements.txt --upgrade
             env/bin/pip3 install -r user_requirements.txt --upgrade
       - save_cache:
-          key: deps-{{ .Branch }}-{{ checksum "requirements.txt" }}
+          key: deps-cimg-python3.8-{{ .Branch }}-{{ checksum "requirements.txt" }}
           paths:
             - "env"
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,4 +36,4 @@ jobs:
             git config user.email "smokey@erwaysoftware.com"
       - run:
           name: Pytest
-          command: env/bin/python3 -W default::Warning -m pytest -n 4 test
+          command: env/bin/python3 -W default::Warning -m pytest -n 5 --dist loadgroup test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,4 +36,4 @@ jobs:
             git config user.email "smokey@erwaysoftware.com"
       - run:
           name: Pytest
-          command: env/bin/python3 -W default::Warning -m pytest test
+          command: env/bin/python3 -W default::Warning -m pytest -n 4 test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/python:3.8-buster
+      - image: cimg/python:3.8
     branches:
       ignore: deploy
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,23 +30,27 @@ jobs:
       id: cache
       uses: actions/cache@v2
       with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-1-${{ hashFiles('**/requirements.txt') }}
+        key: ${{ runner.os }}-${{ matrix.python-version }}-pip-1-${{ hashFiles('**/requirements.txt') }}
         restore-keys: |
-          ${{ runner.os }}-pip-1-
+          ${{ runner.os }}-${{ matrix.python-version }}-pip-1-${{ hashFiles('**/requirements.txt') }}
+          ${{ runner.os }}-${{ matrix.python-version }}-pip-1-
+        path: |
+          ~/.cache/pip
+          env
     - name: Install dependencies
       run: |
-        pip3 install -U wheel
-        pip3 install -U -r requirements.txt -r user_requirements.txt pytest-cov coveralls
+        python3 -m venv env
+        env/bin/pip3 install -U wheel
+        env/bin/pip3 install -U -r requirements.txt -r user_requirements.txt pytest-cov coveralls
     - name: Lint tests
-      run: flake8 --config=tox_tests.ini test/
+      run: env/bin/python3 -m flake8 --config=tox_tests.ini ./test/
     - name: Lint classes
-      run: flake8 --config=tox_classes.ini classes/
+      run: env/bin/python3 -m flake8 --config=tox_classes.ini ./classes/
     - name: Lint code
-      run: flake8 ./
+      run: env/bin/python3 -m flake8 ./
     - name: Pytest
       run: |
-        python3 -W default::Warning -m pytest \
+        env/bin/python3 -W default::Warning -m pytest \
           --cov=chatcommunicate \
           --cov=findspam \
           --cov=globalvars \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,5 +54,6 @@ jobs:
           --cov=datahandling \
           --cov=chatcommands \
           --cov=helpers \
-          -n 4 \
+          -n 5 \
+          --dist loadgroup \
           test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,6 +54,6 @@ jobs:
           --cov=datahandling \
           --cov=chatcommands \
           --cov=helpers \
-          -n 5 \
+          -n 3 \
           --dist loadgroup \
           test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,4 +54,5 @@ jobs:
           --cov=datahandling \
           --cov=chatcommands \
           --cov=helpers \
+          -n 4 \
           test

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ dnspython>=2.0.0
 PyYAML>=3.12
 msgpack-python>=0.5.6
 colorama>=0.4.1
+pytest-xdist>=2.5.0

--- a/test/test_blacklists.py
+++ b/test/test_blacklists.py
@@ -211,6 +211,8 @@ def test_yaml_asn():
     yaml_validate_existing('watched_asns.yml', YAMLParserASN)
 
 
+# test_yaml_nses currently takes 105s to run, so we want it to start up first, with everything else running in parallel.
+@pytest.mark.xdist_group(name="long_runner_1")
 def test_yaml_nses():
     with open('test_nses.yml', 'w') as y:
         yaml.dump({


### PR DESCRIPTION
This substantially reduces the amount of time which the CI testing takes in GitHub Actions and CircleCI.

### Example CI times
| Which testing | without PR |  with this PR |
|---------------|-------------|--------------|
| GH Actions<br/>Python 3.6 | [6m 7s](https://github.com/Charcoal-SE/SmokeDetector/runs/6294209828?check_suite_focus=true)  | [2m 55s](https://github.com/Charcoal-SE/SmokeDetector/runs/6295148586?check_suite_focus=true) |
| GH Actions<br/>Python 3.10 | [6m 45s](https://github.com/Charcoal-SE/SmokeDetector/runs/6294209884?check_suite_focus=true) | [3m 3s](https://github.com/Charcoal-SE/SmokeDetector/runs/6295148678?check_suite_focus=true) |
| CircleCI<br>Python 3.8 | [5m 51s](https://app.circleci.com/pipelines/github/Charcoal-SE/SmokeDetector/69250/workflows/71f84c9a-d15d-4bd3-a22a-b9f27d6445d8/jobs/108378) | [2m 26s](https://app.circleci.com/pipelines/github/Charcoal-SE/SmokeDetector/69254/workflows/246fece6-519a-41fb-b823-e858fc311130/jobs/108382) |

Note: for the times for with this PR, look at the times for the CI testing done on the PR, rather than the commit which was pushed. The commit will have higher times, because the dependency caches need to be regenerated.
### What was done
* Use `pytest-xdist` to run the tests in parallel in more than one process.
   * Assign the network-limited, longest-running, low-CPU, test `test_yaml_nses` to its own testing group
   *  Use 1 more process than there are CPUs, which allows the more CPU intensive tasks to be run while the above low-CPU test waits for network interactions
* CircleCI
   * Update build image to one which isn't deprecated
   * Cache the .git directory, so we don't spend a couple of minutes in each CI run downloading the repository
   * Use 5 processes
* GitHub Actions
   * Use 3 processes
   * Use Python's `venv` and cache the virtual environment directory. This reduces the amount of time installing dependencies.

### Drawbacks
When running the `pytest` tests in parallel, we don't get a nicely formatted header with pass/fail information shown on a per-test file basis.
#### New `pytest` Header
```
============================= test session starts ==============================
platform linux -- Python 3.10.4, pytest-7.1.2, pluggy-1.0.0
rootdir: /home/runner/work/Charcoal-SE-SmokeDetector/Charcoal-SE-SmokeDetector
plugins: forked-1.4.0, cov-2.10.1, xdist-2.5.0, timeout-2.1.0
gw0 I / gw1 I / gw2 I
gw0 [348] / gw1 [348] / gw2 [348]

...........................s............................................ [ 20%]
........................................................................ [ 41%]
........................................................................ [ 62%]
........................................................................ [ 82%]
............................................................             [100%]

---------- coverage: platform linux, python 3.10.4-final-0 -----------
Name                 Stmts   Miss  Cover
----------------------------------------
chatcommands.py       1277    685    46%
chatcommunicate.py     422    127    70%
datahandling.py        470    229    51%
findspam.py           1015    127    87%
globalvars.py          216     26    88%
helpers.py             206     84    59%
spamhandling.py        146     41    72%
----------------------------------------
TOTAL                 3752   1319    65%

================== 347 passed, 1 skipped in 187.45s (0:03:07) ==================
```
#### Old `pytest` Header
```
============================= test session starts ==============================
platform linux -- Python 3.10.4, pytest-7.1.2, pluggy-1.0.0
rootdir: /home/runner/work/SmokeDetector/SmokeDetector
plugins: cov-2.10.1, timeout-2.1.0
collected 348 items

test/test_blacklists.py ......                                           [  1%]
test/test_chatcommands.py ...................................            [ 11%]
test/test_chatcommunicate.py .......                                     [ 13%]
test/test_datahandling.py ..                                             [ 14%]
test/test_findspam.py .................................................. [ 28%]
........................................................................ [ 49%]
......                                                                   [ 51%]
test/test_globalvars.py .                                                [ 51%]
test/test_helpers.py ..                                                  [ 52%]
test/test_parsing.py ................................................... [ 66%]
......................................................................   [ 86%]
test/test_phone_numbers.py ...........                                   [ 89%]
test/test_socketscience.py .                                             [ 90%]
test/test_spamhandling.py ..................................             [100%]

---------- coverage: platform linux, python 3.10.4-final-0 -----------
Name                 Stmts   Miss  Cover
----------------------------------------
chatcommands.py       1277    600    53%
chatcommunicate.py     422    127    70%
datahandling.py        470    229    51%
findspam.py           1015    127    87%
globalvars.py          216     26    88%
helpers.py             202     82    59%
spamhandling.py        146     41    72%
----------------------------------------
TOTAL                 3748   1232    67%


======================= 348 passed in 349.57s (0:05:49) ========================
```