### PR TITLE
Store scan stats and add thread stats in BodyFetcher

### DIFF
--- a/bodyfetcher.py
+++ b/bodyfetcher.py
@@ -896,6 +896,6 @@ class BodyFetcher:
 
         end_time = time.time()
         scan_stats['scan_time'] = end_time - full_start_time
-        GlobalVars.PostScanStat.add_stat(scan_stats)
+        GlobalVars.PostScanStat.add(scan_stats)
         log('debug', current_thread.name)
         return

--- a/chatcommands.py
+++ b/chatcommands.py
@@ -954,6 +954,11 @@ def stat(operation, from_stats=None, to_stats=None, alias_used="stats"):
         'errors': 0,
         'max_scan_time': 0,
         'max_scan_time_post': '',
+        'post_processing_lock': 0,
+        'check_unchanged': 0,
+        'threads': '',
+        'high_CPU': '',
+        'site_limited': '',
     }
     known_operations = [
         'clear',
@@ -1039,10 +1044,21 @@ def stat(operation, from_stats=None, to_stats=None, alias_used="stats"):
         stats['posts_scanned'] = '{}, Q({}), A({})'.format(*posts_questions_answers_scanned)
         posts_questions_answers_scantime = (round(stats.pop('scan_time', 0), 2),
                                             round(stats.pop('scan_question', 0), 2),
-                                            round(stats.pop('scan_answers', 0), 2))
+                                            round(stats.pop('scan_answer', 0), 2))
         stats['scan_time'] = '{}, Q({}), A({})'.format(*posts_questions_answers_scantime)
         q_and_a_unchanged = tuple(stats.pop('unchanged_' + key, 0) for key in ['questions', 'answers'])
         stats['unchanged_posts'] = '{}, Q({}), A({})'.format(sum(q_and_a_unchanged), *q_and_a_unchanged)
+        threads_limited_so_non_so = (stats.pop('threads_limited_SO', 0), stats.pop('threads_limited_non_SO', 0))
+        limited_threads = sum(threads_limited_so_non_so)
+        total_threads = stats.pop('thread_count', 0)
+        api_calls = stats.pop('api_calls', 0)
+        stats['threads'] = ('{}, API({}), 155QA({})'
+                            ', EW({}), BFrr({})').format(total_threads,
+                                                         api_calls,
+                                                         stats.pop('source_155-questions-active', 0),
+                                                         stats.pop('source_EditWatcher', 0),
+                                                         stats.pop('source_BF_re-reqest', 0))
+        stats['site_limited'] = '{}, SO({}), nonSO({})'.format(limited_threads, *threads_limited_so_non_so)
         # Round all the floats to 2 digits after the decimal point
         for key, value in stats.items():
             if type(value) is float:

--- a/chatcommands.py
+++ b/chatcommands.py
@@ -1030,8 +1030,7 @@ def stat(operation, from_stats=None, to_stats=None, alias_used="stats"):
         stats_set_keys = GlobalVars.PostScanStat.get_set_keys()
         response = 'The currently stored stats sets are named: "' + '", "'.join(stats_set_keys) + '".'
     elif operation in ['get', 'display', 'show'] and from_stats and not to_stats:
-        # posts_scanned, scan_time, posts_per_second = GlobalVars.PostScanStat.get_stat()
-        # get_stats() gets a copy of the stats, not the actual reference.
+        # get() retrieves a copy of the stats, not the actual reference.
         stats = GlobalVars.PostScanStat.get(from_stats)
         # First, we deal with converting the max_scan_time_post into a Markdown link. We don't know if the post
         # is an answer or question, and SE doesn't care wrt. the URL used when you use /q/ID#.

--- a/datahandling.py
+++ b/datahandling.py
@@ -9,6 +9,7 @@ import json
 import time
 import math
 import threading
+import copy
 
 import requests
 # noinspection PyCompatibility
@@ -160,9 +161,10 @@ def load_files():
     if has_pickle("recentlyScannedPosts.p"):
         with GlobalVars.recently_scanned_posts_lock:
             GlobalVars.recently_scanned_posts = load_pickle("recentlyScannedPosts.p", encoding='utf-8')
