### PR TITLE
blogspot regex updates for blacklisted_websites.txt along with corresponding removals from watched_keywords.txt

### DIFF
--- a/blacklisted_websites.txt
+++ b/blacklisted_websites.txt
@@ -11,7 +11,7 @@ predictway\.com
 up24\.pro
 funmac
 lovebiscuits
-z-data\.blogspot\.com
+z-data\.blogspot
 pub4sure\.com
 freeprnow\.com
 Eglobalfitness
@@ -661,7 +661,7 @@ ideaflix\.com
 usadrugguide\.com
 proofy\.io
 torrentsvpn\.com
-techexperiment\.blogspot\.(?:com|sg)
+techexperiment\.blogspot
 dutraeconomicus\.com
 acewriters\.org
 backupbird\.com
@@ -671,14 +671,14 @@ convertmydoc\.com
 downloadapkinstaller\.com
 contactforhelp\.com
 filesupdated\.com
-fpga4student\.blogspot\.com
+fpga4student\.blogspot
 sql-email\.com
 t90xplodecanada\.us
 moviemaniaonline\.com
 SELLCVV\.SHOP
 biohunter\.in
 bizpro9\.com
-selenium-venkat\.blogspot\.(?:com|sg|in)
+selenium-venkat\.blogspot
 injectfollowers\.com
 chandigarhdentist\.com
 xtrfact\.com
@@ -782,7 +782,7 @@ healthyclubpro\.com
 designerworldonline\.com
 gronkaffedenmark\.com
 donewithjob\.com
-gangadharws\.blogspot\.in
+gangadharws\.blogspot
 advids\.co
 gaanamp3club\.com
 menintalk\.com
@@ -1068,7 +1068,7 @@ nutritionextract\.com
 supplementfector\.org
 teknixhealthcare\.com
 bodyprohealth\.com
-inforahasiajudionline\.blogspot\.com
+inforahasiajudionline\.blogspot
 smlcodes\.com
 dissertationclub\.co\.uk
 t-rexmuscleadvice\.com
@@ -1113,7 +1113,7 @@ agilechamps\.com
 digitalelectronicservice\.com
 on2it\.se
 djbaap\.com
-onlin-photoshop\.blogspot\.co
+onlin-photoshop\.blogspot
 raitotec\.com
 honsungtech\.com
 bellasvish\.com
@@ -1214,7 +1214,7 @@ healthbuzzer\.com
 biotestosteronexrtry\.com
 tophealthbuy\.com
 ibwpro\.com
-omindiatech\.blogspot\.in
+omindiatech\.blogspot
 care2world\.com
 nidmindia\.com
 getmysupplement\.com
@@ -1272,7 +1272,7 @@ freesupplementrial\.com
 trysupercbdreview\.com
 supplementssafe\.com
 bestvpnprovider\.com
-zincreward\.blogspot\.com
+zincreward\.blogspot
 fitnesseducations\.com
 needsupplementhelp\.com
 scamcare\.com
@@ -1334,7 +1334,7 @@ shibo333\.com
 puremusclestrength\.com
 sildenafilguide\.com
 hacknohumanverification\.org
-hahmadsolutions\.blogspot\.com
+hahmadsolutions\.blogspot
 cleanserenewdenmark\.com
 waltessays\.com
 slimatrexnorway\.com
@@ -1418,7 +1418,7 @@ mymybear\.com
 drozien\.com
 getsupplementhelp\.com
 beautysk\.com
-apkroidstore\.blogspot\.com
+apkroidstore\.blogspot
 wellness350\.com
 try-nitricstorm\.com
 ifirmationantiagingcream\.com
@@ -1553,7 +1553,7 @@ MusConv\.com
 videoder\.zone
 diving-solutions\.com
 studio\.stupeflix\.com
-everything4comp\.blogspot\.com
+everything4comp\.blogspot
 testoultra\.in
 webtrackker\.com
 garciniasecretdietabout\.com
@@ -1827,7 +1827,7 @@ horlaxendeutschland\.de
 reverseasia\.com
 cognegicsystems\.com
 supplement4fitness\.com
-reviewcrazybulkus\.blogspot\.in
+reviewcrazybulkus\.blogspot
 jstbusiness\.com
 aolsupports\.org
 leemi\.ca
@@ -1870,7 +1870,7 @@ francesupplement\.fr
 nettv4u\.com
 healthfulnutritions\.com
 nutritioncurcumin\.com
-onlineweblogsite\.blogspot\.in
+onlineweblogsite\.blogspot
 endovexstore\.com
 deathbymodernmedicine\.com
 testosteronboosters\.com
@@ -2001,7 +2001,7 @@ agrud\.com
 seodigitalmarketing\.in
 bluesupplement\.org
 freebiebitcoin\.com
-dxncodestrikereview\.blogspot\.com
+dxncodestrikereview\.blogspot
 chromebooksupportnumber\.com
 compaqsupportnumber\.com
 dellcustomersupportnumbers\.com
@@ -2848,7 +2848,7 @@ fairsupplement\.com
 welnesscare\.com
 intellectslinkup\.com
 ketodietwalmart\.com
