### PR TITLE
Move to SE API 2.4 to support Staging Ground; add request timeouts

### DIFF
--- a/apigetpost.py
+++ b/apigetpost.py
@@ -54,27 +54,23 @@ class PostData:
 
 
 def api_get_post(post_url):
-    GlobalVars.api_request_lock.acquire()
+    with GlobalVars.api_request_lock:
+        # Respect backoff, if we were given one
+        if GlobalVars.api_backoff_time > time.time():
+            time.sleep(GlobalVars.api_backoff_time - time.time() + 2)
+        d = parsing.fetch_post_id_and_site_from_url(post_url)
+        if d is None:
+            return None
+        post_id, site, post_type = d
 
-    # Respect backoff, if we were given one
-    if GlobalVars.api_backoff_time > time.time():
-        time.sleep(GlobalVars.api_backoff_time - time.time() + 2)
-    d = parsing.fetch_post_id_and_site_from_url(post_url)
-    if d is None:
-        GlobalVars.api_request_lock.release()
-        return None
-    post_id, site, post_type = d
-
-    request_url = GlobalVars.se_api_url_base + "{}s/{}".format(post_type, post_id)
-    params = get_se_api_default_params_questions_answers_posts_add_site(site)
-    response = requests.get(request_url, params=params, timeout=GlobalVars.default_requests_timeout).json()
-    if "backoff" in response:
-        if GlobalVars.api_backoff_time < time.time() + response["backoff"]:
-            GlobalVars.api_backoff_time = time.time() + response["backoff"]
-    if 'items' not in response or len(response['items']) == 0:
-        GlobalVars.api_request_lock.release()
-        return False
-    GlobalVars.api_request_lock.release()
+        request_url = GlobalVars.se_api_url_base + "{}s/{}".format(post_type, post_id)
+        params = get_se_api_default_params_questions_answers_posts_add_site(site)
+        response = requests.get(request_url, params=params, timeout=GlobalVars.default_requests_timeout).json()
+        if "backoff" in response:
+            if GlobalVars.api_backoff_time < time.time() + response["backoff"]:
+                GlobalVars.api_backoff_time = time.time() + response["backoff"]
+        if 'items' not in response or len(response['items']) == 0:
+            return False
 
     item = response['items'][0]
     post_data = PostData()

--- a/apigetpost.py
+++ b/apigetpost.py
@@ -63,16 +63,10 @@ def api_get_post(post_url):
         GlobalVars.api_request_lock.release()
         return None
     post_id, site, post_type = d
-    if post_type == "answer":
-        api_filter = r"!4z6S)cPO)zvpuDWsWTAUW(kaV6K6thsqi1tlYa"
-    elif post_type == "question":
-        api_filter = r"!m)9.UaQrI5-DZXtlTpWhv2HroYRgS3dPhv.2vxV7fpGT*27rEHM.BKV1"
-    else:
-        raise ValueError("Unknown post type: {}".format(post_type))
 
     request_url = "https://api.stackexchange.com/2.2/{}s/{}".format(post_type, post_id)
     params = {
-        'filter': api_filter,
+        'filter': GlobalVars.se_api_question_answer_post_filter,
         'key': 'IAkbitmze4B8KpacUfLqkw((',
         'site': site
     }

--- a/apigetpost.py
+++ b/apigetpost.py
@@ -67,7 +67,7 @@ def api_get_post(post_url):
 
     request_url = GlobalVars.se_api_url_base + "{}s/{}".format(post_type, post_id)
     params = get_se_api_default_params_questions_answers_posts_add_site(site)
-    response = requests.get(request_url, params=params).json()
+    response = requests.get(request_url, params=params, timeout=GlobalVars.default_requests_timeout).json()
     if "backoff" in response:
         if GlobalVars.api_backoff_time < time.time() + response["backoff"]:
             GlobalVars.api_backoff_time = time.time() + response["backoff"]

--- a/apigetpost.py
+++ b/apigetpost.py
@@ -4,6 +4,7 @@ import parsing
 from globalvars import GlobalVars
 import time
 import html
+from helpers import get_se_api_default_params_questions_answers_posts_add_site
 
 
 class PostData:
@@ -65,11 +66,7 @@ def api_get_post(post_url):
     post_id, site, post_type = d
 
     request_url = GlobalVars.se_api_url_base + "{}s/{}".format(post_type, post_id)
