### PR TITLE
Add optional "additional_failover_text" entry in SD's config file.

### DIFF
--- a/globalvars.py
+++ b/globalvars.py
@@ -437,6 +437,12 @@ class GlobalVars:
     if valid_rule_ids is not None:
         valid_rule_ids = valid_rule_ids.split(";")
 
+    # Additional text to send to chat when this instance receives a "failover" from MS:
+    # If present at the start and end of the string in the config file, a single ["'] character is stripped from
+    # both the start and end of the value. This allows the value in the config file to be enclosed in quotes
+    # to preserve leading whitespace, but also permit the string to contain those characters.
+    additional_failover_text = regex.sub(r'''^['"](.*)['"]$''', r'\1', config.get("additional_failover_text", ""))
+
     # environ_or_none replaced by os.environ.get (essentially dict.get)
     bot_name = os.environ.get("SMOKEDETECTOR_NAME", git_name)
     bot_repo_slug = os.environ.get("SMOKEDETECTOR_REPO", git_user_repo)

--- a/metasmoke.py
+++ b/metasmoke.py
@@ -487,7 +487,8 @@ class Metasmoke:
                     if response['failover']:
                         GlobalVars.standby_mode = False
 
-                        chatcommunicate.tell_rooms_with("debug", GlobalVars.location + " received failover signal.",
+                        chatcommunicate.tell_rooms_with("debug", GlobalVars.location + " received failover signal."
+                                                        + GlobalVars.additional_failover_text,
                                                         notify_site="/failover")
 
                 if response.get('standby', False):


### PR DESCRIPTION
This PR adds an optional `additional_failover_text` entry to SD's config file, which allows additional per-instance text to be added to the chat message the instance posts upon receiving a "failover" from MS.

The issue that this is attempting to address is that we have had several times recently where MS has sent a `failover` to Makyen/EC2-linux when Osiris was actually still operational. The chat notification of the failover and restarting text has gone generally unnoticed until the fact that there are two active instances running causes some secondary issue. This is intended to allow me to have text specific to Makyen/EC2-linux which calls more attention to the fact that there's been a failover, in order to make it more likely that the situation is evaluated and addressed by a human.