### PR TITLE
Improve message for watch during ongoing CI testing

### DIFF
--- a/chatcommands.py
+++ b/chatcommands.py
@@ -554,7 +554,18 @@ def do_blacklist(blacklist_type, msg, force=False):
             return None
         except Exception:
             pass
-    return result
+    additional_state = (" However, the blacklists were not reloaded at this time. The most likely issue"
+                        " is another change was made on SD's master branch on GitHub and everything"
+                        " is waiting for CI to pass and MS to update the deploy branch.")
+    if GlobalVars.MSStatus.is_down():
+        additional_state += (" But, metasmoke is currently down, so that won't happen. Someone with write"
+                             " permission to SD's GitHub reository will need to manually update the deploy"
+                             " branch. Usually, this means you should ping an MS admin.")
+    else:
+        additional_state += (" That could take a few to several minutes. If SD doesn't automatically reload"
+                             " the blacklists or automatically reboot after that time, then someone should"
+                             " investigate why that hasn't happened.")
+    return result + additional_state
 
 
 # noinspection PyIncorrectDocstring

--- a/gitmanager.py
+++ b/gitmanager.py
@@ -260,7 +260,7 @@ class GitManager:
         if op == 'blacklist':
             return (True, "Blacklisted `{0}`".format(item))
         elif op == 'watch':
-            return (True, "`{0}` will be added to the watchlist once the ongoing CI testing is done".format(item))
+            return (True, "Added `{0}` to watchlist".format(item))
 
     @classmethod
     def remove_from_blacklist(cls, item, username, blacklist_type="", code_privileged=False, metasmoke_down=False):

--- a/gitmanager.py
+++ b/gitmanager.py
@@ -260,7 +260,7 @@ class GitManager:
         if op == 'blacklist':
             return (True, "Blacklisted `{0}`".format(item))
         elif op == 'watch':
-            return (True, "Added `{0}` to watchlist".format(item))
+            return (True, "`{0}` will be added to the watchlist once the ongoing CI testing is done".format(item))
 
     @classmethod
     def remove_from_blacklist(cls, item, username, blacklist_type="", code_privileged=False, metasmoke_down=False):

--- a/test/test_chatcommands.py
+++ b/test/test_chatcommands.py
@@ -334,7 +334,7 @@ def test_watch(monkeypatch):
         assert wrap_watch("trimfire", True).startswith("Already watched")
 
         monkeypatch.setattr("gitmanager.GitManager.add_to_blacklist", lambda *args, **kwargs: (True, "Hahaha"))
-        assert wrap_watch("male enhancement", True) == "Hahaha"
+        assert wrap_watch("male enhancement", True).startswith("Hahaha ")
     finally:
         git.checkout("master")
 


### PR DESCRIPTION
Tl;dr when someone does `!!/watch` during CI testing it will ping them instead of just saying that it reloaded the watchlist. This PR explains what is happening (it will be added once the current CI testing is done), so it is clear what is happening

Context is [in the transcript](https://chat.stackexchange.com/transcript/message/61892018#61892018), phrasing suggested by @codygray.

TODO:
The spot in the code is here:

https://github.com/Charcoal-SE/SmokeDetector/blob/master/gitmanager.py#L260-L263

Do we also need to adjust that message for blacklisting? I suspect yes, but I should check that as well