-    params = {
-        'filter': GlobalVars.se_api_question_answer_post_filter,
-        'key': 'IAkbitmze4B8KpacUfLqkw((',
-        'site': site
-    }
+    params = get_se_api_default_params_questions_answers_posts_add_site(site)
     response = requests.get(request_url, params=params).json()
     if "backoff" in response:
         if GlobalVars.api_backoff_time < time.time() + response["backoff"]:

--- a/apigetpost.py
+++ b/apigetpost.py
@@ -64,7 +64,7 @@ def api_get_post(post_url):
         return None
     post_id, site, post_type = d
 
-    request_url = "https://api.stackexchange.com/2.2/{}s/{}".format(post_type, post_id)
+    request_url = GlobalVars.se_api_url_base + "{}s/{}".format(post_type, post_id)
     params = {
         'filter': GlobalVars.se_api_question_answer_post_filter,
         'key': 'IAkbitmze4B8KpacUfLqkw((',

--- a/apigetpost.py
+++ b/apigetpost.py
@@ -4,7 +4,7 @@ import parsing
 from globalvars import GlobalVars
 import time
 import html
-from helpers import get_se_api_default_params_questions_answers_posts_add_site
+from helpers import get_se_api_default_params_questions_answers_posts_add_site, get_se_api_url_for_route
 
 
 class PostData:
@@ -63,7 +63,7 @@ def api_get_post(post_url):
             return None
         post_id, site, post_type = d
 
-        request_url = GlobalVars.se_api_url_base + "{}s/{}".format(post_type, post_id)
+        request_url = get_se_api_url_for_route("{}s/{}".format(post_type, post_id))
         params = get_se_api_default_params_questions_answers_posts_add_site(site)
         response = requests.get(request_url, params=params, timeout=GlobalVars.default_requests_timeout).json()
         if "backoff" in response:

--- a/bodyfetcher.py
+++ b/bodyfetcher.py
@@ -555,7 +555,7 @@ class BodyFetcher:
         else:
             question_modifier = "/{0}".format(";".join([str(post) for post in posts]))
 
-        url = "https://api.stackexchange.com/2.2/questions{}".format(question_modifier)
+        url = GlobalVars.se_api_url_base + "questions{}".format(question_modifier)
         params = {
             'filter': GlobalVars.se_api_question_answer_post_filter,
             'key': 'IAkbitmze4B8KpacUfLqkw((',

--- a/bodyfetcher.py
+++ b/bodyfetcher.py
@@ -18,7 +18,7 @@ from chatcommunicate import tell_rooms_with
 from classes import Post, PostParseError
 from helpers import (log, log_current_thread, append_to_current_thread_name,
                      convert_new_scan_to_spam_result_if_new_reasons, add_to_global_bodyfetcher_queue_in_new_thread,
-                     get_se_api_default_params_questions_answers_posts_add_site)
+                     get_se_api_default_params_questions_answers_posts_add_site, get_se_api_url_for_route)
 import recently_scanned_posts as rsp
 from tasks import Tasks
 
@@ -556,7 +556,7 @@ class BodyFetcher:
         else:
             question_modifier = "/{0}".format(";".join([str(post) for post in posts]))
 
-        url = GlobalVars.se_api_url_base + "questions{}".format(question_modifier)
+        url = get_se_api_url_for_route("questions{}".format(question_modifier))
         params = get_se_api_default_params_questions_answers_posts_add_site(site)
         params.update(pagesize_modifier)
 

--- a/bodyfetcher.py
+++ b/bodyfetcher.py
@@ -557,7 +557,7 @@ class BodyFetcher:
 
         url = "https://api.stackexchange.com/2.2/questions{}".format(question_modifier)
         params = {
-            'filter': '!1rs)sUKylwB)8isvCRk.xNu71LnaxjnPS12*pX*CEOKbPFwVFdHNxiMa7GIVgzDAwMa',
+            'filter': GlobalVars.se_api_question_answer_post_filter,
             'key': 'IAkbitmze4B8KpacUfLqkw((',
             'site': site
         }

--- a/bodyfetcher.py
+++ b/bodyfetcher.py
@@ -17,7 +17,8 @@ from datahandling import (add_or_update_api_data, clear_api_data, schedule_store
 from chatcommunicate import tell_rooms_with
 from classes import Post, PostParseError
 from helpers import (log, log_current_thread, append_to_current_thread_name,
-                     convert_new_scan_to_spam_result_if_new_reasons, add_to_global_bodyfetcher_queue_in_new_thread)
+                     convert_new_scan_to_spam_result_if_new_reasons, add_to_global_bodyfetcher_queue_in_new_thread,
+                     get_se_api_default_params_questions_answers_posts_add_site)
 import recently_scanned_posts as rsp
 from tasks import Tasks
 
@@ -556,11 +557,7 @@ class BodyFetcher:
             question_modifier = "/{0}".format(";".join([str(post) for post in posts]))
 
         url = GlobalVars.se_api_url_base + "questions{}".format(question_modifier)
-        params = {
-            'filter': GlobalVars.se_api_question_answer_post_filter,
-            'key': 'IAkbitmze4B8KpacUfLqkw((',
-            'site': site
-        }
+        params = get_se_api_default_params_questions_answers_posts_add_site(site)
         params.update(pagesize_modifier)
 
         # wait to make sure API has/updates post data

--- a/chatcommands.py
+++ b/chatcommands.py
@@ -1186,11 +1186,11 @@ def pull(alias_used='pull'):
         return
 
     request = requests.get('https://api.github.com/repos/{}/git/refs/heads/deploy'.format(
-        GlobalVars.bot_repo_slug))
+        GlobalVars.bot_repo_slug), timeout=GlobalVars.default_requests_timeout)
     latest_sha = request.json()["object"]["sha"]
     request = requests.get(
-        'https://api.github.com/repos/{}/commits/{}/statuses'.format(
-            GlobalVars.bot_repo_slug, latest_sha))
+        'https://api.github.com/repos/{}/commits/{}/statuses'.format(GlobalVars.bot_repo_slug, latest_sha),
+        timeout=GlobalVars.default_requests_timeout)
     states = []
     for ci_status in request.json():
         state = ci_status["state"]
