### PR TITLE
Add a second verification pass for initial NS verification failures

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -462,3 +462,7 @@ def strip_pre_elements(text, leave_note=False):
 
 def strip_pre_and_code_elements(text, leave_note=False):
     return strip_code_elements(strip_pre_elements(text, leave_note=leave_note), leave_note=leave_note)
+
+
+def pluralize(value, base, plural_end, single_end='', zero_is_plural=True):
+    return base + plural_end if value > 1 or (zero_is_plural and value == 0) else base + single_end


### PR DESCRIPTION
The intent of this change is to prevent CI testing from failing due to intermittent DNS resolution issues. While we already do a second pass, it doesn't seem to resolve the issues we're seeing on particular domains. This collects the entries which failed the first round of testing and re-tests all of the failures (many/most will have already been tested twice, so this is a third and fourth attempt, but delayed).

In addition, with the prior code we don't have easy access to the entry which is is failing. With this change, the failing entries are collected into a list in both a first and second pass. If we continue to have issues with a specific domain that isn't actually a failure and something we want to remove from then list, then we can just exclude it from being reported as an error in CI testing.