-    if has_pickle("postScanStats.p"):
-        GlobalVars.PostScanStat.stats, GlobalVars.PostScanStat.stats_for_ms = load_pickle("postScanStats.p",
-                                                                                          encoding='utf-8')
+    if has_pickle("postScanStats2.p"):
+        with GlobalVars.PostScanStat.rw_lock:
+            GlobalVars.PostScanStat.stats = load_pickle("postScanStats2.p", encoding='utf-8')
+        GlobalVars.PostScanStat.reset('uptime')
     blacklists.load_blacklists()
 
 
@@ -454,9 +456,8 @@ def store_recently_scanned_posts():
 
 def store_post_scan_stats():
     with GlobalVars.PostScanStat.rw_lock:
-        stats = GlobalVars.PostScanStat.stats.copy()
-        stats_for_ms = GlobalVars.PostScanStat.stats_for_ms.copy()
-    dump_pickle("postScanStats.p", (stats, stats_for_ms))
+        stats = copy.deepcopy(GlobalVars.PostScanStat.stats)
+    dump_pickle("postScanStats2.p", stats)
 
 
 # methods that help avoiding reposting alerts:

--- a/datahandling.py
+++ b/datahandling.py
@@ -160,7 +160,9 @@ def load_files():
     if has_pickle("recentlyScannedPosts.p"):
         with GlobalVars.recently_scanned_posts_lock:
             GlobalVars.recently_scanned_posts = load_pickle("recentlyScannedPosts.p", encoding='utf-8')
-
+    if has_pickle("postScanStats.p"):
+        GlobalVars.PostScanStat.stats, GlobalVars.PostScanStat.stats_for_ms = load_pickle("postScanStats.p",
+                                                                                          encoding='utf-8')
     blacklists.load_blacklists()
 
 
@@ -448,6 +450,13 @@ def store_recently_scanned_posts():
             if recently_scanned_posts_save_handle:
                 recently_scanned_posts_save_handle.cancel()
         dump_pickle("recentlyScannedPosts.p", GlobalVars.recently_scanned_posts)
+
+
+def store_post_scan_stats():
+    with GlobalVars.PostScanStat.rw_lock:
+        stats = GlobalVars.PostScanStat.stats.copy()
+        stats_for_ms = GlobalVars.PostScanStat.stats_for_ms.copy()
+    dump_pickle("postScanStats.p", (stats, stats_for_ms))
 
 
 # methods that help avoiding reposting alerts:

--- a/globalvars.py
+++ b/globalvars.py
@@ -11,6 +11,7 @@ from configparser import NoOptionError, ConfigParser
 import threading
 import subprocess as sp
 import platform
+import copy
 
 # noinspection PyCompatibility
 import regex
@@ -157,12 +158,14 @@ class GlobalVars:
 
     class PostScanStat:
         """ Tracking post scanning data """
-        # Setting up the stats dict with default values isn't needed. If a key/value pair is in the new_stats
-        # sent to add_stat, then it will be automatically added. The list here is merely to document the
-        # keys and values which are currently expected.
         # All stats in a key are reported into chat using the !!/stats command. The report_order_with_defaults
         # variable in the code for that command shows what's expected to be here, but other values could exist.
-        # stats are accumulated from reboot to reboot.
+        # Stats are accumulated unless the stats set is locked.
+        # The default stat set is "uptime".
+
+        # Setting up the stats dict with default values isn't needed. If a key/value pair is in the new_stats
+        # sent to add(), then it will be automatically added. The list here is merely to document the
+        # keys and values which are currently expected.
         default_stats = {
             'scan_time': 0,
             'posts_scanned': 0,
@@ -174,88 +177,114 @@ class GlobalVars:
             'max_scan_time': 0,
             'max_scan_time_post': '',
         }
-        # stats_for_ms are accumulated, but cleared each time SD reports to MS.
-        stats_for_ms = {}
-        stats_from_reload = default_stats.copy()
-        stats = default_stats.copy()
+        # stats is a dict of stat_sets, which use keys as the name of the set of stats. The default keys are
+        # 'all', 'uptime', and 'ms'.
+        # Each stat set is a dict with keys: 'stats', 'start_timestamp', and optionally 'locked_timestamp'.
+        # If the stats set is locked, the optional 'locked_timestamp' key exists and has a datetime value.
+        # All of the actual stats are in the dict which is stored in the 'stats' key.
+        stats = {}
         rw_lock = threading.Lock()
 
         @staticmethod