@@ -2137,7 +2137,7 @@ def allspam(msg, url):
         params = get_se_api_default_params({
             'filter': '!6Pbp)--cWmv(1',
         })
-        res = requests.get(request_url, params=params).json()
+        res = requests.get(request_url, params=params, timeout=GlobalVars.default_requests_timeout).json()
         if "backoff" in res:
             if GlobalVars.api_backoff_time < time.time() + res["backoff"]:
                 GlobalVars.api_backoff_time = time.time() + res["backoff"]
@@ -2162,7 +2162,7 @@ def allspam(msg, url):
         # Fetch posts
         request_url = GlobalVars.se_api_url_base + "users/{}/posts".format(u_id)
         params = get_se_api_default_params_questions_answers_posts_add_site(u_site)
-        res = requests.get(request_url, params=params).json()
+        res = requests.get(request_url, params=params, timeout=GlobalVars.default_requests_timeout).json()
         if "backoff" in res:
             if GlobalVars.api_backoff_time < time.time() + res["backoff"]:
                 GlobalVars.api_backoff_time = time.time() + res["backoff"]
@@ -2201,7 +2201,7 @@ def allspam(msg, url):
                 # Fetch posts
                 req_url = GlobalVars.se_api_url_base + "answers/{}".format(post['post_id'])
                 params = get_se_api_default_params_questions_answers_posts_add_site(u_site)
-                answer_res = requests.get(req_url, params=params).json()
+                answer_res = requests.get(req_url, params=params, timeout=GlobalVars.default_requests_timeout).json()
                 if "backoff" in answer_res:
                     if GlobalVars.api_backoff_time < time.time() + answer_res["backoff"]:
                         GlobalVars.api_backoff_time = time.time() + answer_res["backoff"]

--- a/chatcommands.py
+++ b/chatcommands.py
@@ -29,7 +29,8 @@ from ast import literal_eval
 # noinspection PyCompatibility
 import regex
 from helpers import exit_mode, only_blacklists_changed, only_modules_changed, log, expand_shorthand_link, \
-    reload_modules, chunk_list, remove_regex_comments, regex_compile_no_cache, log_current_exception
+    reload_modules, chunk_list, remove_regex_comments, regex_compile_no_cache, log_current_exception, \
+    get_se_api_default_params, get_se_api_default_params_questions_answers_posts_add_site
 from classes import Post
 from classes.feedback import *
 from classes.dns import dns_resolve