-doublebitcoin24hours\.blogspot\.com
+doublebitcoin24hours\.blogspot
 medhush\.com
 digitalkrishna\.in
 sachiyasteel\.com
@@ -3066,7 +3066,7 @@ today22\.com
 careerdose\.com
 e[\W_]*+a[\W_]*+r[\W_]*+n[\W_]*+7[\W_]*+4[\W_]*+c[\W_]*+o[\W_]*+m(?#obfuscated earn74.com)
 \bhackmarvel4\b(?#abuse the website blacklist to get more detections/weight on a persistent spammer)
-gisinfomedia\.blogspot\.com
+gisinfomedia\.blogspot
 pilspedia\.com
 buyonlinecare\.com
 2basetechnologies\.com
@@ -3136,7 +3136,7 @@ technobrigadeinfotech\.com
 autobodycu\.org
 pillsenergy\.com
 fitnesshealthpills\.com
-nutrihut\.blogspot\.com
+nutrihut\.blogspot
 biznutrition\.com
 weightlosscharitychallenge\.com
 trendebook\.com
@@ -3558,7 +3558,7 @@ w-ww-office\.com
 slimketoboost\.com
 fast2earn\.com
 healthyaustralia\.com\.au
-educationbygyan\.blogspot\.com
+educationbygyan\.blogspot
 nexgenitsolutions\.in
 buy24x7online\.com
 javaprintln\.com
@@ -3665,7 +3665,7 @@ phukiensamsung\.com
 sigsync\.com
 essayservicescanner\.com
 bilimyurt\.com
-ourunbiasedreview\.blogspot\.com
+ourunbiasedreview\.blogspot
 advisoroffer\.com
 offer4cart\.com
 myfitnessclubb\.com
@@ -3714,7 +3714,7 @@ gotoassignmenthelp\.com
 sprinkledata\.com
 customboxesworld\.co\.uk
 nox\.tips
-biramjih\.blogspot\.com
+biramjih\.blogspot
 onmogul\.com
 natureswater\.ie
 digit-it\.com
@@ -4059,7 +4059,7 @@ transparencymarketresearch\.com
 login2explore\.com
 apl\.ninja
 thetechtrackers\.com
-tukangkuli707\.blogspot\.com
+tukangkuli707\.blogspot
 signalscv\.com
 hkrtrainings\.com
 ketoavis[\W_]*+com

--- a/blacklisted_websites.txt
+++ b/blacklisted_websites.txt
@@ -1553,7 +1553,6 @@ MusConv\.com
 videoder\.zone
 diving-solutions\.com
 studio\.stupeflix\.com
-everything4comp\.blogspot
 testoultra\.in
 webtrackker\.com
 garciniasecretdietabout\.com
@@ -5304,5 +5303,3 @@ w3beginners\.com
 dibiz\.com
 crackmix\.com
 cemca\.org\.in
-jemi\.so
-codelearno\.com

--- a/watched_keywords.txt
+++ b/watched_keywords.txt
@@ -12726,7 +12726,6 @@
 1570776475	Makyen	lonnuckerow
 1570776484	Makyen	smsindiahub\.in
 1570776508	Makyen	wisetechhack(?:@gmail\.com)?
-1570776519	Makyen	nutrihut\.blogspot
 1570776529	Makyen	/@kyarascott
 1570776549	Makyen	kaspersky-login\.me
 1570776558	Makyen	freshly[\W_]*+bloom[\W_]*+keto
@@ -19574,7 +19573,6 @@
 1590075242	user12986714	dwnlds\.co
 1590075526	Xnero	deveondi\.com
 1590090453	Makyen	uniccsshop\.io
-1590118391	Makyen	educationbygyan\.blogspot
 1590118419	Makyen	(?-i:s9uPt\.jpg)
 1590123267	NobodyNada - Reinstate Monica	(link)?domino168(\.com)?
 1590126852	tripleee	china-rigid\.com
@@ -23497,7 +23495,6 @@
 1603542916	Mast	tmg-clothing\.com
 1603543083	Mast	wiki87\.com
 1603550572	Glorfindel	windowcrack\.com
-1603553622	Makyen	biramjih\.blogspot
 1603555085	Spevacus	jobs87\.com
 1603555106	Spevacus	movies-us\.xyz
 1603566039	NobodyNada	CryptoDredge

--- a/watched_keywords.txt
+++ b/watched_keywords.txt
@@ -49887,3 +49887,4 @@
 1681823365	Jeff Schaller	4khdmovies\.club
 1681823448	tripleee	deltron[\W_]*+technologies(?!\.com(?<=deltrontechnologies\.com))
 1681825638	Jeff Schaller	yocofee\.com
+1681826463	Machavity	@goodbisht4755


### PR DESCRIPTION
generalized most of the blogspot regexes in blacklisted_websites.txt; this resulted in some duplication with older entries in watched_keywords.txt, so this PR removes those older entries.

I don't know why the preview here doesn't show `everything4comp\.blogspot` remaining in blacklisted_websites; maybe because it was previously duplicated with my regex change?