### PR TITLE
Add inline attribution for chat replies which are forwarded to MS as comments

### DIFF
--- a/chatcommunicate.py
+++ b/chatcommunicate.py
@@ -641,7 +641,7 @@ def dispatch_command(msg):
                 return func(*args, original_msg=msg, alias_used=command_name, quiet_action=quiet_action)
 
 
-def dispatch_reply_command(msg, reply, full_cmd, comment=True):
+def dispatch_reply_command(message_replied_to, reply, full_cmd, comment=True):
     command_parts = full_cmd.split(" ", 1)
 
     if len(command_parts) == 2:
@@ -664,16 +664,16 @@ def dispatch_reply_command(msg, reply, full_cmd, comment=True):
         assert min_arity == 1
 
         if max_arity == 1:
-            return func(msg, original_msg=reply, alias_used=cmd, quiet_action=quiet_action)
+            return func(message_replied_to, original_msg=reply, alias_used=cmd, quiet_action=quiet_action)
         elif max_arity == 2:
-            return func(msg, args, original_msg=reply, alias_used=cmd, quiet_action=quiet_action)
+            return func(message_replied_to, args, original_msg=reply, alias_used=cmd, quiet_action=quiet_action)
         else:
             args = args.split()
             args.extend([None] * (max_arity - len(args)))
 
-            return func(msg, *args, original_msg=reply, alias_used=cmd, quiet_action=quiet_action)
+            return func(message_replied_to, *args, original_msg=reply, alias_used=cmd, quiet_action=quiet_action)
     elif comment and is_privileged(reply.owner, reply.room):
-        post_data = get_report_data(msg)
+        post_data = get_report_data(message_replied_to)
 
         if post_data:
             expected_domains = (r'\b(?:erwaysoftware\.com|stackexchange\.com|stackoverflow\.com|serverfault\.com'

--- a/chatcommunicate.py
+++ b/chatcommunicate.py
@@ -641,6 +641,13 @@ def dispatch_command(msg):
                 return func(*args, original_msg=msg, alias_used=command_name, quiet_action=quiet_action)
 
 
+def get_attribution_for_message(msg):
+    host_url = 'https://chat.{}/'.format(msg._client.host)
+    message_url = '{}transcript/message/{}'.format(host_url, msg.id)
+    user_url = '{}users/{}/{}'.format(host_url, msg.owner.id, msg.owner.name)
+    return ' &ndash; from a [chat message]({}) by [{}]({})'.format(message_url, msg.owner.name, user_url)
+
+
 def dispatch_reply_command(message_replied_to, reply, full_cmd, comment=True):
     command_parts = full_cmd.split(" ", 1)
 
@@ -687,7 +694,8 @@ def dispatch_reply_command(message_replied_to, reply, full_cmd, comment=True):
                     # and doesn't have much text other than the reply, and contains at lesat one  MS and/or SE domain.
                     # So, we don't want to forward it as a comment to MS.
                     return
-            Tasks.do(metasmoke.Metasmoke.post_auto_comment, full_cmd, reply.owner, url=post_data[0])
+            Tasks.do(metasmoke.Metasmoke.post_auto_comment, full_cmd + get_attribution_for_message(reply),
+                     reply.owner, url=post_data[0])
 
 
 def dispatch_shorthand_command(msg):


### PR DESCRIPTION
This is needed in order to minimally comply with the CC BY SA license under which all chat messages are posted. It includes a link to both the chat message and the user account which posted the chat message. It should actually be a bit more involved, but this is a good first step.

The attribution looks like:
> This is a test of a reply 008 &ndash; from a [chat message](https://chat.stackexchange.com/transcript/message/61829040) by [Makyen](https://chat.stackexchange.com/users/156050/Makyen)


We probably should also add inline attribution for other types of comments which are forwarded to MS, but those are more clearly intended by the user to be included in reports (e.g. the comment at the end of a `!!/report`).