### PR TITLE
make the split more forgiving in the "report" chat command

### DIFF
--- a/chatcommands.py
+++ b/chatcommands.py
@@ -2078,7 +2078,7 @@ def report(msg, args, alias_used="report"):
     alias_used = alias_used or "report"
 
     argsraw = args.split(' "', 1)
-    urls = argsraw[0].split(' ')
+    urls = argsraw[0].split(sep=None)
 
     message_url = "https://chat.{0}/transcript/{1}?m={2}".format(msg._client.host, msg.room.id, msg.id)
 


### PR DESCRIPTION
In situations where multiple spaces exist after the URL(s) and before the custom reason, the first element of "argsraw" might have trailing space(s). This change uses string.split()'s behavior with sep=None to regard runs of consecutive whitespace as a single separator (https://docs.python.org/3.3/library/stdtypes.html#str.split). This change also allows for multiple spaces between multiple URLs.

I tested manually with this driver code:
```
#!/usr/bin/python3

def original(args):
  argsraw = args.split(' "', 1)
  urls = argsraw[0].split(' ')
  print("argsraw elements:")
  for a in argsraw:
    print("\t->"+a+"<-")
  print("urls elements:")
  for a in urls:
    print("\t->"+a+"<-")

def jeff(args):
  argsraw = args.split(' "', 1)
  urls = argsraw[0].split(sep=None)
  print("argsraw elements:")
  for a in argsraw:
    print("\t->"+a+"<-")
  print("urls elements:")
  for a in urls:
    print("\t->"+a+"<-")

input1 = r'https://stackoverflow.com/a/78350222/  "Contents of ... etc"'
input2 = r'https://stackoverflow.com/a/78350223/ https://stackoverflow.com/a/78350224/  https://stackoverflow.com/a/78350225/    https://stackoverflow.com/a/78350226/      https://stackoverflow.com/a/78350227/  "Contents of ... etc"'

print("input1:", input1)
jeff(input1)
print("\n")

print("input2:", input2)
jeff(input2)
```

The original output was:
```
input1: https://stackoverflow.com/a/78350222/  "Contents of ... etc"
argsraw elements:
        ->https://stackoverflow.com/a/78350222/ <-
        ->Contents of ... etc"<-
urls elements:
        ->https://stackoverflow.com/a/78350222/<-
        -><-


input2: https://stackoverflow.com/a/78350223/ https://stackoverflow.com/a/78350224/  https://stackoverflow.com/a/78350225/    https://stackoverflow.com/a/78350226/      https://stackoverflow.com/a/78350227/  "Contents of ... etc"
argsraw elements:
        ->https://stackoverflow.com/a/78350223/ https://stackoverflow.com/a/78350224/  https://stackoverflow.com/a/78350225/    https://stackoverflow.com/a/78350226/      https://stackoverflow.com/a/78350227/ <-
        ->Contents of ... etc"<-
urls elements:
        ->https://stackoverflow.com/a/78350223/<-
        ->https://stackoverflow.com/a/78350224/<-
        -><-
        ->https://stackoverflow.com/a/78350225/<-
        -><-
        -><-
        -><-
        ->https://stackoverflow.com/a/78350226/<-
        -><-
        -><-
        -><-
        -><-
        -><-
        ->https://stackoverflow.com/a/78350227/<-
        -><-
```

The output from this PR is:
```
input1: https://stackoverflow.com/a/78350222/  "Contents of ... etc"
argsraw elements:
        ->https://stackoverflow.com/a/78350222/ <-
        ->Contents of ... etc"<-
urls elements:
        ->https://stackoverflow.com/a/78350222/<-


input2: https://stackoverflow.com/a/78350223/ https://stackoverflow.com/a/78350224/  https://stackoverflow.com/a/78350225/    https://stackoverflow.com/a/78350226/      https://stackoverflow.com/a/78350227/  "Contents of ... etc"
argsraw elements:
        ->https://stackoverflow.com/a/78350223/ https://stackoverflow.com/a/78350224/  https://stackoverflow.com/a/78350225/    https://stackoverflow.com/a/78350226/      https://stackoverflow.com/a/78350227/ <-
        ->Contents of ... etc"<-
urls elements:
        ->https://stackoverflow.com/a/78350223/<-
        ->https://stackoverflow.com/a/78350224/<-
        ->https://stackoverflow.com/a/78350225/<-
        ->https://stackoverflow.com/a/78350226/<-
        ->https://stackoverflow.com/a/78350227/<-
```