-        def add_stat(new_stats):
-            """ Adding post scanning data """
+        def add(new_stats):
+            """ Add post scanning data """
             with GlobalVars.PostScanStat.rw_lock:
-                all_stats = GlobalVars.PostScanStat.stats
-                reload_stats = GlobalVars.PostScanStat.stats_from_reload
-                ms_stats = GlobalVars.PostScanStat.stats_for_ms
+                dict_of_stat_sets = GlobalVars.PostScanStat.stats
                 # First, deal with all stats which are not simple accumulators
                 new_max_time = new_stats.pop('max_scan_time', 0)
                 new_max_time_post = new_stats.pop('max_scan_time_post', '')
-                if (new_max_time > all_stats.get('max_scan_time', 0)):
-                    all_stats['max_scan_time'] = new_max_time
-                    all_stats['max_scan_time_post'] = new_max_time_post
-                if (new_max_time > reload_stats.get('max_scan_time', 0)):
-                    reload_stats['max_scan_time'] = new_max_time
-                    reload_stats['max_scan_time_post'] = new_max_time_post
-                # Every other stat is accumulated into the existing values.
-                # MS wants only posts_scanned, scan_time, posts_per_second, but it doesn't hurt to also
-                # keep any additional ones which are sccumulators. We don't keep a copy of anything which
-                # requres special handling (e.g. max_time and max_time_post).
-                for key, value in new_stats.items():
-                    old_all_value = all_stats.get(key, 0)
-                    old_reload_value = reload_stats.get(key, 0)
-                    old_ms_value = ms_stats.get(key, 0)
-                    if type(value) in [int, float]:
-                        # There isn't any value currently used here which should be anything other than an
-                        # int or float, but, just in case, we only directly replace string values
-                        all_stats[key] = old_all_value + value
-                        reload_stats[key] = old_reload_value + value
-                        ms_stats[key] = old_ms_value + value
-                    else:
-                        all_stats[key] = value
-                        reload_stats[key] = value
-                        ms_stats[key] = value
+                for stat_set in dict_of_stat_sets.values():
+                    # MS wants only posts_scanned, scan_time, posts_per_second, but it doesn't hurt to also
+                    # keep any additional ones.
+                    if not stat_set.get('locked_timestamp', False):
+                        these_stats = stat_set['stats']
+                        if new_max_time > these_stats.get('max_scan_time', 0):
+                            these_stats['max_scan_time'] = new_max_time
+                            these_stats['max_scan_time_post'] = new_max_time_post
+                        for stat_name, value in new_stats.items():
+                            old_value = these_stats.get(stat_name, 0)
+                            if type(value) in [int, float]:
+                                these_stats[stat_name] = old_value + value
+                            else:
+                                # There isn't any value currently used here which should be anything other than an int
+                                # or float, but, just in case, we directly replace values which aren't int or float.
+                                these_stats[stat_name] = value
 
         @staticmethod
         def get_stats_for_ms():
-            """ Getting post scanning statistics for reporting to MS """
-            copy = GlobalVars.PostScanStat.get_stats('ms')
+            """ Get post scanning statistics for reporting to MS """
+            stats_copy = GlobalVars.PostScanStat.get('ms')
             # MS wants only posts_scanned, scan_time, posts_per_second
-            return (copy.get(key, 0) for key in ['posts_scanned', 'scan_time', 'posts_per_second'])
+            return (stats_copy.get(key, 0) for key in ['posts_scanned', 'scan_time', 'posts_per_second'])
 
         @staticmethod
-        def get_stats(stats_to_use='reload'):
-            """ Getting post scanning statistics """
+        def get(stats_set_key='uptime'):
+            """ Get post scanning statistics from a stat set, including derived data, start and lock timestamps. """
             with GlobalVars.PostScanStat.rw_lock:
-                if stats_to_use == 'reload':
-                    copy = GlobalVars.PostScanStat.stats_from_reload.copy()
-                elif stats_to_use == 'ms':
-                    copy = GlobalVars.PostScanStat.stats_for_ms.copy()
-                else:
-                    copy = GlobalVars.PostScanStat.stats.copy()
+                stats_set = copy.deepcopy(GlobalVars.PostScanStat.stats[stats_set_key])
+            stats_copy = stats_set['stats']
             # Derived values:
