### PR TITLE
CI: Run NS validations in parallel. Shows all errors, not just first.

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -434,3 +434,7 @@ def convert_new_scan_to_spam_result_if_new_reasons(new_info, old_info, match_ign
 
 def regex_compile_no_cache(regex_text, flags=0, ignore_unused=False, **kwargs):
     return regex_raw_compile(regex_text, flags, ignore_unused, kwargs, False)
+
+
+def color(text, color, attrs=None):
+    return colored(text, color, attrs=attrs)


### PR DESCRIPTION
This changes the CI validation of the "*_nses.yml" files to run the validations in parallel, rather than fully serial. The validation of these files is the longest running CI test, by a considerable margin, so tends to dominate how long it takes to perform CI testing. The changes in this PR use `concurrent.futures` to run 20 validations in parallel. While this doesn't actually reduce the time by a factor of 20, it significantly reduces it. How much it reduces the overall test time depends on how long it takes to get DNS responses for each entries/domain and the sequence of domains which are validated in each thread. While the test remains as the longest single test, it is substantially reduced and is intended to be run in parallel with the CPU intensive tests (already allocated within the CI to be done that way).

A beneficial side-effect of this change is that all of the entries are checked and any errors are reported for each of them, rather than the test stopping at the first error.

This also adjusts the formatting of the `log()` output to make it more clear which domain/entry has failed and in which file.