### PR TITLE
Add a command to allow rejecting a pull request as a duplicate

### DIFF
--- a/chatcommands.py
+++ b/chatcommands.py
@@ -699,7 +699,7 @@ def approve(msg, pr_id):
         raise CmdException(str(e))
 
 
-@command(str, privileged=True, whole_msg=True, give_name=True, aliases=["close", "reject-force", "close-force"])
+@command(str, privileged=True, whole_msg=True, give_name=True, aliases=["close", "reject-force", "close-force", "reject-duplicate"])
 def reject(msg, args, alias_used="reject"):
     argsraw = args.split(' "', 1)
     try:
@@ -716,6 +716,7 @@ def reject(msg, args, alias_used="reject"):
     except IndexError:
         reason = ''
     force = alias_used.split("-")[-1] == "force"
+    duplicate = alias_used.split("-")[-1] == "duplicate"
     code_permissions = is_code_privileged(msg._client.host, msg.owner.id)
     if not code_permissions:
         raise CmdException("You need blacklist manager privileges to reject pull requests")
@@ -736,7 +737,7 @@ def reject(msg, args, alias_used="reject"):
     reject_reason_image_text = "\n\n![Rejected with SmokeyReject]({})".format(rejected_image)
     comment = rejected_by_text + reject_reason_text + reject_reason_image_text
     try:
-        message = GitManager.reject_pull_request(pr_id, comment)
+        message = GitManager.reject_pull_request(pr_id, comment, duplicate)
         return message
     except Exception as e:
         raise CmdException(str(e))


### PR DESCRIPTION
Often, pull requests have to be closed as duplicates (such as if a privileged user watches or blacklists a keyword that has a pending PR by a non-privileged user, so that PR has to be procedurally rejected). Per policy, these are labeled with the "type: duplicate" label so that users searching through one's PR history can tell between PRs that are procedurally rejected for this reason and those that are *actually* rejected.

This code change adds the `!!/reject-duplicate` command, so that users who procedurally reject duplicate PRs don't have to go to the issue after the fact and apply the label manually: it can be done with one command.