-            scan_time = copy.get('scan_time', 0)
-            posts_scanned = copy.get('posts_scanned', 0)
+            scan_time = stats_copy.get('scan_time', 0)
+            posts_scanned = stats_copy.get('posts_scanned', 0)
             if scan_time == 0:
-                copy['posts_per_second'] = None
+                stats_copy['posts_per_second'] = None
             else:
-                copy['posts_per_second'] = posts_scanned / scan_time
-            return copy
+                stats_copy['posts_per_second'] = posts_scanned / scan_time
+            # Stats which are properties of the stat_set
+            stats_copy['start_timestamp'] = stats_set['start_timestamp']
+            locked_timestamp = stats_set.get('locked_timestamp', None)
+            if locked_timestamp:
+                stats_copy['locked_timestamp'] = locked_timestamp
+            return stats_copy
+
+        @staticmethod
+        def reset(stats_set_key):
+            """ Resets/clears/creates post scanning data in a stats set """
+            with GlobalVars.PostScanStat.rw_lock:
+                GlobalVars.PostScanStat.stats[stats_set_key] = {}
+                GlobalVars.PostScanStat.stats[stats_set_key]['stats'] = GlobalVars.PostScanStat.default_stats.copy()
+                GlobalVars.PostScanStat.stats[stats_set_key]['start_timestamp'] = datetime.utcnow()
+
+        @staticmethod
+        def lock(stats_set_key):
+            """ Locks post scanning data in a stats set """
+            with GlobalVars.PostScanStat.rw_lock:
+                GlobalVars.PostScanStat.stats[stats_set_key]['locked_timestamp'] = datetime.utcnow()
+
+        @staticmethod
+        def unlock(stats_set_key):
+            """ Unlocks post scanning data in a stats set """
+            with GlobalVars.PostScanStat.rw_lock:
+                GlobalVars.PostScanStat.stats[stats_set_key].pop('locked_timestamp', None)
+
+        @staticmethod
+        def delete(stats_set_key):
+            """ Deletes a stats set """
+            with GlobalVars.PostScanStat.rw_lock:
+                GlobalVars.PostScanStat.stats.pop(stats_set_key, None)
+
+        @staticmethod
+        def copy(from_type, to_type):
+            """ Copies the contents of a stat set to another stat set key """
+            with GlobalVars.PostScanStat.rw_lock:
+                GlobalVars.PostScanStat.stats[to_type] = copy.deepcopy(GlobalVars.PostScanStat.stats[from_type])
+
+        @staticmethod
+        def create(stats_set_key):
+            """ Creates a stat set (identical to a reset) """
+            GlobalVars.PostScanStat.reset[stats_set_key]
+
+        @staticmethod
+        def get_set_keys():
+            """ Get a list of the available stat set keys """
+            with GlobalVars.PostScanStat.rw_lock:
+                keys = list(GlobalVars.PostScanStat.stats.keys())
+            return keys
 
         @staticmethod
         def reset_ms_stats():
-            """ Resetting post scanning data for MS """
-            with GlobalVars.PostScanStat.rw_lock:
-                GlobalVars.PostScanStat.stats_for_ms = {}
-
-        def reset_reload_stats(self):
-            """ Resetting post scanning data kept from last reload """
-            with GlobalVars.PostScanStat.rw_lock:
-                GlobalVars.PostScanStat.stats_from_reload = self.default_stats.copy()
-
-        def reset_full_stats(self):
-            """ Resetting post all time scanning data """
-            with GlobalVars.PostScanStat.rw_lock:
-                GlobalVars.PostScanStat.stats = self.default_stats.copy()
+            """ Reset post scanning data for MS """
+            GlobalVars.PostScanStat.reset('ms')
 
     config_parser = ConfigParser(interpolation=None)
 
@@ -454,6 +483,7 @@ class GlobalVars:
                 cls.commit.id, cls.location)
 
 
-GlobalVars.PostScanStat.reset_ms_stats()
+for stats_set_key in ['all', 'uptime', 'ms']:
+    GlobalVars.PostScanStat.reset(stats_set_key)
 GlobalVars.MSStatus.reset_ms_status()
 GlobalVars.reload()

