### PR TITLE
Add a Staging Ground message indicator to reports on Staging Ground posts

### DIFF
--- a/spamhandling.py
+++ b/spamhandling.py
@@ -211,7 +211,7 @@ def build_message(post, reasons):
         username = post.user_name.strip()
         escaped_username = escape_format(parsing.escape_markdown(username))
         user = "[{}\u202D]({})".format(escaped_username, poster_url)
-        
+
     # If the post URL is a staging ground link, indicate that; ensure that the post is on Stack Overflow
     if shortened_site == "stackoverflow.com" and "staging-ground" in post.post_url:
         staging = "(Staging Ground) "

--- a/spamhandling.py
+++ b/spamhandling.py
@@ -169,7 +169,8 @@ def handle_spam(post, reasons, why):
 def build_message(post, reasons):
     # This is the main report format. Username and user link are deliberately not separated as with title and post
     # link, because we may want to use "by a deleted user" rather than a username+link.
-    message_format = "{prefix_ms} {{reasons}} ({reason_weight}): [{title}\u202D]({post_url}) by {user} on `{site}`"
+    message_format = "{prefix_ms} {{reasons}} ({reason_weight}): [{title}\u202D]({post_url}) {staging}\
+                      by {user} on `{site}`"
 
     # Post URL, user URL, and site details are all easy - just data from the post object, transformed a bit
     # via datahandling.
@@ -210,11 +211,17 @@ def build_message(post, reasons):
         username = post.user_name.strip()
         escaped_username = escape_format(parsing.escape_markdown(username))
         user = "[{}\u202D]({})".format(escaped_username, poster_url)
+        
+    # If the post URL is a staging ground link, indicate that; ensure that the post is on Stack Overflow
+    if shortened_site == "stackoverflow.com" and "staging-ground" in post.post_url:
+        staging = "(Staging Ground) "
+    else:
+        staging = ""
 
     # Build the main body of the message. The next step is to insert the reason list while keeping the message
     # under 500 characters long.
     message = message_format.format(prefix_ms=prefix, reason_weight=reason_weight, title=sanitized_title,
-                                    post_url=post_url, user=user, site=shortened_site)
+                                    post_url=post_url, staging=staging, user=user, site=shortened_site)
 
     for reason_count in range(5, 0, -1):
         reason = ", ".join(reasons[:reason_count])


### PR DESCRIPTION
As mentioned in #7649, it would be helpful to indicate that if a post might be hidden due to being in the Staging Ground. This pull requests implements one of the suggestions of displaying that information in the message report. Sample:

> [ SmokeDetector | MS ] No whitespace in title (71): SomeQuestion‭ (Staging Ground) by some-user on stackoverflow.com

Note: This change might potentially break certain userscripts on those reports?