@@ -2113,7 +2114,6 @@ def allspam(msg, url):
     :return:
     """
 
-    api_key = 'IAkbitmze4B8KpacUfLqkw(('
     crn, wait = can_report_now(msg.owner.id, msg._client.host)
     if not crn:
         raise CmdException("You can execute the !!/allspam command again in {} seconds. "
@@ -2134,10 +2134,9 @@ def allspam(msg, url):
             time.sleep(GlobalVars.api_backoff_time - time.time() + 2)
         # Fetch sites
         request_url = GlobalVars.se_api_url_base + "users/{}/associated".format(user[0])
-        params = {
+        params = get_se_api_default_params({
             'filter': '!6Pbp)--cWmv(1',
-            'key': api_key
-        }
+        })
         res = requests.get(request_url, params=params).json()
         if "backoff" in res:
             if GlobalVars.api_backoff_time < time.time() + res["backoff"]:
@@ -2162,11 +2161,7 @@ def allspam(msg, url):
             time.sleep(GlobalVars.api_backoff_time - time.time() + 2)
         # Fetch posts
         request_url = GlobalVars.se_api_url_base + "users/{}/posts".format(u_id)
-        params = {
-            'filter': GlobalVars.se_api_question_answer_post_filter,
-            'key': api_key,
-            'site': u_site
-        }
+        params = get_se_api_default_params_questions_answers_posts_add_site(u_site)
         res = requests.get(request_url, params=params).json()
         if "backoff" in res:
             if GlobalVars.api_backoff_time < time.time() + res["backoff"]:
@@ -2205,11 +2200,7 @@ def allspam(msg, url):
                     time.sleep(GlobalVars.api_backoff_time - time.time() + 2)
                 # Fetch posts
                 req_url = GlobalVars.se_api_url_base + "answers/{}".format(post['post_id'])
-                params = {
-                    'filter': GlobalVars.se_api_question_answer_post_filter,
-                    'key': api_key,
-                    'site': u_site
-                }
+                params = get_se_api_default_params_questions_answers_posts_add_site(u_site)
                 answer_res = requests.get(req_url, params=params).json()
                 if "backoff" in answer_res:
                     if GlobalVars.api_backoff_time < time.time() + answer_res["backoff"]:

--- a/chatcommands.py
+++ b/chatcommands.py
@@ -30,7 +30,7 @@ from ast import literal_eval
 import regex
 from helpers import exit_mode, only_blacklists_changed, only_modules_changed, log, expand_shorthand_link, \
     reload_modules, chunk_list, remove_regex_comments, regex_compile_no_cache, log_current_exception, \
-    get_se_api_default_params, get_se_api_default_params_questions_answers_posts_add_site
+    get_se_api_default_params, get_se_api_default_params_questions_answers_posts_add_site, get_se_api_url_for_route
 from classes import Post
 from classes.feedback import *
 from classes.dns import dns_resolve
@@ -2132,7 +2132,7 @@ def allspam(msg, url):
             if GlobalVars.api_backoff_time > time.time():
                 time.sleep(GlobalVars.api_backoff_time - time.time() + 2)
             # Fetch sites
-            request_url = GlobalVars.se_api_url_base + "users/{}/associated".format(user[0])
+            request_url = get_se_api_url_for_route("users/{}/associated".format(user[0]))
             params = get_se_api_default_params({
                 'filter': '!6Pbp)--cWmv(1',
             })
@@ -2158,7 +2158,7 @@ def allspam(msg, url):
             if GlobalVars.api_backoff_time > time.time():
                 time.sleep(GlobalVars.api_backoff_time - time.time() + 2)
             # Fetch posts
-            request_url = GlobalVars.se_api_url_base + "users/{}/posts".format(u_id)
+            request_url = get_se_api_url_for_route("users/{}/posts".format(u_id))
             params = get_se_api_default_params_questions_answers_posts_add_site(u_site)
             res = requests.get(request_url, params=params, timeout=GlobalVars.default_requests_timeout).json()
             if "backoff" in res:
@@ -2196,7 +2196,7 @@ def allspam(msg, url):
                     if GlobalVars.api_backoff_time > time.time():
                         time.sleep(GlobalVars.api_backoff_time - time.time() + 2)
                     # Fetch posts
-                    req_url = GlobalVars.se_api_url_base + "answers/{}".format(post['post_id'])
+                    req_url = get_se_api_url_for_route("answers/{}".format(post['post_id']))
                     params = get_se_api_default_params_questions_answers_posts_add_site(u_site)
                     answer_res = requests.get(req_url, params=params,
                                               timeout=GlobalVars.default_requests_timeout).json()

--- a/chatcommands.py
+++ b/chatcommands.py
@@ -2133,7 +2133,7 @@ def allspam(msg, url):
         if GlobalVars.api_backoff_time > time.time():
             time.sleep(GlobalVars.api_backoff_time - time.time() + 2)
         # Fetch sites
-        request_url = "https://api.stackexchange.com/2.2/users/{}/associated".format(user[0])
+        request_url = GlobalVars.se_api_url_base + "users/{}/associated".format(user[0])
         params = {
             'filter': '!6Pbp)--cWmv(1',
             'key': api_key
@@ -2161,7 +2161,7 @@ def allspam(msg, url):
         if GlobalVars.api_backoff_time > time.time():
             time.sleep(GlobalVars.api_backoff_time - time.time() + 2)
         # Fetch posts
-        request_url = "https://api.stackexchange.com/2.2/users/{}/posts".format(u_id)
+        request_url = GlobalVars.se_api_url_base + "users/{}/posts".format(u_id)
         params = {
             'filter': GlobalVars.se_api_question_answer_post_filter,
             'key': api_key,
@@ -2204,7 +2204,7 @@ def allspam(msg, url):
                 if GlobalVars.api_backoff_time > time.time():
                     time.sleep(GlobalVars.api_backoff_time - time.time() + 2)
                 # Fetch posts
-                req_url = "https://api.stackexchange.com/2.2/answers/{}".format(post['post_id'])
+                req_url = GlobalVars.se_api_url_base + "answers/{}".format(post['post_id'])
                 params = {
                     'filter': GlobalVars.se_api_question_answer_post_filter,
                     'key': api_key,

--- a/chatcommands.py
+++ b/chatcommands.py
@@ -2163,7 +2163,7 @@ def allspam(msg, url):
         # Fetch posts
         request_url = "https://api.stackexchange.com/2.2/users/{}/posts".format(u_id)
         params = {
-            'filter': '!fsv5ng(IaK_MBkZYCDWuA.U2DqLwdl*YEL_',
+            'filter': GlobalVars.se_api_question_answer_post_filter,
             'key': api_key,
             'site': u_site
         }
@@ -2206,7 +2206,7 @@ def allspam(msg, url):
                 # Fetch posts
                 req_url = "https://api.stackexchange.com/2.2/answers/{}".format(post['post_id'])
                 params = {
-                    'filter': '!*Jxb9s5EOrE51WK*',
+                    'filter': GlobalVars.se_api_question_answer_post_filter,
                     'key': api_key,
                     'site': u_site
                 }

--- a/datahandling.py
+++ b/datahandling.py
@@ -20,7 +20,7 @@ from globalvars import GlobalVars
 import metasmoke
 from parsing import api_parameter_from_link, post_id_from_link
 import blacklists
-from helpers import ErrorLogs, log, log_current_exception, redact_passwords
+from helpers import ErrorLogs, log, log_current_exception, redact_passwords, get_se_api_default_params
 from tasks import Tasks
 
 last_feedbacked = None
@@ -515,12 +515,11 @@ def refresh_sites():
     page = 1
     url = GlobalVars.se_api_url_base + "sites"
     while has_more:
-        params = {
+        params = get_se_api_default_params({
             'filter': '!)Qpa1bTB_jCkeaZsqiQ8pDwI',
-            'key': 'IAkbitmze4B8KpacUfLqkw((',
             'page': page,
             'pagesize': 500
-        }
+        })
         response = requests.get(url, params=params)
 
         data = response.json()

--- a/datahandling.py
+++ b/datahandling.py
@@ -20,7 +20,8 @@ from globalvars import GlobalVars
 import metasmoke
 from parsing import api_parameter_from_link, post_id_from_link
 import blacklists
-from helpers import ErrorLogs, log, log_current_exception, redact_passwords, get_se_api_default_params
+from helpers import (ErrorLogs, log, log_current_exception, redact_passwords, get_se_api_default_params,
+                     get_se_api_url_for_route)
 from tasks import Tasks
 
 last_feedbacked = None
@@ -513,7 +514,7 @@ def fetch_lines_from_error_log(count):
 def refresh_sites():
     has_more = True
     page = 1
-    url = GlobalVars.se_api_url_base + "sites"
+    url = get_se_api_url_for_route("sites")
     while has_more:
         params = get_se_api_default_params({
             'filter': '!)Qpa1bTB_jCkeaZsqiQ8pDwI',

--- a/datahandling.py
+++ b/datahandling.py
@@ -513,7 +513,7 @@ def fetch_lines_from_error_log(count):
 def refresh_sites():
     has_more = True
     page = 1
-    url = "https://api.stackexchange.com/2.2/sites"
+    url = GlobalVars.se_api_url_base + "sites"
     while has_more:
         params = {
             'filter': '!)Qpa1bTB_jCkeaZsqiQ8pDwI',

--- a/datahandling.py
+++ b/datahandling.py
@@ -520,7 +520,7 @@ def refresh_sites():
             'page': page,
             'pagesize': 500
         })
-        response = requests.get(url, params=params)
+        response = requests.get(url, params=params, timeout=GlobalVars.default_requests_timeout)
 
         data = response.json()
         if "error_message" in data:
@@ -823,7 +823,8 @@ def fill_site_id_dict_by_id_from_site_id_dict():
 
 
 def refresh_site_id_dict():
-    message = requests.get('https://meta.stackexchange.com/topbar/site-switcher/all-pinnable-sites')
+    message = requests.get('https://meta.stackexchange.com/topbar/site-switcher/all-pinnable-sites',
+                           timeout=GlobalVars.default_requests_timeout)
     data = json.loads(message.text)
     site_ids_dict = {entry['hostname']: entry['siteid'] for entry in data}
     if len(site_ids_dict) >= SE_SITE_IDS_MINIMUM_VALID_LENGTH:

--- a/deletionwatcher.py
+++ b/deletionwatcher.py
@@ -12,7 +12,7 @@ import websocket
 from globalvars import GlobalVars
 import metasmoke
 import datahandling
-from helpers import log
+from helpers import log, get_se_api_default_params_questions_answers_posts_add_site
 from parsing import fetch_post_id_and_site_from_url, to_protocol_relative
 from tasks import Tasks
 
@@ -148,10 +148,7 @@ class DeletionWatcher:
         for site, posts in saved.items():
             ids = ";".join(post_id for post_id in posts if not DeletionWatcher._ignore((post_id, site)))
             uri = GlobalVars.se_api_url_base + "posts/{}".format(ids)
-            params = {
-                'site': site,
-                'key': 'IAkbitmze4B8KpacUfLqkw(('
-            }
+            params = get_se_api_default_params_questions_answers_posts_add_site(site)
             res = requests.get(uri, params=params)
             json = res.json()
 

--- a/deletionwatcher.py
+++ b/deletionwatcher.py
@@ -147,7 +147,7 @@ class DeletionWatcher:
 
         for site, posts in saved.items():
             ids = ";".join(post_id for post_id in posts if not DeletionWatcher._ignore((post_id, site)))
-            uri = "https://api.stackexchange.com/2.2/posts/{}".format(ids)
+            uri = GlobalVars.se_api_url_base + "posts/{}".format(ids)
             params = {
                 'site': site,
                 'key': 'IAkbitmze4B8KpacUfLqkw(('

--- a/deletionwatcher.py
+++ b/deletionwatcher.py
@@ -12,7 +12,7 @@ import websocket
 from globalvars import GlobalVars
 import metasmoke
 import datahandling
-from helpers import log, get_se_api_default_params_questions_answers_posts_add_site
+from helpers import log, get_se_api_default_params_questions_answers_posts_add_site, get_se_api_url_for_route
 from parsing import fetch_post_id_and_site_from_url, to_protocol_relative
 from tasks import Tasks
 
@@ -147,7 +147,7 @@ class DeletionWatcher:
 
         for site, posts in saved.items():
             ids = ";".join(post_id for post_id in posts if not DeletionWatcher._ignore((post_id, site)))
-            uri = GlobalVars.se_api_url_base + "posts/{}".format(ids)
+            uri = get_se_api_url_for_route("posts/{}".format(ids))
             params = get_se_api_default_params_questions_answers_posts_add_site(site)
             res = requests.get(uri, params=params, timeout=GlobalVars.default_requests_timeout)
             json = res.json()

--- a/deletionwatcher.py
+++ b/deletionwatcher.py
@@ -149,7 +149,7 @@ class DeletionWatcher:
             ids = ";".join(post_id for post_id in posts if not DeletionWatcher._ignore((post_id, site)))
             uri = GlobalVars.se_api_url_base + "posts/{}".format(ids)
             params = get_se_api_default_params_questions_answers_posts_add_site(site)
-            res = requests.get(uri, params=params)
+            res = requests.get(uri, params=params, timeout=GlobalVars.default_requests_timeout)
             json = res.json()
 
             if "items" not in json:

--- a/findspam.py
+++ b/findspam.py
@@ -1859,7 +1859,7 @@ def toxic_check(post):
         return False, False, False, ""
 
     try:
-        response = requests.post(PERSPECTIVE, json={
+        response = requests.post(PERSPECTIVE, timeout=GlobalVars.default_requests_timeout, json={
             "comment": {
                 "text": s
             },

--- a/gitmanager.py
+++ b/gitmanager.py
@@ -50,7 +50,8 @@ class GitHubManager:
         """ Perform API calls. """
         if isinstance(payload, dict):
             payload = json.dumps(payload)
-        response = requests.request(method, route, data=payload, **cls.auth_args)
+        response = requests.request(method, route, data=payload, timeout=GlobalVars.default_requests_timeout,
+                                    **cls.auth_args)
         return response
 
     @classmethod
@@ -61,14 +62,14 @@ class GitHubManager:
         if isinstance(payload, dict):
             payload = json.dumps(payload)
         response = requests.post("https://api.github.com/repos/{}/pulls".format(GlobalVars.bot_repo_slug),
-                                 data=payload, **cls.auth_args)
+                                 data=payload, timeout=GlobalVars.default_requests_timeout, **cls.auth_args)
         return response.json()
 
     @classmethod
     def comment_on_thread(cls, thread_id, body):
         url = "https://api.github.com/repos/{}/issues/{}/comments".format(GlobalVars.bot_repo_slug, thread_id)
         payload = json.dumps({'body': body})
-        response = requests.post(url, data=payload, **cls.auth_args)
+        response = requests.post(url, data=payload, timeout=GlobalVars.default_requests_timeout, **cls.auth_args)
         return response.json()
 
     @classmethod
@@ -339,7 +340,8 @@ class GitManager:
 
     @classmethod
     def merge_pull_request(cls, pr_id, comment=""):
-        response = requests.get("https://api.github.com/repos/{}/pulls/{}".format(GlobalVars.bot_repo_slug, pr_id))
+        response = requests.get("https://api.github.com/repos/{}/pulls/{}".format(GlobalVars.bot_repo_slug, pr_id),
+                                timeout=GlobalVars.default_requests_timeout)
         if not response:
             raise ConnectionError("Cannot connect to GitHub API")
         pr_info = response.json()
@@ -379,7 +381,8 @@ class GitManager:
 
     @classmethod
     def reject_pull_request(cls, pr_id, comment=""):
-        response = requests.get("https://api.github.com/repos/{}/pulls/{}".format(GlobalVars.bot_repo_slug, pr_id))
+        response = requests.get("https://api.github.com/repos/{}/pulls/{}".format(GlobalVars.bot_repo_slug, pr_id),
+                                timeout=GlobalVars.default_requests_timeout)
         if not response:
             raise ConnectionError("Cannot connect to GitHub API")
         pr_info = response.json()

--- a/globalvars.py
+++ b/globalvars.py
@@ -90,6 +90,7 @@ class GlobalVars:
     recently_scanned_posts_lock = threading.Lock()
     recently_scanned_posts_retention_time = 24 * 60 * 60  # 24 hours
     api_backoff_time = 0
+    default_requests_timeout = 60
     deletion_watcher = None
 
     not_privileged_warning = \

--- a/globalvars.py
+++ b/globalvars.py
@@ -169,6 +169,7 @@ class GlobalVars:
     # with an answer.
     se_api_question_answer_post_filter = \
         "!7bj2kejr9-Tmw-wWkT)JQ1T3qUUB9KLZAB0TT-dWOwUFyqxVII1y.BH6Ji(.pwih1odhF-wr29R*Jbti"
+    se_api_url_base = "https://api.stackexchange.com/2.2/"
 
     class PostScanStat:
         """ Tracking post scanning data """

--- a/globalvars.py
+++ b/globalvars.py
@@ -155,6 +155,20 @@ class GlobalVars:
 
     api_request_lock = threading.Lock()  # Get this lock before making API requests
     apiquota_rw_lock = threading.Lock()  # Get this lock before reading/writing apiquota
+    # The following is a filter for the SE API to use on /questions, /answers, and /posts routes, which
+    # returns consistent data for all three types of requests, as far as that is possible.
+    # However, it should be noted that some of the fields which are available in the /questions and /answers
+    # routes are not available when the same post is obtained through the /posts routes.
+    # Our primary scanning is done based on responses to the /questions route. In general, data should be
+    # obtained from that route when possible. Unfortunately, there isn't a good way to go from just a post_id
+    # to both knowing that it's a question or answer and having the posts full data.
+    # [Note: URL decoding can't actually be relied upon to determine if a post is a question or answer, because the
+    # /a and /q main/meta site routes take a post ID and return whichever of question or answer it is.]
+    # The best case is that we know or guess that the post is either a question or answer and we request it
+    # accurately from the correct route. However, for scanning posts, we also want the question data associated
+    # with an answer.
+    se_api_question_answer_post_filter = \
+        "!7bj2kejr9-Tmw-wWkT)JQ1T3qUUB9KLZAB0TT-dWOwUFyqxVII1y.BH6Ji(.pwih1odhF-wr29R*Jbti"
 
     class PostScanStat:
         """ Tracking post scanning data """

--- a/globalvars.py
+++ b/globalvars.py
@@ -169,7 +169,15 @@ class GlobalVars:
     # with an answer.
     se_api_question_answer_post_filter = \
         "!7bj2kejr9-Tmw-wWkT)JQ1T3qUUB9KLZAB0TT-dWOwUFyqxVII1y.BH6Ji(.pwih1odhF-wr29R*Jbti"
-    se_api_url_base = "https://api.stackexchange.com/2.2/"
+    se_api_url_base = "https://api.stackexchange.com/2.4/"
+    se_api_default_params = {
+        'key': 'IAkbitmze4B8KpacUfLqkw((',
+    }
+    se_api_default_params_questions_answers_posts = se_api_default_params.copy()
+    se_api_default_params_questions_answers_posts.update({
+        'filter': se_api_question_answer_post_filter,
+        'state': 'PublishedAndStagingGround',
+    })
 
     class PostScanStat:
         """ Tracking post scanning data """

--- a/helpers.py
+++ b/helpers.py
@@ -484,3 +484,7 @@ def get_se_api_default_params_questions_answers_posts_add_site(site):
     all_params = GlobalVars.se_api_default_params_questions_answers_posts.copy()
     all_params.update({'site': site})
     return all_params
+
+
+def get_se_api_url_for_route(route):
+    return GlobalVars.se_api_url_base + route

--- a/helpers.py
+++ b/helpers.py
@@ -466,3 +466,21 @@ def strip_pre_and_code_elements(text, leave_note=False):
 
 def pluralize(value, base, plural_end, single_end='', zero_is_plural=True):
     return base + plural_end if value > 1 or (zero_is_plural and value == 0) else base + single_end
+
+
+def get_se_api_default_params(params):
+    all_params = GlobalVars.se_api_default_params.copy()
+    all_params.update(params)
+    return all_params
+
+
+def get_se_api_default_params_questions_answers_posts(params):
+    all_params = GlobalVars.se_api_default_params_questions_answers_posts.copy()
+    all_params.update(params)
+    return all_params
+
+
+def get_se_api_default_params_questions_answers_posts_add_site(site):
+    all_params = GlobalVars.se_api_default_params_questions_answers_posts.copy()
+    all_params.update({'site': site})
+    return all_params


### PR DESCRIPTION
This PR does:
* Moves our use of the SE API to version 2.4 in order to support the Staging Ground on SO
* Adds 60 second timeouts to all `requests` accesses
   * The exact timeout used may need to be adjusted based on any issues we see in use. Splitting between what's used for the SE API and each of the other things for which we make requests (e.g. SE API, Perspective API, GitHub API) may be desirable, but is not implemented at this time.
   * Not having a timeout on all of our accesses may be what have caused some of the hangs we've seen over time, particularly for chat commands. ChatExchange already had a timeout for all accesses, but what we were doing in response to commands didn't in various cases.
* Use `with` semantics for `GlobalVars.api_request_lock`   
   There were cases where the lock would not be released.
* DRY:
   * Use a single `filter` for all SE API requests for questions, answers, and posts.
   * Move default SE API parameters into `GlobalVars` and make handling them more consistent.
   * Move SE API URL generation into a helper function