### PR TITLE
Allow us to force the regex package to not implicitly cache some regexes at compile time

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -19,6 +19,7 @@ from threading import Thread
 from termcolor import colored
 import requests
 import regex
+from regex.regex import _compile as regex_raw_compile
 
 from globalvars import GlobalVars
 
@@ -429,3 +430,7 @@ def convert_new_scan_to_spam_result_if_new_reasons(new_info, old_info, match_ign
         # There are new reasons the post would have been reported
         return (True, actual_new_reasons, actual_new_why)
     return new_info
+
+
+def regex_compile_no_cache(regex_text, flags=0, ignore_unused=False, **kwargs):
+    return regex_raw_compile(regex_text, flags, ignore_unused, kwargs, False)


### PR DESCRIPTION
This adds a helper function `regex_compile_no_cache()` which can be used to compile a `regex` without the regular expression entering the `regex` package's implicit cache, which allows us to do so on a per-compilation basis. Unfortunately, the `regex` package only exposes `regex.cache_all()` and `regex.purge()`. The `regex.cache_all()` method turns the cache on and off globally, which is fine in a single threaded application, but has undesired side effects if used dynamically in an application where there are multiple threads, like SD. We have been using `regex.purge()`, which works, but results in a notable number of regular expressions needing to be recompiled into the implicit cache.

Not putting specific compiled regular expressions into the implicit cache can leave the slots available in the implicit cache open for other regular expressions. This is important if we were to have any detections which used a regex which was dynamically created based on the post content. If we did, then those regexes which are used for a single post would fill the cache and result in having to repeatedly recompile the static regular expressions used in the rest of the code.

This PR also uses the `regex_compile_no_cache()` function to compile the regular expressions which are used in regex-only detections, as well as a few regular expressions which are compiled in findspam.py once upon module initialization (i.e. outside of functions). This replaces our prior use of `regex.purge()` to prevent those from filling up the implicit cache.

I also went through all of the code for the existing detections in findspam.py looking for any cases where we were constructing dynamic regular expressions on a per-post basis and didn't see any. It's possible that there's code which is called on a per-post basis outside of findspam.py which should use `regex_compile_no_cache()`. While I intend to look around for it, I have not yet done so.