### PR TITLE
Enable Markdown formatting in some longer !!/watch/blacklist-number command replies

### DIFF
--- a/chatcommands.py
+++ b/chatcommands.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 # noinspection PyUnresolvedReferences
-from chatcommunicate import add_room, block_room, CmdException, command, get_report_data, \
+from chatcommunicate import add_room, block_room, CmdException, CmdExceptionLongReply, command, get_report_data, \
     is_privileged, message, \
     tell_rooms, tell_rooms_with, get_message
 # noinspection PyUnresolvedReferences
@@ -417,8 +417,8 @@ def do_blacklist(blacklist_type, msg, force=False):
             if not phone_numbers.is_digit_count_in_number_regex_range(digit_count):
                 digit_count_text = " The supplied pattern contains" + \
                                    " {} digits, which doesn't meet the requirements.".format(digit_count)
-            raise CmdException("That pattern can't be detected by the number detections. " +
-                               number_regex_requires + digit_count_text)
+            raise CmdExceptionLongReply("That pattern can't be detected by the number detections. " +
+                                        number_regex_requires + digit_count_text)
         normalized_format_escaped = str(normalized).replace('{', '{{').replace('}', '}}')
         normalized_on_list = 'A normalized version, `{}`, of that pattern'.format(normalized_format_escaped) + \
                              ' is already on the number {}list{extra}. You can use' + \
@@ -448,7 +448,7 @@ def do_blacklist(blacklist_type, msg, force=False):
         if deobfuscated_processed != processed:
             other_issues.append("That pattern appears to be homoglyph obfuscated. It's better to" +
                                 " use the non-obfuscated number. Perhaps try: " +
-                                "`!!/{} {}`".format(blacklist_command, deobfuscated_processed))
+                                "`!!/{} {}`.".format(blacklist_command, deobfuscated_processed))
         formatted_north_american = \
             phone_numbers.get_north_american_with_separators_from_normalized(normalized_deobfuscated)
         north_american_formatting = "use a format which starts with an optional `1` followed by" + \
@@ -459,7 +459,7 @@ def do_blacklist(blacklist_type, msg, force=False):
                                     " end of the pattern to force also using the alternate normalized form, or" + \
                                     " `(?#NO NorAm)` if it's not a North American phone number and it's" + \
                                     " incorrectly recognized as one." + \
-                                    " Perhaps try \n`!!/{} {}`\n".format(blacklist_command, formatted_north_american)
+                                    " Perhaps try \n`!!/{} {}`.\n".format(blacklist_command, formatted_north_american)
         if not force_no_north_american and unused_maybe_north_american_norm:
             other_issues.append("That pattern may be a North American number. If it is, please " +
                                 north_american_formatting)
@@ -496,11 +496,11 @@ def do_blacklist(blacklist_type, msg, force=False):
             reasons = check_blacklist(
                 concretized_pattern, is_username=username, is_watchlist=is_watchlist, is_phone=is_phone)
             if reasons:
-                raise CmdException("That pattern looks like it's already caught by " +
-                                   format_blacklist_reasons(reasons) + other_issues_text + append_force_to_do)
+                raise CmdExceptionLongReply("That pattern looks like it's already caught by " +
+                                            format_blacklist_reasons(reasons) + other_issues_text + append_force_to_do)
 
         if other_issues_text:
-            raise CmdException(other_issues_text + append_force_to_do)
+            raise CmdExceptionLongReply(other_issues_text + append_force_to_do)
 
     metasmoke_down = False
 

