### PR TITLE
Use the newer regex.cache_all() switch instead of regex.purge()

### DIFF
--- a/findspam.py
+++ b/findspam.py
@@ -506,9 +506,10 @@ class Rule:
             try:
                 compiled_regex = self.compiled_regex
             except AttributeError:
+                regex.cache_all(False)  # Don't keep the regex in the cache.
                 compiled_regex = regex.compile(self.regex, regex.UNICODE, city=city_list, ignore_unused=True)
+                regex.cache_all(True)
                 self.compiled_regex = compiled_regex
-                regex.purge()  # Don't keep the regex in the cache.
 
             if self.title and not post.is_answer:
                 matches = list(compiled_regex.finditer(post.title))


### PR DESCRIPTION
In the 2020.10.23 version of the `regex` package, the overall switch `regex.cache_all()` was introduced to enable and disable the `regex` package's internal cache of compiled regular expressions. We store the compile version of the regexes which are used directly for each detection and rely on the `regex` package's cache for many of the other regexes which we use. Thus, there's no need for the regex package to include the regular expressions used directly for detections in its cache.

Prior versions of the regex package had the ability to use `regex.purge()` to purge the cache. We have been using that to purge the cache immediately after we compiled one of the detection regular expressions which we are manually storing.

This PR changes what we're doing to use the newer capability to turn off adding new regexes to the cache specifically just prior to compiling one of the detection regexes which we're manually handling and then turn it back on just after that compilation is done. This should end up somewhat more efficient and prevent the need for compiling some regular expressions which we do want cached a second time.

Future work:  
We should look at our overall usage of the regex cache to see if we're spending time re-compiling regexes which we use repeatedly.