### PR TITLE
Remove Erica from Erica rule (sic)

### DIFF
--- a/findspam.py
+++ b/findspam.py
@@ -2730,7 +2730,7 @@ create_rule("several emoji in title",
 # Parenting troll
 # This rule is currently broken and detects nothing. It appears it was supposed to be for usernames.
 create_rule("bad keyword in {}",
-            r"(?i)\b(erica|jeff|er1ca|spam|moderator)\b",
+            r"(?i)\b(jeff|spam|moderator)\b",
             all=False, sites=["parenting.stackexchange.com"],
             title=False, body_summary=True, max_rep=52,
             rule_id="bad keywords: erica, jeff, er1ca, etc., bodies, parenting")


### PR DESCRIPTION
Proposed by Glorfindel in chat: https://chat.stackexchange.com/transcript/message/61791436#61791436

I didn't change the rule's description to keep the history intact on the metasmoke side. Perhaps that is not something we want, though?