### PR TITLE
CI: Don't use a venv for either GitHub Actions or CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,9 @@ jobs:
           command: |
             ssh-keyscan github.com >> ~/.ssh/known_hosts
             python3 -m venv env
+            env/bin/pip3 list --outdated --format=freeze > pip_outdated_freeze.txt
+            cat pip_outdated_freeze.txt
+            grep -v '^\-e' pip_outdated_freeze.txt | cut -d = -f 1  | xargs -n1 env/bin/pip3 install -U
             env/bin/pip3 install -r requirements.txt --upgrade --upgrade-strategy eager
             env/bin/pip3 install -r user_requirements.txt --upgrade --upgrade-strategy eager
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,13 +11,22 @@ jobs:
           keys:
             - git-cimg-python3.8-{{ .Branch }}
             - git-cimg-python3.8
+            - git
       - checkout
       - save_cache:
           key: git-cimg-python3.8-{{ .Branch }}
           paths:
             - ".git"
+      - run:
+          # Put data about the CI environment upon which the env cache may depend
+          # into the file ci_environment.txt, which we'll checksum in order to only use
+          # the env cache when that data hasn't changed. Currently, that's the full
+          # Python version.
+          name: Gather CI environment information
+          command: |
+            python3 --version > ci_environment.txt
       - restore_cache:
-          key: env-cimg-python3.8-{{ .Branch }}-{{ checksum "requirements.txt" }}
+          key: env-cimg-python3.8-{{ checksum "ci_environment.txt" }}-{{ checksum "requirements.txt" }}-{{ checksum "user_requirements.txt" }}
       - run:
           name: install python dependencies in venv
           command: |
@@ -26,7 +35,7 @@ jobs:
             env/bin/pip3 install -r requirements.txt --upgrade --upgrade-strategy eager
             env/bin/pip3 install -r user_requirements.txt --upgrade --upgrade-strategy eager
       - save_cache:
-          key: env-cimg-python3.8-{{ .Branch }}-{{ checksum "requirements.txt" }}
+          key: env-cimg-python3.8-{{ checksum "ci_environment.txt" }}-{{ checksum "requirements.txt" }}-{{ checksum "user_requirements.txt" }}
           paths:
             - "env"
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,12 +31,8 @@ jobs:
           name: install python dependencies in venv
           command: |
             ssh-keyscan github.com >> ~/.ssh/known_hosts
-            python3 -m venv env
-            env/bin/pip3 list --outdated --format=freeze | grep -v -E "pyflakes|pycodestyle|coverage|flake8|pep8-naming|ChatExchange" > pip_outdated_freeze.txt
-            cat pip_outdated_freeze.txt
-            grep -v '^\-e' pip_outdated_freeze.txt | cut -d = -f 1  | xargs -n1 env/bin/pip3 install -U
-            env/bin/pip3 install -r requirements.txt --upgrade --upgrade-strategy eager
-            env/bin/pip3 install -r user_requirements.txt --upgrade --upgrade-strategy eager
+            pip3 install -r requirements.txt --upgrade --upgrade-strategy eager
+            pip3 install -r user_requirements.txt --upgrade --upgrade-strategy eager
       - save_cache:
           key: env-cimg-python3.8-{{ checksum "ci_environment.txt" }}-{{ checksum "requirements.txt" }}-{{ checksum "user_requirements.txt" }}
           paths:
@@ -65,4 +61,4 @@ jobs:
           name: Pytest
           # Use 5 processes is intended to allow one DNS lookup bound long running test run
           # in parallel with most of the other tests which generally consume more CPU.
-          command: env/bin/python3 -W default::Warning -m pytest -n 5 --dist loadgroup test
+          command: python3 -W default::Warning -m pytest -n 5 --dist loadgroup test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
           command: |
             ssh-keyscan github.com >> ~/.ssh/known_hosts
             python3 -m venv env
-            env/bin/pip3 list --outdated --format=freeze > pip_outdated_freeze.txt
+            env/bin/pip3 list --outdated --format=freeze | grep -v -E "pyflakes|pycodestyle|coverage|flake8|pep8-naming|ChatExchange" > pip_outdated_freeze.txt
             cat pip_outdated_freeze.txt
             grep -v '^\-e' pip_outdated_freeze.txt | cut -d = -f 1  | xargs -n1 env/bin/pip3 install -U
             env/bin/pip3 install -r requirements.txt --upgrade --upgrade-strategy eager

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,8 +23,8 @@ jobs:
           command: |
             ssh-keyscan github.com >> ~/.ssh/known_hosts
             python3 -m venv env