--- a/helpers.py
+++ b/helpers.py
@@ -37,6 +37,7 @@ def exit_mode(*args, code=0):
     # Flush any buffered queue timing data
     import datahandling  # this must not be a top-level import in order to avoid a circular import
     datahandling.flush_queue_timings_data()
+    datahandling.store_post_scan_stats()
     datahandling.store_recently_scanned_posts()
 
     # We have to use '_exit' here, because 'sys.exit' only exits the current

--- a/helpers.py
+++ b/helpers.py
@@ -384,7 +384,7 @@ def add_to_global_bodyfetcher_queue_in_new_thread(hostname, question_id, should_
         source_text = " from {}".format(source)
     t = Thread(name="bodyfetcher post enqueuing: {}/{}{}".format(hostname, question_id, source_text),
                target=GlobalVars.bodyfetcher.add_to_queue,
-               args=(hostname, question_id, should_check_site))
+               args=(hostname, question_id, should_check_site, source))
     t.start()
 
 

--- a/metasmoke.py
+++ b/metasmoke.py
@@ -579,15 +579,13 @@ class Metasmoke:
         current_apiquota = GlobalVars.apiquota
         GlobalVars.apiquota_rw_lock.release()
 
-        posts_scanned, scan_time, posts_per_second = GlobalVars.PostScanStat.get_stats_for_ms()
+        posts_scanned, scan_time, posts_per_second = GlobalVars.PostScanStat.get_stats_for_ms(reset=True)
         payload = {'key': GlobalVars.metasmoke_key,
                    'statistic': {'posts_scanned': posts_scanned,
                                  'api_quota': current_apiquota}}
         if posts_per_second:
             # Send scan rate as well, if applicable.
             payload['statistic']['post_scan_rate'] = posts_per_second
-
-        GlobalVars.PostScanStat.reset_ms_stats()
 
         headers = {'Content-type': 'application/json'}
 

--- a/metasmoke.py
+++ b/metasmoke.py
@@ -729,7 +729,8 @@ class Metasmoke:
         in_standby_mode = GlobalVars.standby_mode or GlobalVars.no_se_activity_scan
         if not in_standby_mode:
             # This is the active instance, so should be scanning. If it's not scanning, then report or go to standby.
-            if GlobalVars.PostScanStat.get_stats_for_ms() == Metasmoke.scan_stat_snapshot:
+            current_ms_stats = GlobalVars.PostScanStat.get_stats_for_ms()
+            if current_ms_stats == Metasmoke.scan_stat_snapshot:
                 # There's been no actvity since the last ping.
                 Metasmoke.status_pings_since_scan_activity += 1
                 with GlobalVars.ignore_no_se_websocket_activity_lock:
@@ -750,5 +751,5 @@ class Metasmoke:
                     chatcommunicate.tell_rooms_with("debug", status_message)
             else:
                 Metasmoke.status_pings_since_scan_activity = 0
-                Metasmoke.scan_stat_snapshot = GlobalVars.PostScanStat.get_stats_for_ms()
+                Metasmoke.scan_stat_snapshot = current_ms_stats
         Metasmoke.send_status_ping()


### PR DESCRIPTION
Currently, all of the stats, including the ones for MS, are not kept through rebooting. In addition to substantially expanding the `stats` command, this PR stores the stats across reboots. At a minimum, it will make the stats collected by MS be more accurate.

This PR does the following:
* Creates multiple stats sets which are individually manipulable. The default list of stats sets is "all", "uptime", and "ms". These stat sets are protected from destructive operations unless a `-force` is provided in the command. The "all" set is intended to be all time. The "uptime" set is the default set displayed and is cleared upon reboot. The "ms" stats are the stats being accumulated for MS and are reset upon being sent to MS.
   * Effectively, this means people can store a set of stats that starts and ends at the times they run different `!!/stats` commands.
