### PR TITLE
Don't detect images in code in "post is mostly images"

### DIFF
--- a/findspam.py
+++ b/findspam.py
@@ -24,7 +24,7 @@ import dns.resolver
 import requests
 import chatcommunicate
 
-from helpers import log, regex_compile_no_cache
+from helpers import log, regex_compile_no_cache, strip_pre_and_code_elements
 import metasmoke_cache
 from globalvars import GlobalVars
 import blacklists
@@ -464,8 +464,7 @@ class Rule:
 
         if self.stripcodeblocks:
             # use a placeholder to avoid triggering "linked punctuation" on code-only links
-            body_to_check = regex.sub("(?s)<pre>.*?</pre>", "\nstripped pre\n", body_to_check)
-            body_to_check = regex.sub("(?s)<code>.*?</code>", "\nstripped code\n", body_to_check)
+            body_to_check = strip_pre_and_code_elements(body_to_check, leave_note=True)
         if reason == 'phone number detected in {}':
             body_to_check = regex.sub("<(?:a|img)[^>]+>", "", body_to_check)
 

--- a/findspam.py
+++ b/findspam.py
@@ -24,7 +24,7 @@ import dns.resolver
 import requests
 import chatcommunicate
 
-from helpers import log, regex_compile_no_cache, strip_pre_and_code_elements
+from helpers import log, regex_compile_no_cache, strip_pre_and_code_elements, strip_code_elements
 import metasmoke_cache
 from globalvars import GlobalVars
 import blacklists
@@ -888,7 +888,7 @@ def mostly_img(s, site):
     if len(s) == 0:
         return False, ""
 
-    s_len_img = len_img_block(s)
+    s_len_img = len_img_block(strip_code_elements(s))
     if s_len_img / len(s) > IMG_TXT_R_THRES:
         return True, "{:.4f} of the post is html image blocks".format(s_len_img / len(s))
     return False, ""

--- a/helpers.py
+++ b/helpers.py
@@ -438,3 +438,15 @@ def regex_compile_no_cache(regex_text, flags=0, ignore_unused=False, **kwargs):
 
 def color(text, color, attrs=None):
     return colored(text, color, attrs=attrs)
+
+
+def strip_code_elements(text, leave_note=False):
+    return regex.sub("(?s)<code>.*?</code>", "\nstripped code\n" if leave_note else "", text)
+
+
+def strip_pre_elements(text, leave_note=False):
+    return regex.sub("(?s)<pre>.*?</pre>", "\nstripped pre\n" if leave_note else "", text)
+
+
+def strip_pre_and_code_elements(text, leave_note=False):
+    return strip_code_elements(strip_pre_elements(text, leave_note=leave_note), leave_note=leave_note)


### PR DESCRIPTION
This PR prevents `<img>` elements within `<code></code>` from being considered as "images" when determining if the post is "mostly images". A [search on MS for posts detected by "post is mostly images" and which contain any `<code>`  in the body](https://metasmoke.erwaysoftware.com/search?body=%3Ccode&body_is_regex=1&reason=174) shows that this detection is 225 Total / 1 TP (0.44% TP) / 223 FP / 4 NAA if code even exists in the post. If [the `<img>` is within the code](https://metasmoke.erwaysoftware.com/search?utf8=%E2%9C%93&body_is_regex=1&body=%3Cimg+%28%3F%3D%28%3F%3A%5B%5E%3C%5D%7C%3C%28%3F%21%5C%2F%3Fcode%3E%29%29*%2B%3C%5C%2Fcode%3E%29&reason=174), it's 199 Total / 1 TP (0.5% TP) / 197 FP / 4 NAA.

The [1 TP](https://metasmoke.erwaysoftware.com/post/282663) would have still been caught by "potentially bad keyword in {}". While this TP is something which we would want to catch, having this detection catch it doesn't appear worth the FP and NAA.