### PR TITLE
Fix Smokey being able to self-delete messages (poof/delete-force, automated self-deletion, etc.)

### DIFF
--- a/chatcommunicate.py
+++ b/chatcommunicate.py
@@ -90,6 +90,7 @@ def init(username, password, try_cookies=True):
                             if me.id > 0:
                                 client.logged_in = True
                                 logged_in = True
+                                client._thread.start()
                                 log('debug', 'chat.{}: Logged in to chat only using cached cookies'.format(site))
                         except Exception:
                             # This is a fallback using the ChatExchange functionality we've been using for a long time.


### PR DESCRIPTION
When reconnecting using a modified cookie-login method introduced in #6733 , as we're not calling one of the Chat Exchange "client" object's login methods, the Chat Exchange _worker thread doesn't get restarted, and as a result, message deletion is queued up but not performed. This PR explicitly starts that thread back up.

Had a chat with Makyen about this [here](https://chat.stackexchange.com/transcript/message/61152096#61152096), and for future reference, [he mentions](https://chat.stackexchange.com/transcript/message/61152294#61152294) we should probably implement an abbreviated login function into our fork of Chat Exchange that doesn't rely upon Main/Meta sites being up, but that's more of a "Would be nice"/"Implement if you have time" thing.

This resolves issue #6776 and a sub-issue [mentioned there by Ryan M](https://github.com/Charcoal-SE/SmokeDetector/issues/6776#issuecomment-985796442).