### PR TITLE
Add per-entry ignore of NS validation failures in CI testing

### DIFF
--- a/watched_nses.yml
+++ b/watched_nses.yml
@@ -2544,6 +2544,7 @@ items:
   disable: true
   ns: dns-parking.net.
 - ns: dns-parking.com.
+  ignore_validation_errors: true
 - ns: host.com.pk.
 - ns: genxwhosting.com.
 - ns: phase8.net.


### PR DESCRIPTION
This adds the ability to ignore NS validation failures during CI testing on a per-entry basis in the *nses.yml files. If an entry in those files has the value `ignore_validation_errors: true`, then validation errors will not cause CI failures.

This is primarily in order to be able to prevent CI failures due to the persistent intermittent issues with validating `dns-parking.com.`.  This PR adds `ignore_validation_errors: true` to the `dns-parking.com.` entry in watched_nses.yml, which will result in not seeing CI testing failures when that domain fails DNS validation.

There probably should be some automated testing which still validates, and fails on, entries which have `ignore_validation_errors: true`, as we do want to know about such domains if they *actually* stop having a DNS entry. However, this PR just patches over the persistent frustration of looking at CI failures and finding that it's yet another time that `dns-parking.com.` had an intermittent problem. No attempt is made here to address the issue of wanting some type reporting for such domains when they actually go away.
