### PR TITLE
More uniform exception logging helpers

### DIFF
--- a/chatcommands.py
+++ b/chatcommands.py
@@ -29,7 +29,7 @@ from ast import literal_eval
 # noinspection PyCompatibility
 import regex
 from helpers import exit_mode, only_blacklists_changed, only_modules_changed, log, expand_shorthand_link, \
-    reload_modules, chunk_list, remove_regex_comments, regex_compile_no_cache
+    reload_modules, chunk_list, remove_regex_comments, regex_compile_no_cache, log_current_exception
 from classes import Post
 from classes.feedback import *
 from classes.dns import dns_resolve
@@ -2403,7 +2403,7 @@ def dump_data():
         s = "{}, {}, {}\n{}".format(metadata['time'], metadata['location'], metadata['rev'], s)
         tell_rooms_with('dump', s)
     except Exception:
-        log_exception(*sys.exc_info())
+        log_current_exception()
         raise CmdException("Failed to dump data. Run `!!/errorlogs` for details.")
     return "Data successfully dumped"
 
@@ -2419,7 +2419,7 @@ def load_data(msg_id, hostname, alias_used="load-data"):
     except ValueError as e:
         raise CmdException(str(e)) from None
     except Exception:
-        log_exception(*sys.exc_info())
+        log_current_exception()
         raise CmdException("Failed to load data. Run `!!/errorlogs` for details.")
     return "Data successfully loaded"
 

--- a/chatcommands.py
+++ b/chatcommands.py
@@ -542,7 +542,7 @@ def do_blacklist(blacklist_type, msg, force=False):
         try:
             if not GlobalVars.on_branch:
                 # Restart if HEAD detached
-                log('warning', "Pulling local with HEAD detached, checkout deploy", f=True)
+                log('warning', "Pulling local with HEAD detached, checkout deploy", and_file=True)
                 exit_mode("checkout_deploy")
             GitManager.pull_local()
             GlobalVars.reload()
@@ -628,7 +628,7 @@ def unblacklist(msg, item, alias_used="unwatch"):
         try:
             if not GlobalVars.on_branch:
                 # Restart if HEAD detached
-                log('warning', "Pulling local with HEAD detached, checkout deploy", f=True)
+                log('warning', "Pulling local with HEAD detached, checkout deploy", and_file=True)
                 exit_mode("checkout_deploy")
             GitManager.pull_local()
             GlobalVars.reload()
@@ -662,7 +662,7 @@ def approve(msg, pr_id):
             try:
                 if not GlobalVars.on_branch:
                     # Restart if HEAD detached
-                    log('warning', "Pulling local with HEAD detached, checkout deploy", f=True)
+                    log('warning', "Pulling local with HEAD detached, checkout deploy", and_file=True)
                     exit_mode("checkout_deploy")
                 GitManager.pull_local()
                 GlobalVars.reload()

--- a/chatcommunicate.py
+++ b/chatcommunicate.py
@@ -140,7 +140,8 @@ def init(username, password, try_cookies=True):
                         # is in read-only mode and isn't accepting login attempts. Under those conditions,
                         # there's nothing which we or SD can do other than wait for SE to resolve the issue.
                         # So, instead of spinning the CPU hard in order to retry at the maximum rate, we delay a bit.