* Stores all stat sets upon SD shutdown and restores them when rebooting. They are currently not stored upon a crash. This PR causes all stats sets to be retained upon shutdowns/reboots, but not upon crashes, ctrl-c, etc. The "uptime" stats set is explicitly reset upon reboot.
*  The `!!/stats` command is expanded to offer the following actions:
   * `clear` (1 argument required): Clears a stat set, alias for `reset`
   * `copy` (2 arguments required): Copies one stat set to another:  example: `!!/stats copy uptime Makyen-test2`
   * `create` (1 argument required): Creates a new stat set (e.g. create "Makyen-test1" with `!!/stats create Makyen-test1`)
   * `delete` (1 argument required): Deletes the stat set: example `!!/stats delete Makyen-test1`
   * `display` (1 argument optional): An alias for `get`
   * `get`: Outputs the stats to chat. This is the default operation. The default set used is "uptime". Example: `!!/stats` will show the stats for the "uptime" stats set.
   * `lock` (1 argument required): Locks a stats set from being updated with data from new `BodyFetcher` threads and scans.
   * `list` (0 arguments required): Lists the currently stored stats sets
   * `reset` (1 argument required): Resets a stats set to no stats, but any new stats will be added
   * `show` (1 argument optional): alias for `get`
   * `unlock` (1 argument required): Unlocks the stats set. Additional stats from `BodyFetcher` threads and scans will be accumulated into the stats set.
* Adds additional statistics for BodyFetcher threads:
   * Count the times threads end due to high CPU use
   * Count the times threads fetch from the SE API
   * Count the times threads don't pick a site out of the queue due to there being too many threads currently processing for that site. This is separated out into counts for SO and non-SO (currently SO has a higher maximum thread threshold).
   * Count the threads based on the source of the thread: 155-active-questions, EditWatcher, and BodyFetcher re-requests. BodyFetcher re-requests happen when a post which the thread thinks it's supposed to be scanning is skipped due to the post currently being scanned in another thread. PR #7003 will disable such re-requests for Stack Overflow.
   * All errors in the threads, as opposed to just those when scanning a question or answer
* Makes the getting and resetting of stats atomic when being sent to MS (i.e. the stats are retrieved and reset at the same time, so there isn't the possibility of loosing some stats between the two operations).

### Current output
The [current output of the `!!/stats` command looks like](https://chat.stackexchange.com/transcript/message/61172875#61172875):
> !!/stats list

> @Makyen The currently stored stats sets are named: "all", "uptime", "ms", "Mak-test1".

> !!/stats Mak-test1

> @Makyen "Mak-test1" stats: Posts scanned: 2990, Q(1623), A(1367); Scan time: 4250.73, Q(3783.24), A(458.69); Posts per second: 0.7; Grace period edits: 125; Unchanged posts: 15535, Q(7983), A(7552); No post lock: 51; Errors: 0; Max scan time: 76.68; Max scan time post: [codereview.stackexchange.com/276691](//codereview.stackexchange.com/q/276691); Post processing lock: 0.32; Check unchanged: 0.93; Threads: 658, API(292), 155QA(357), EW(261), BFrr(0); High CPU: 535; Site limited: 0, SO(0), nonSO(0); All errors: 0; Started: 2022-05-19T21:21:46.229118

> !!/stats lock Mak-test1

> @Makyen The lock operation succeeded on Mak-test1.

> !!/stats Mak-test1

> @Makyen "Mak-test1" stats: Posts scanned: 3000, Q(1629), A(1371); Scan time: 4264.03, Q(3794.74), A(460.48); Posts per second: 0.7; Grace period edits: 125; Unchanged posts: 15535, Q(7983), A(7552); No post lock: 51; Errors: 0; Max scan time: 76.68; Max scan time post: [codereview.stackexchange.com/276691](//codereview.stackexchange.com/q/276691); Post processing lock: 0.32; Check unchanged: 0.93; Threads: 663, API(296), 155QA(360), EW(262), BFrr(0); High CPU: 540; Site limited: 0, SO(0), nonSO(0); All errors: 0; Started: 2022-05-19T21:21:46.229118; Locked: 2022-05-20T00:05:58.086480

[The explanation of the `!!/stats` output has been moved to a [separate comment](https://github.com/Charcoal-SE/SmokeDetector/pull/7004#issuecomment-1133116441) to make it easier to link directly to it.]

#### Testing for this was done in the [Makyen Test 02 chat room](https://chat.stackexchange.com/rooms/97026/makyentest02) around [here](https://chat.stackexchange.com/transcript/message/61172006#61172006).