### PR TITLE
Update GitHub Actions: Python 3.11, setup-python@v4, cache@v3, unlock coverage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,12 +23,12 @@ jobs:
       run: |
         git remote set-branches --add origin deploy
         git fetch --depth=5 origin master deploy
-    - uses: actions/setup-python@v3
+    - uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Setup cache
       id: cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         key: ${{ runner.os }}-${{ env.pythonLocation }}-pip-cache-version-1-${{ hashFiles('**/requirements.txt') }}}-${{ hashFiles('**/user_requirements.txt') }}
         restore-keys: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         python-version:
           - '3.8'
-          - '3.10'
+          - '3.11'
     steps:
     - uses: actions/checkout@v3
     - name: Fetch branches

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ git+https://github.com/Charcoal-SE/ChatExchange.git
 appdirs>=1.4.3
 beautifulsoup4>=4.6.0
 colorama>=0.4.1
-coverage>=4.5.1,<5
+coverage>=6.5.0
 dnspython>=2.0.0
 flake8~=3.8.0
 msgpack-python>=0.5.6


### PR DESCRIPTION
This PR makes a few changes to CI testing with GitHub Actions:
* Moves our "current" Python version testing from 3.10 to 3.11, due to recent release of Python 3.11.  
   As an interesting note: testing on CircleCI (which this PR doesn't change) indicates a notable speedup on CircleCI testing when moving from Python 3.8 ([average of 5 runs 2m53s](https://app.circleci.com/pipelines/github/makyen/Charcoal-SE-SmokeDetector/3033)) to Python 3.11 ([average of 6 runs 2m 12s](https://app.circleci.com/pipelines/github/makyen/Charcoal-SE-SmokeDetector/3034), which is about a 24% improvement). Testing was on CircleCI merely because it's easier to see multiple runs on the same `git` commit.
* Updates to `actions/setup-python@v4` and `actions/cache@v3` from v3 and v2 respectively. We were seeing deprecation warnings in the test output.
* Unlocks the version of the `coverage` package in requirements.txt and requires a version >= 6.5.0 which is, currently, the latest version.  
   The version had been locked to < v5 in [this commit](https://github.com/makyen/Charcoal-SE-SmokeDetector/commit/539a58d5867877f1915d9aca435d49e64aa904a7) due to a compatibility issue with TravisCI. We're no longer using TravisCI, so compatibility with TravisCI is no longer an issue. With the switch to Python 3.11, it became clear that having the `coverage` version locked to what is now a quite old version was causing a substantial increase in CI testing times under Python 3.11 (about 3 to 5 times longer to complete testing).