### PR TITLE
findspam.py: obfuscated_words: prevent FP on contraction of "who are"

### DIFF
--- a/findspam.py
+++ b/findspam.py
@@ -2722,6 +2722,9 @@ def obfuscated_word(s, site):
         # prevent FP on simple English possessive
         if word[-2:] == "'s" and word[:-2] + "s" in obfuscation_keywords:
             continue
+        # prevent FP on contraction of "who are"
+        if word == "who're":
+            continue
         # prevent FP on stuff like 'I have this "number": 1111'
         word = word.strip(punctuation).lower()
         translated = word.translate(translation_1337)


### PR DESCRIPTION
https://metasmoke.erwaysoftware.com/search?utf8=%E2%9C%93&why_is_regex=1&why=Obfuscated+word+in+%5Cw%2B+-+%22who%27re%22 is massively FP, and the hits where it's not FP are coincidental, and usually also trigger other rules