### PR TITLE
Disable redirector test for t.ly/AqjA

### DIFF
--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -6,7 +6,9 @@ import helpers
 
 @pytest.mark.skipif("CHINA" in os.environ, reason="")
 @pytest.mark.parametrize('shortened, original', [
-    ('https://t.ly/AqjA', 'https://charcoal-se.org/smokey/'),
+    # FIXME: disabled for now
+    # See bug report https://github.com/Charcoal-SE/SmokeDetector/issues/11151
+    # ('https://t.ly/AqjA', 'https://charcoal-se.org/smokey/'),
     ('https://bit.ly/2jhMbxn', 'https://charcoal-se.org/'),
 ])
 def test_unshorten_link(shortened, original):


### PR DESCRIPTION
This test started failing because of a CAPTCHA problem

See https://github.com/Charcoal-SE/SmokeDetector/issues/11151