### PR TITLE
A collection of typo fixes in comments and ending periods in chat replies

### DIFF
--- a/bodyfetcher.py
+++ b/bodyfetcher.py
@@ -68,7 +68,7 @@ class BodyFetcher:
     ]
 
     # special_cases are the minimum number of posts, for each of the specified sites, which
-    # need to be in the queue prior to feching posts.
+    # need to be in the queue prior to fetching posts.
     # The number of questions we fetch each day per site is the total of
     #   new questions + new answers + edits.
     # Stack Overflow is handled specially. It's know that some SO edits/new posts don't

--- a/bodyfetcher.py
+++ b/bodyfetcher.py
@@ -419,7 +419,7 @@ class BodyFetcher:
                         return (site, new_posts)
                     else:
                         # We don't actually have any posts to process, so need to give up the site processing lock
-                        # we alreadying obtained.
+                        # we already obtained.
                         self.release_site_processing_lock(site_to_handle)
                         site_to_handle = None
                 # There's no site in the queue which has met the applicable threshold.

--- a/bodyfetcher.py
+++ b/bodyfetcher.py
@@ -164,7 +164,7 @@ class BodyFetcher:
                     self.queue[hostname] = {}
 
                 # Something about how the queue is being filled is storing Post IDs in a list.
-                # So, if we get here we need to make sure that the correct types are paseed.
+                # So, if we get here we need to make sure that the correct types are passed.
                 #
                 # If the item in self.queue[hostname] is a dict, do nothing.
                 # If the item in self.queue[hostname] is not a dict but is a list or a tuple, then convert to dict and

