### PR TITLE
Add pytest-timeout and set 300 second per-test timeout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,4 +55,4 @@ jobs:
           name: Pytest
           # Use 5 processes is intended to allow one DNS lookup bound long running test run
           # in parallel with most of the other tests which generally consume more CPU.
-          command: python3 -W default::Warning -m pytest -n 5 --dist loadgroup test
+          command: python3 -W default::Warning -m pytest -n 5 --dist loadgroup --timeout=300 test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,4 +58,5 @@ jobs:
           --cov=helpers \
           -n 3 \
           --dist loadgroup \
+          --timeout=300 \
           test

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ pep8-naming==0.7.0
 phonenumbers>=8.8.11
 psutil>=5.9.0
 pytest-xdist>=2.5.0
+pytest-timeout>=2.1.0
 pytest>=4.1.0
 PyYAML>=3.12
 regex>=2020.10.23


### PR DESCRIPTION
This PR adds pytest-timeout and sets a per-test timeout of 300 seconds. This will have the following effects:
1. We won't have a, potentially, hours-long span of time where there are multiple CI tests running, which will all eventually fail, but which aren't reported into Charcoal HQ until the first one actually fails. In other words, we'll see that the CI tests failed much sooner.
2. We won't have as good information as to what exactly failed, other than that a test exceeded the timeout. What and how much information we get is going to depend on the test (most likely one of the `bisect` tests that are intended to identify poorly performing watches/blacklists) and the exact way that it failed. This will make finding the exact problem a bit more difficult, but the problem is highly likely to be the most recent change.

#### What's the difference in output?
An example of the difference in output from the CI tests is:
1. **Without timeout**: The tests for the commit adding the problematic regex earlier today, which took ~ 50 minutes to complete, were: [GitHub Actions, Python 3.8](https://github.com/Charcoal-SE/SmokeDetector/actions/runs/4593084644/jobs/8110691772), [GitHub Actions, Python 3.11](https://github.com/Charcoal-SE/SmokeDetector/actions/runs/4593084644/jobs/8110691772), and [CircleCI](https://circleci.com/gh/Charcoal-SE/SmokeDetector/126083)
2. **With timeout**: The tests under the same conditions, but with a per-test timeout of 300 seconds: [GitHub Actions, Python 3.8](https://github.com/makyen/Charcoal-SE-SmokeDetector/actions/runs/4599971772/jobs/8126017748), [GitHub Actions, Python 3.11](https://github.com/makyen/Charcoal-SE-SmokeDetector/actions/runs/4599971772/jobs/8126017889), and [CircleCI](https://github.com/makyen/Charcoal-SE-SmokeDetector/runs/12485948028)
3. **Non-failing tests with pytest-timeout enabled**: [GitHub Actions, Python 3.8](https://github.com/makyen/Charcoal-SE-SmokeDetector/actions/runs/4599969373/jobs/8126012678), [GitHub Actions, Python 3.11](https://github.com/makyen/Charcoal-SE-SmokeDetector/actions/runs/4599969373/jobs/8126012841), and [CircleCI](https://github.com/makyen/Charcoal-SE-SmokeDetector/runs/12485938866)