-            env/bin/pip3 install -r requirements.txt --upgrade
-            env/bin/pip3 install -r user_requirements.txt --upgrade
+            env/bin/pip3 install -r requirements.txt --upgrade --upgrade-strategy eager
+            env/bin/pip3 install -r user_requirements.txt --upgrade --upgrade-strategy eager
       - save_cache:
           key: env-cimg-python3.8-{{ .Branch }}-{{ checksum "requirements.txt" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,42 +27,30 @@ jobs:
             python3 --version > ci_environment.txt
       - restore_cache:
           key: pip-cache-cimg-python3.8-{{ checksum "ci_environment.txt" }}-{{ checksum "requirements.txt" }}-{{ checksum "user_requirements.txt" }}
-      - restore_cache:
-          key: env-cimg-python3.8-{{ checksum "ci_environment.txt" }}-{{ checksum "requirements.txt" }}-{{ checksum "user_requirements.txt" }}
       - run:
-          name: install python dependencies in venv
+          name: Install Python dependencies
           command: |
             ssh-keyscan github.com >> ~/.ssh/known_hosts
             pip3 install -r requirements.txt --upgrade --upgrade-strategy eager
             pip3 install -r user_requirements.txt --upgrade --upgrade-strategy eager
       - save_cache:
-          key: env-cimg-python3.8-{{ checksum "ci_environment.txt" }}-{{ checksum "requirements.txt" }}-{{ checksum "user_requirements.txt" }}
-          paths:
-            - "env"
-      - save_cache:
           key: pip-cache-cimg-python3.8-{{ checksum "ci_environment.txt" }}-{{ checksum "requirements.txt" }}-{{ checksum "user_requirements.txt" }}
           paths:
             - "/home/circleci/.cache/pip"
       - run:
-          name: Lint tests
-          command: env/bin/python3 -m flake8 --config=tox_tests.ini ./test/
+          name: Lint ./tests
+          command: python3 -m flake8 --config=tox_tests.ini ./test/
       - run:
-          name: Lint classes
-          command: env/bin/python3 -m flake8 --config=tox_classes.ini ./classes/
+          name: Lint ./classes
+          command: python3 -m flake8 --config=tox_classes.ini ./classes/
       - run:
           name: Lint code
-          command: env/bin/python3 -m flake8 ./
+          command: python3 -m flake8 ./
       - run:
           name: Prepare Git for test
           command: |
             git config user.name SmokeDetector
             git config user.email "smokey@erwaysoftware.com"
-      - run:
-          name: cat users.yml
-          command: cat users.yml
-      - run:
-          name: cat test/data_test_spamhandling.txt
-          command: cat test/data_test_spamhandling.txt
       - run:
           name: Pytest
           # Use 5 processes is intended to allow one DNS lookup bound long running test run

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,8 @@ jobs:
           command: |
             python3 --version > ci_environment.txt
       - restore_cache:
+          key: pip-cache-cimg-python3.8-{{ checksum "ci_environment.txt" }}-{{ checksum "requirements.txt" }}-{{ checksum "user_requirements.txt" }}
+      - restore_cache:
           key: env-cimg-python3.8-{{ checksum "ci_environment.txt" }}-{{ checksum "requirements.txt" }}-{{ checksum "user_requirements.txt" }}
       - run:
           name: install python dependencies in venv
@@ -37,6 +39,10 @@ jobs:
           key: env-cimg-python3.8-{{ checksum "ci_environment.txt" }}-{{ checksum "requirements.txt" }}-{{ checksum "user_requirements.txt" }}
           paths:
             - "env"
+      - save_cache:
+          key: pip-cache-cimg-python3.8-{{ checksum "ci_environment.txt" }}-{{ checksum "requirements.txt" }}-{{ checksum "user_requirements.txt" }}
+          paths:
+            - "/home/circleci/.cache/pip"
       - run:
           name: Lint tests
           command: env/bin/python3 -m flake8 --config=tox_tests.ini ./test/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,9 @@ jobs:
       run: |
         python3 -m venv env
         source env/bin/activate
+        env/bin/pip3 list --outdated --format=freeze > pip_outdated_freeze.txt
+        cat pip_outdated_freeze.txt
+        grep -v '^\-e' pip_outdated_freeze.txt | cut -d = -f 1  | xargs -n1 env/bin/pip3 install -U
         env/bin/pip3 install -U wheel --upgrade-strategy eager
         env/bin/pip3 install -U -r requirements.txt -r user_requirements.txt pytest-cov coveralls --upgrade-strategy eager
     - name: Lint tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
       run: |
         python3 -m venv env
         source env/bin/activate
-        env/bin/pip3 list --outdated --format=freeze > pip_outdated_freeze.txt
+        env/bin/pip3 list --outdated --format=freeze | grep -v -E "pyflakes|pycodestyle|coverage|flake8|pep8-naming|ChatExchange" > pip_outdated_freeze.txt
         cat pip_outdated_freeze.txt
         grep -v '^\-e' pip_outdated_freeze.txt | cut -d = -f 1  | xargs -n1 env/bin/pip3 install -U
         env/bin/pip3 install -U wheel --upgrade-strategy eager

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,8 +41,8 @@ jobs:
       run: |
         python3 -m venv env
         source env/bin/activate
-        env/bin/pip3 install -U wheel
-        env/bin/pip3 install -U -r requirements.txt -r user_requirements.txt pytest-cov coveralls
+        env/bin/pip3 install -U wheel --upgrade-strategy eager
+        env/bin/pip3 install -U -r requirements.txt -r user_requirements.txt pytest-cov coveralls --upgrade-strategy eager
     - name: Lint tests
       run: env/bin/python3 -m flake8 --config=tox_tests.ini ./test/
     - name: Lint classes

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,13 +39,8 @@ jobs:
           env
     - name: Install dependencies
       run: |
-        python3 -m venv env
-        source env/bin/activate
-        env/bin/pip3 list --outdated --format=freeze | grep -v -E "pyflakes|pycodestyle|coverage|flake8|pep8-naming|ChatExchange" > pip_outdated_freeze.txt
-        cat pip_outdated_freeze.txt
-        grep -v '^\-e' pip_outdated_freeze.txt | cut -d = -f 1  | xargs -n1 env/bin/pip3 install -U
-        env/bin/pip3 install -U wheel --upgrade-strategy eager
-        env/bin/pip3 install -U -r requirements.txt -r user_requirements.txt pytest-cov coveralls --upgrade-strategy eager
+        pip3 install -U wheel --upgrade-strategy eager
+        pip3 install -U -r requirements.txt -r user_requirements.txt pytest-cov coveralls --upgrade-strategy eager
     - name: Lint tests
       run: env/bin/python3 -m flake8 --config=tox_tests.ini ./test/
     - name: Lint classes
@@ -54,7 +49,7 @@ jobs:
       run: env/bin/python3 -m flake8 ./
     - name: Pytest
       run: |
-        env/bin/python3 -W default::Warning -m pytest \
+        python3 -W default::Warning -m pytest \
           --cov=chatcommunicate \
           --cov=findspam \
           --cov=globalvars \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,17 +36,16 @@ jobs:
           ${{ runner.os }}-${{ env.pythonLocation }}-pip-cache-version-1-
         path: |
           ~/.cache/pip
-          env
-    - name: Install dependencies
+    - name: Install Python dependencies
       run: |
         pip3 install -U wheel --upgrade-strategy eager
         pip3 install -U -r requirements.txt -r user_requirements.txt pytest-cov coveralls --upgrade-strategy eager
-    - name: Lint tests
-      run: env/bin/python3 -m flake8 --config=tox_tests.ini ./test/
-    - name: Lint classes
-      run: env/bin/python3 -m flake8 --config=tox_classes.ini ./classes/
+    - name: Lint ./tests
+      run: python3 -m flake8 --config=tox_tests.ini ./test/
+    - name: Lint ./classes
+      run: python3 -m flake8 --config=tox_classes.ini ./classes/
     - name: Lint code
-      run: env/bin/python3 -m flake8 ./
+      run: python3 -m flake8 ./
     - name: Pytest
       run: |
         python3 -W default::Warning -m pytest \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,10 +30,10 @@ jobs:
       id: cache
       uses: actions/cache@v2
       with:
-        key: ${{ runner.os }}-${{ matrix.python-version }}-pip-2-${{ hashFiles('**/requirements.txt') }}
+        key: ${{ runner.os }}-${{ env.pythonLocation }}-pip-cache-version-1-${{ hashFiles('**/requirements.txt') }}}-${{ hashFiles('**/user_requirements.txt') }}
         restore-keys: |
-          ${{ runner.os }}-${{ matrix.python-version }}-pip-2-${{ hashFiles('**/requirements.txt') }}
-          ${{ runner.os }}-${{ matrix.python-version }}-pip-2-
+          ${{ runner.os }}-${{ env.pythonLocation }}-pip-cache-version-1-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('**/user_requirements.txt') }}
+          ${{ runner.os }}-${{ env.pythonLocation }}-pip-cache-version-1-
         path: |
           ~/.cache/pip
           env

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,6 @@ jobs:
           env
     - name: Install dependencies
       run: |
-        rm -rf env/bin env/include env/pyvenv.cfg env/lib/python*/site-packages/{easy_install.py,pip*,pkg_resources,setuptools*}
         python3 -m venv env
         source env/bin/activate
         env/bin/pip3 install -U wheel


### PR DESCRIPTION
Upon additional testing, it was seen that there needed to be more done in each CI run in order to make sure that a cache of the venv stayed at the most recent versions of our sub-dependencies without exceeding the versions required for our explicit requirements. The extra steps are required because `pip` doesn't update sub-dependencies of explicitly specified dependencies, unless required. Doing the extra steps cost enough time such that using a venv is, at best, neutral with respect to the amount of time required for installing all of the requirements from cached copies of the package downloads. In multiple cases, using the cached venv actually took longer. The entire point of using a venv in our CI was that fully caching the installed dependencies resulted in a savings in the run time for the CI tests. Without there being a time savings, there isn't a point to using a venv.

So, this PR removes the use of venv from both GitHub Actions and CircleCI. It implements/re-implements caching for the main pip download cache.


Resolves #7100