--- a/chatcommands.py
+++ b/chatcommands.py
@@ -2343,7 +2343,7 @@ def report_posts(urls, reported_by_owner, reported_in=None, blacklist_by=None, o
         # be the why as the second. This converts that output back into what they would be
         # if the post wasn't previously reported for the cases where we want to process it
         # as such.
-        # Expand real scan results from dirty returm value when not "!!/scan"
+        # Expand real scan results from dirty return value when not "!!/scan"
         # Presence of "scan_why" indicates the post IS spam but ignored
         if (operation != "scan" or is_forced) and (not scan_spam) and scan_why:
             scan_spam = True

--- a/chatcommands.py
+++ b/chatcommands.py
@@ -2520,7 +2520,7 @@ def false(feedback, msg, comment, alias_used="false"):
     result = "Registered " + post_type + " as false positive"
     if user is None:
         if feedback_type.blacklist:
-            # The command was to bloacklist the user, but we're unable to determine the user.
+            # The command was to blacklist the user, but we're unable to determine the user.
             raise CmdException(result + ', but could not get user from URL: `{0!r}`'.format(owner_url))
     else:
         if feedback_type.blacklist:

--- a/chatcommunicate.py
+++ b/chatcommunicate.py
@@ -692,7 +692,7 @@ def dispatch_reply_command(message_replied_to, reply, full_cmd, comment=True):
                 content_without_at_and_expected_links = regex.sub(sub_regex_text, '', content)
                 if len(content_without_at_and_expected_links) < 100:
                     # This is a "still alive" message which includes at least a link to one of the domains
-                    # and doesn't have much text other than the reply, and contains at lesat one  MS and/or SE domain.
+                    # and doesn't have much text other than the reply, and contains at least one MS and/or SE domain.
                     # So, we don't want to forward it as a comment to MS.
                     return
             Tasks.do(metasmoke.Metasmoke.post_auto_comment, full_cmd + get_attribution_for_message(reply),

--- a/findspam.py
+++ b/findspam.py
@@ -2364,7 +2364,7 @@ create_rule("bad keyword in {}",
             rule_id="bad keywords: movies, free, skin care, training, not bodies")
 
 # Potentially bad keywords in titles and usernames, all sites
-# Not suffient %TP for blacklist: 2020-06-27 01:00UTC: ~77.59%TP
+# Not sufficient %TP for blacklist: 2020-06-27 01:00UTC: ~77.59%TP
 # Title Results: 398/TP:312/FP:81/NAA:3
 # Username Results: 17/TP:10/FP:8/NAA:0
 create_rule("potentially bad keyword in {}",

--- a/gitmanager.py
+++ b/gitmanager.py
@@ -152,7 +152,7 @@ class GitManager:
 
             exists, line = blacklister.exists(item_to_blacklist)
             if exists:
-                return (False, 'Already {}ed on line {} of {}'.format(op, line, blacklist_file_name))
+                return (False, 'Already {}ed on line {} of {}.'.format(op, line, blacklist_file_name))
 
             watch_removed = False
             if blacklist_type not in {Blacklist.WATCHED_KEYWORDS, Blacklist.WATCHED_NUMBERS}:
@@ -193,7 +193,7 @@ class GitManager:
 
                 if ((GlobalVars.github_username is None or GlobalVars.github_password is None)
                         and (GlobalVars.github_access_token is None)):
-                    return (False, "Tell someone to set a GH token")
+                    return (False, "Tell someone to set a GH token.")
 
                 payload = {"title": "{0}: {1} {2}".format(username, op.title(), item),
                            "body": "[{0}]({1}) requests the {2} of the {3} `{4}`. See the MS search [here]"
@@ -259,9 +259,9 @@ class GitManager:
             cls.gitmanager_lock.release()
 
         if op == 'blacklist':
-            return (True, "Blacklisted `{0}`".format(item))
+            return (True, "Blacklisted `{0}`.".format(item))
         elif op == 'watch':
-            return (True, "Added `{0}` to watchlist".format(item))
+            return (True, "Added `{0}` to watchlist.".format(item))
 
     @classmethod
     def remove_from_blacklist(cls, item, username, blacklist_type="", code_privileged=False, metasmoke_down=False):

--- a/helpers.py
+++ b/helpers.py
@@ -63,7 +63,7 @@ class ErrorLogs:
             db.commit()
         except (sqlite3.OperationalError):
             # In CI testing, it's possible for the table to be created in a different thread between when
-            # we first test for the table's existanceand when we try to create the table.
+            # we first test for the table's existance and when we try to create the table.
             if db.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='error_logs'").fetchone() is None:
                 # Table 'error_logs' still doesn't exist
                 raise

--- a/helpers.py
+++ b/helpers.py
@@ -63,7 +63,7 @@ class ErrorLogs:
             db.commit()
         except (sqlite3.OperationalError):
             # In CI testing, it's possible for the table to be created in a different thread between when
-            # we first test for the table's existance and when we try to create the table.
+            # we first test for the table's existence and when we try to create the table.
             if db.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='error_logs'").fetchone() is None:
                 # Table 'error_logs' still doesn't exist
                 raise

--- a/phone_numbers.py
+++ b/phone_numbers.py
@@ -288,7 +288,7 @@ def get_deobfuscated_candidates(text):
 # North American phone numbers with fairly strict formatting
 # The goal here is to be sure about identification, even if that leaves ones which are not identified.
 # Without a 1. It must have a separator between the 334 groupings, like \d{3}\D\d{3}\D\d{4}, but with more
-# than just a single \D permited. The start can be our normal mix.
+# than just a single \D permitted. The start can be our normal mix.
 NA_NUMBER_CENTRAL_OFFICE_AND_LINE_REGEX = r'(?<=\D)[2-9]\d{2}(?:[\W_]*+|\D(?=\d))(?<=\D)\d{4}$'
 NA_NUMBER_CENTRAL_OFFICE_AND_LINE_LOOSE = r'[2-9]\d{2}(?:[\W_]*+|\D(?=\d))\d{4}$'
 NA_NUMBER_WITHOUT_ONE_REGEX_START = r'^(?:[' + VALID_NON_DIGIT_START_CHARACTERS + \
@@ -298,7 +298,7 @@ NA_NUMBER_WITHOUT_ONE_REGEX_START = r'^(?:[' + VALID_NON_DIGIT_START_CHARACTERS 
 NA_NUMBER_WITHOUT_ONE_REGEX = NA_NUMBER_WITHOUT_ONE_REGEX_START + NA_NUMBER_CENTRAL_OFFICE_AND_LINE_REGEX
 NA_NUMBER_WITHOUT_ONE_LOOSE = NA_NUMBER_WITHOUT_ONE_REGEX_START + NA_NUMBER_CENTRAL_OFFICE_AND_LINE_LOOSE
 # With a 1. It must have a separator between the 334 groupings, like 1\d{3}\D\d{3}\D\d{4}, but with more
-# than just a single \D permited and a separator is permitted after the 1. The start can be our normal mix.
+# than just a single \D permitted and a separator is permitted after the 1. The start can be our normal mix.
 NA_NUMBER_WITH_ONE_REGEX_START = r'^(?:[' + VALID_NON_DIGIT_START_CHARACTERS + \
                                  r']{1,2}1|1(?<=[^\d' + VALID_NON_DIGIT_START_CHARACTERS + \
                                  r']1|^1))(?:[\W_]*+|\D(?=\d))' + \

--- a/phone_numbers.py
+++ b/phone_numbers.py
@@ -11,7 +11,7 @@ from helpers import get_only_digits, remove_end_regex_comments
 #   we use multiple regular expressions, with each specifying an explicit length within the range in which we're
 #   interested and then combine the results.
 #   In order to make it more efficient, we combine those into a single regular expression using lookaheads and
-#   capture groups, which will put all of the different possibilites into capture groups, along with empty strings
+#   capture groups, which will put all of the different possibilities into capture groups, along with empty strings
 #   for each length which didn't match.
 # The use of separate Unicode and ASCII flagged versions of the regexes is also because they can result in different
 #   start and end points for the numbers. We continue to keep that separation for the NUMBER_REGEX,


### PR DESCRIPTION
This started out when I saw https://chat.stackexchange.com/transcript/11540?m=65513403#65513403 with the wording "Added MZ80T1 to watchlist However, the blacklists..." and so I wanted to add the missing period to that reply. That turned into scanning for a couple other missing periods, and then I ran the comments through `aspell` and piled those in as well.