-                        # The situations where the problem is on our end rather than on SE's end tend
+                        # The situations where the problem is on our end rather than on SE's end tend to be when
+                        # the SD instance owner is already watching the console.
                         sleep_time = 30 * (retry + 1)
                         log('warning', 'Login to SE appears unavailable. Can be caused by: SD config issue,' +
                             ' bad network connection, or Stack Exchange is down/read-only.' +

--- a/chatcommunicate.py
+++ b/chatcommunicate.py
@@ -115,11 +115,13 @@ def init(username, password, try_cookies=True):
                                 log('debug', 'chat.{}: Logged in to chat only using cached cookies'.format(site))
                         except Exception:
                             # This is a fallback using the ChatExchange functionality we've been using for a long time.
+                            log_current_exception(log_level='debug')
                             log('debug', 'chat.{}: chat-only login failed. Falling back to normal cookies'.format(site))
                             client.login_with_cookie(cookies[site])
                             logged_in = True
                             log('debug', 'chat.{}: Logged in using cached cookies'.format(site))
                 except LoginError as e:
+                    log_current_exception(log_level='debug')
                     exc_type, exc_obj, exc_tb = sys.exc_info()
                     log('debug', 'chat.{}: Login error {}: {}'.format(site, exc_type.__name__, exc_obj))
                     log('debug', 'chat.{}: Falling back to credential-based login'.format(site))
@@ -134,6 +136,7 @@ def init(username, password, try_cookies=True):
                 except Exception as e:
                     exc_type, exc_obj, exc_tb = sys.exc_info()
                     log('debug', 'chat.{}: Login error {}: {}'.format(site, exc_type.__name__, exc_obj))
+                    log_current_exception(log_level='debug')
                     if exc_type.__name__ == 'LoginError' and str(exc_obj) == 'fkey input not found':
                         # ChatExchange didn't find the `fkey` <input> in the SE login page. Under most operating
                         # conditions, this means that we've either lost connectivity to SE entirely or SE

--- a/chatcommunicate.py
+++ b/chatcommunicate.py
@@ -20,8 +20,7 @@ import copy
 import datahandling
 import metasmoke
 import classes.feedback
-from helpers import log, redact_passwords
-from excepthook import log_exception
+from helpers import log, redact_passwords, log_current_exception
 from globalvars import GlobalVars
 from parsing import fetch_post_id_and_site_from_url, fetch_post_url_from_msg_content, fetch_owner_url_from_msg_content
 from tasks import Tasks
@@ -538,7 +537,7 @@ class ChatCommand:
         except CmdExceptionLongReply as e:
             return '\n' + str(e).replace('\n', ' ')
         except Exception:  # Everything else
-            log_exception(*sys.exc_info())
+            log_current_exception()
             return "I hit an error while trying to run that command; run `!!/errorlogs` for details."
 
     def __repr__(self):

--- a/datahandling.py
+++ b/datahandling.py
@@ -20,7 +20,7 @@ from globalvars import GlobalVars
 import metasmoke
 from parsing import api_parameter_from_link, post_id_from_link
 import blacklists
-from helpers import ErrorLogs, log, log_exception, redact_passwords
+from helpers import ErrorLogs, log, log_current_exception, redact_passwords
 from tasks import Tasks
 
 last_feedbacked = None
@@ -628,7 +628,7 @@ def get_user_names_on_notification_list(chat_site, room_id, se_site, client):
                 names.append(client.get_user(user_id).name)
             except Exception:
                 # The user is probably deleted, or we're having communication problems with chat.
-                log_exception(*sys.exc_info())
+                log_current_exception()
                 log('warn', 'ChatExchange failed to get user for a report notification. '
                             'See Error log for more details. Tried client.host: '
                             '{}:: user_id: {}:: chat_site: {}'.format(client.host, user_id, chat_site))
@@ -652,7 +652,7 @@ def get_user_names_on_notification_list(chat_site, room_id, se_site, client):
             # cause us to crash, as it's on the path we take for going into standby.
             # It should be noted that this *could* be caused by a discontinuity between room_id and
             # client.
-            log_exception(*sys.exc_info())
+            log_current_exception()
             log('warn', 'ChatExchange failed to get current users. See Error log for more details. Tried '
                         'client.host: {}:: room: {}:: passed chat_site: {}'.format(client.host, room_id, chat_site))
             current_users = []
@@ -846,7 +846,7 @@ def refresh_site_id_dict_if_needed_and_get_issues():
         except Exception:
             # We ignore any problems with getting or refreshing the list of SE sites, as we handle it by
             # testing to see if we have valid data (i.e. SD doesn't need to fail for an exception here).
-            log_exception(*sys.exc_info())
+            log_current_exception()
             issues.append("An exception occurred when trying to get the SE site ID list."
                           " See the error log for details.")
         if is_se_site_id_list_length_valid():

--- a/gitmanager.py
+++ b/gitmanager.py
@@ -21,7 +21,7 @@ else:
     from sh.contrib import git
     from sh import ErrorReturnCode as GitError
 
-from helpers import log, log_exception, only_blacklists_changed
+from helpers import log, log_current_exception, only_blacklists_changed
 from blacklists import *
 
 
@@ -250,7 +250,7 @@ class GitManager:
                         return (False, "A bad or invalid reply was received from GH, the message was: %s" %
                                 response['message'])
         except Exception as err:
-            log_exception(*sys.exc_info())
+            log_current_exception()
             return (False, "Git functions failed for unspecified reasons, details may be in error log.")
         finally:
             # Always return to `deploy` branch when done with anything.
@@ -328,7 +328,7 @@ class GitManager:
 
         except Exception as e:
             log('error', '{}: {}'.format(type(e).__name__, e))
-            log_exception(*sys.exc_info())
+            log_current_exception()
             return False, 'Git operations failed for unspecified reasons.'
         finally:
             git.checkout('deploy')
@@ -416,7 +416,7 @@ class GitManager:
         except GitError as e:
             if GlobalVars.on_windows:
                 return False, "Not doing this, we're on Windows."
-            log_exception(*sys.exc_info())
+            log_current_exception()
             return False, "`git pull` has failed. This shouldn't happen. Details have been logged."
 
         if GlobalVars.on_windows:

--- a/helpers.py
+++ b/helpers.py
@@ -211,19 +211,19 @@ def get_traceback_from_traceback_or_message(traceback_or_message):
         return ''.join(traceback.format_tb(traceback_or_message))
 
 
-def log_exception(exctype, value, traceback_or_message, f=False, *, level=None):
+def log_exception(exctype, value, traceback_or_message, log_to_file=False, *, level=None):
     level = 'error' if level is None else level
     now = datetime.utcnow()
     tr = get_traceback_from_traceback_or_message(traceback_or_message)
     exception_only = ''.join(traceback.format_exception_only(exctype, value)).strip()
     logged_msg = "{exception}\n{now} UTC\n{row}\n\n".format(exception=exception_only, now=now, row=tr)
     # Redacting passwords happens in log() and ErrorLogs.add().
-    log(level, logged_msg, f=f)
+    log(level, logged_msg, f=log_to_file)
     ErrorLogs.add(now.timestamp(), exctype.__name__, str(value), tr)
 
 
-def log_current_exception(f=False, level=None):
-    log_exception(*sys.exc_info(), f, level=level)
+def log_current_exception(log_to_file=False, level=None):
+    log_exception(*sys.exc_info(), log_to_file=log_to_file, level=level)
 
 
 def log_current_thread(log_level, prefix="", postfix=""):

--- a/helpers.py
+++ b/helpers.py
@@ -211,19 +211,19 @@ def get_traceback_from_traceback_or_message(traceback_or_message):
         return ''.join(traceback.format_tb(traceback_or_message))
 
 
-def log_exception(exctype, value, traceback_or_message, and_file=False, *, level=None):
-    level = 'error' if level is None else level
+def log_exception(exctype, value, traceback_or_message, and_file=False, *, log_level=None):
+    log_level = 'error' if log_level is None else log_level
     now = datetime.utcnow()
     tr = get_traceback_from_traceback_or_message(traceback_or_message)
     exception_only = ''.join(traceback.format_exception_only(exctype, value)).strip()
     logged_msg = "{exception}\n{now} UTC\n{row}\n\n".format(exception=exception_only, now=now, row=tr)
     # Redacting passwords happens in log() and ErrorLogs.add().
-    log(level, logged_msg, and_file=and_file)
+    log(log_level, logged_msg, and_file=and_file)
     ErrorLogs.add(now.timestamp(), exctype.__name__, str(value), tr)
 
 
-def log_current_exception(and_file=False, level=None):
-    log_exception(*sys.exc_info(), and_file=and_file, level=level)
+def log_current_exception(and_file=False, log_level=None):
+    log_exception(*sys.exc_info(), and_file=and_file, log_level=log_level)
 
 
 def log_current_thread(log_level, prefix="", postfix=""):

--- a/helpers.py
+++ b/helpers.py
@@ -161,7 +161,7 @@ def redact_passwords(value):
 
 
 # noinspection PyMissingTypeHints
-def log(log_level, *args, f=False, no_exception=False):
+def log(log_level, *args, and_file=False, no_exception=False):
     levels = {
         'debug': [0, 'grey'],
         'info': [1, 'cyan'],
@@ -184,7 +184,7 @@ def log(log_level, *args, f=False, no_exception=False):
         exc_tb = sys.exc_info()[2]
         print(redact_passwords("".join(traceback.format_tb(exc_tb))), file=sys.stderr)
 
-    if f:  # Also to file
+    if and_file:  # Also to file
         log_file(log_level, *args)
 
 
@@ -211,19 +211,19 @@ def get_traceback_from_traceback_or_message(traceback_or_message):
         return ''.join(traceback.format_tb(traceback_or_message))
 
 
-def log_exception(exctype, value, traceback_or_message, log_to_file=False, *, level=None):
+def log_exception(exctype, value, traceback_or_message, and_file=False, *, level=None):
     level = 'error' if level is None else level
     now = datetime.utcnow()
     tr = get_traceback_from_traceback_or_message(traceback_or_message)
     exception_only = ''.join(traceback.format_exception_only(exctype, value)).strip()
     logged_msg = "{exception}\n{now} UTC\n{row}\n\n".format(exception=exception_only, now=now, row=tr)
     # Redacting passwords happens in log() and ErrorLogs.add().
-    log(level, logged_msg, f=log_to_file)
+    log(level, logged_msg, and_file=and_file)
     ErrorLogs.add(now.timestamp(), exctype.__name__, str(value), tr)
 
 
-def log_current_exception(log_to_file=False, level=None):
-    log_exception(*sys.exc_info(), log_to_file=log_to_file, level=level)
+def log_current_exception(and_file=False, level=None):
+    log_exception(*sys.exc_info(), and_file=and_file, level=level)
 
 
 def log_current_thread(log_level, prefix="", postfix=""):

--- a/metasmoke.py
+++ b/metasmoke.py
@@ -289,7 +289,7 @@ class Metasmoke:
                         GitManager.pull_remote()
                         if not GlobalVars.on_branch:
                             # Restart if HEAD detached
-                            log('warning', "Pulling remote with HEAD detached, checkout deploy", f=True)
+                            log('warning', "Pulling remote with HEAD detached, checkout deploy", and_file=True)
                             exit_mode("checkout_deploy")
                         GlobalVars.reload()
                         findspam.FindSpam.reload_blacklists()
@@ -299,7 +299,7 @@ class Metasmoke:
                         GitManager.pull_remote()
                         if not GlobalVars.on_branch:
                             # Restart if HEAD detached
-                            log('warning', "Pulling remote with HEAD detached, checkout deploy", f=True)
+                            log('warning', "Pulling remote with HEAD detached, checkout deploy", and_file=True)
                             exit_mode("checkout_deploy")
                         GlobalVars.reload()
                         reload_modules()

--- a/metasmoke.py
+++ b/metasmoke.py
@@ -25,7 +25,7 @@ import spamhandling
 import classes
 import chatcommunicate
 from helpers import log, exit_mode, only_blacklists_changed, \
-    only_modules_changed, blacklist_integrity_check, reload_modules, log_exception
+    only_modules_changed, blacklist_integrity_check, reload_modules, log_current_exception
 from gitmanager import GitManager
 import findspam
 from socketscience import SocketScience
@@ -185,7 +185,7 @@ class Metasmoke:
                         raise
                     except Exception as e:
                         log('error', '{}: {}'.format(type(e).__name__, e))
-                        log_exception(*sys.exc_info())
+                        log_current_exception()
                         GlobalVars.MSStatus.failed()
                         Metasmoke.connect_websocket()
             except Exception:
@@ -642,7 +642,7 @@ class Metasmoke:
             return None
         except Exception as e:
             log('error', '{}: {}'.format(type(e).__name__, e))
-            log_exception(*sys.exc_info())
+            log_current_exception()
             exception_only = ''.join(traceback.format_exception_only(type(e), e)).strip()
             chatcommunicate.tell_rooms_with("debug", "{}: In getting MS post information, recovered from `{}`"
                                                      .format(GlobalVars.location, exception_only))

--- a/ws.py
+++ b/ws.py
@@ -165,7 +165,7 @@ except TldIOError as ioerr:
 
     else:
         err_msg = strerror
-    log_exception(type(ioerr), ioerr, err_msg, True, level="warning")
+    log_exception(type(ioerr), ioerr, err_msg, True, log_level="warning")
 
 if "ChatExchangeU" in os.environ:
     log('debug', "ChatExchange username loaded from environment")


### PR DESCRIPTION
This started out with just intending to add some additional debug logging of exception in the chat init sequence in order to be able to get a better idea of what was happening during that process when SE was down. However, prior to that, I made changes to the logging helper functions, `log()`, `log_exception()`, and `log_current_exception()` to have more descriptive argument names, more consistency, etc.

This PR does:
* More consistent argument name `level` -> `log_level` in `log_exception` and `log_current_exception()` to match `log()`
* More descriptive argument name in all three functions `f`->`and_file` to indicate the log is also being recorded in a file.
* Add ability to specify `log_level` and `and_file` for log_current_exception()`
* Use `log_current_exception()` for `log_exception(*sys.exc_info())` throughout the code.
* Add `ErrorLogs.add_current_exception`
* Add debug level logging of exceptions which are caught in the chat room init process.

In addition to CI testing, a *minimal* amount of testing (basically just a smoke test) was performed in the [Makyen Test 02](https://chat.stackexchange.com/transcript/message/61689355#61689355) room.