### PR TITLE
Get !!/dump-data and !!/load-data working

### DIFF
--- a/chatcommands.py
+++ b/chatcommands.py
@@ -2,7 +2,7 @@
 # noinspection PyUnresolvedReferences
 from chatcommunicate import add_room, block_room, CmdException, CmdExceptionLongReply, command, get_report_data, \
     is_privileged, message, \
-    tell_rooms, tell_rooms_with, get_message
+    tell_rooms, tell_rooms_with, get_message, is_self
 # noinspection PyUnresolvedReferences
 from globalvars import GlobalVars
 import findspam
@@ -2375,12 +2375,12 @@ def dump_data():
     return "Data successfully dumped"
 
 
-@command(int, privileged=True)
-def load_data(msg_id):
-    msg = get_message(msg_id)
-    if msg.owner.id != 120914:  # TODO: implement an is_self() in chatcommunicate, don't use magic numbers
-        raise CmdException("Message owner is not SmokeDetector, refusing to load")
-    minimally_validate_content_source(msg)
+@command(int, str, privileged=True, arity=(1, 2), give_name=True, aliases=["load-data-force"])
+def load_data(msg_id, hostname, alias_used="load-data"):
+    force = 'force' in alias_used
+    msg = get_message(msg_id, host=hostname)
+    if not force and not is_self(msg.owner.id, host=hostname):
+        raise CmdException("Message owner is not myself. Refusing to load.")
     try:
         SmokeyTransfer.load(msg.content_source)
     except ValueError as e:

--- a/chatcommunicate.py
+++ b/chatcommunicate.py
@@ -582,7 +582,8 @@ def message(msg):
     return msg
 
 
-def get_message(id, host="stackexchange.com"):
+def get_message(id, host=None):
+    host = host if host else "stackexchange.com"
     with _clients_lock:
         if host not in _clients:
             raise ValueError("Invalid host")
@@ -712,3 +713,10 @@ def dispatch_shorthand_command(msg):
 
     if should_return_output:
         return "\n".join(output)
+
+
+def is_self(test_id, host=None):
+    host = host if host else "stackexchange.com"
+    with _clients_lock:
+        me = _clients[host].get_me()
+    return test_id == me.id

--- a/datahandling.py
+++ b/datahandling.py
@@ -750,7 +750,10 @@ class SmokeyTransfer:
             data['_metadata']['lengths'][key] = length
 
         # hopefully the pickle won't be more than a few MiB
-        raw_data = pickle.dumps(data, protocol=pickle.HIGHEST_PROTOCOL)
+        # For backward compatibility, we use protocol=4, which was introduced in Python 3.4.
+        # protocol=5 was introduced with Python 3.8, so we can move to that once we no longer
+        # support Python 3.7.
+        raw_data = pickle.dumps(data, protocol=4)
         # let's save some traffic
         z_data = zlib.compress(raw_data, 9)
         # need to transfer via chat, so text only


### PR DESCRIPTION
This gets `!!/dump-data` and `!!/load-data` working. It includes the following changes:
* Allow specifying the chat domain, rather than requiring the dump room to be on chat.SE.
* Use pickle `protocol=4` in order to maintain compatibility with Python 3.7
* Implement `is_self()` in chatcommunicate.py to verify that the message being loaded is from the same user.
* Add a `!!/load-data-force` version which ignores the check for the message being from the same user.


#### Testing for this was done in the [Makyen Test 02 chat room](https://chat.stackexchange.com/rooms/97026/makyentest02) around [here](https://chat.stackexchange.com/transcript/message/61502303#61502303). 