--- a/chatcommands.py
+++ b/chatcommands.py
@@ -363,9 +363,9 @@ def do_blacklist(blacklist_type, msg, force=False):
     :return: A string
     """
 
-    def get_normalized_on_list(blacklist_type, extra=''):
+    def get_normalized_on_list(list_type, extra=''):
         return 'A normalized version, `{}`, of that pattern'.format(normalized_format_escaped) + \
-               ' is already on the number {}list{extra}. You can use'.format(blacklist_type, extra=extra) + \
+               ' is already on the number {}list{extra}. You can use'.format(list_type, extra=extra) + \
                ' `!!/bisect-number {}`'.format(pattern) + \
                ' to determine which entries on the number lists match that pattern, which' + \
                ' would tell you: ' + get_number_bisect(msg, pattern)
@@ -377,6 +377,7 @@ def do_blacklist(blacklist_type, msg, force=False):
 
     pattern = get_pattern_from_content_source(msg)
     is_watchlist = bool("watch" in blacklist_type)
+    blacklist_or_watchlist = 'watchlist' if is_watchlist else 'blacklist'
     text_before_pattern = ''
     text_after_pattern = ''
 
@@ -406,7 +407,10 @@ def do_blacklist(blacklist_type, msg, force=False):
             raise CmdException("That pattern is probably too broad, refusing to commit." +
                                " If you really want to add this pattern, you will need to manually submit a PR.")
     else:
-        blacklist_command = blacklist_type.replace("_", "-")
+        # When it's a blacklist command, blacklist_type only provides the type of blacklist, not the full command.
+        blacklist_command = 'blacklist-' + blacklist_type if not is_watchlist \
+            and 'blacklist' not in blacklist_type else blacklist_type
+        blacklist_command = blacklist_command.replace("_", "-")
         exact_match_text = 'In order for a "number" to make an exact match, the pattern must '
         without_comments, comments = phone_numbers.split_processed_and_comments(pattern)
         full_entry_list, processed_as_set, normalized = phone_numbers.process_numlist([pattern])
@@ -568,8 +572,8 @@ def blacklist_keyword(msg, pattern, alias_used="blacklist-keyword"):
     :return: A string
     """
 
-    parts = alias_used.split("-")
-    return do_blacklist(parts[1], msg, force=len(parts) > 2)
+    parts = alias_used.replace("_", "-").split("-")
+    return do_blacklist(parts[1], msg, force='force' in alias_used)
 
 
 # noinspection PyIncorrectDocstring

--- a/chatcommunicate.py
+++ b/chatcommunicate.py
@@ -40,6 +40,10 @@ class CmdException(Exception):
     pass
 
 
+class CmdExceptionLongReply(Exception):
+    pass
+
+
 _prefix_commands = {}
 _reply_commands = {}
 
@@ -487,6 +491,8 @@ class ChatCommand:
             return result if not quiet_action else ""
         except CmdException as e:
             return str(e)
+        except CmdExceptionLongReply as e:
+            return '\n' + str(e).replace('\n', ' ')
         except Exception:  # Everything else
             log_exception(*sys.exc_info())
             return "I hit an error while trying to run that command; run `!!/errorlogs` for details."


### PR DESCRIPTION
This PR does:
* Adds `CmdExceptionLongReply()`, which can be used to indicate a chat command didn't succeed, but allow the response text to use Markdown in a reply to the user which is longer than 500 characters. The primary limitation is that such responses can be only a single paragraph, but the paragraph can be long and use Markdown throughout.
* Use `CmdExceptionLongReply()` in some of the exception replies for the `!!/watch/blacklist-number` commands which were both long and attempting to use Markdown formatting.
* Some tweaks to `!!/watch/blacklist-number` command responses which appeared beneficial, based on problems encountered in Charcoal HQ.
* Perform and report the results from the `!!/bisect-number` which some of the responses from `!!/watch/blacklist-number` tell the user they can do. The original reason for not doing so was a concern that the command might be CPU intensive, based on the CPU issues with the `!!/bisect` command. As it turned out, !!/bisect-number` really isn't a problem to do under these circumstances.
#### Testing for this was done in the [Makyen Test 02 chat room](https://chat.stackexchange.com/rooms/97026/makyentest02) around [here](https://chat.stackexchange.com/transcript/message/61227298#61227298). 