### PR TITLE
Allow users to reject their own watch/blacklist PRs (v2: Now with cleaner commit history!)

### DIFF
--- a/chatcommands.py
+++ b/chatcommands.py
@@ -720,7 +720,7 @@ def reject(msg, args, alias_used="reject"):
     try:
         pr_json = GitHubManager.get_pull_request(pr_id).json()
         if 'body' in pr_json:
-            pr_authored_by_rejector = regex.search(r"(?<=\/users\/)" + str(msg.owner.id),
+            pr_authored_by_rejector = regex.search(r"(?<=/users/)" + str(msg.owner.id),
                                                    pr_json['body'])
             self_reject = pr_authored_by_rejector is not None
     except Exception as e:

--- a/chatcommands.py
+++ b/chatcommands.py
@@ -15,7 +15,7 @@ from metasmoke import Metasmoke
 from blacklists import load_blacklists, Blacklist
 from parsing import *
 from spamhandling import check_if_spam, handle_spam
-from gitmanager import GitManager
+from gitmanager import GitManager, GitHubManager
 import threading
 import random
 import requests
@@ -716,23 +716,38 @@ def reject(msg, args, alias_used="reject"):
         reason = ''
     force = alias_used.split("-")[-1] == "force"
     code_permissions = is_code_privileged(msg._client.host, msg.owner.id)
-    if not code_permissions:
-        raise CmdException("You need blacklist manager privileges to reject pull requests")
+    self_reject = False
+    try:
+        pr_json = GitHubManager.get_pull_request(pr_id).json()
+        if 'body' in pr_json:
+            pr_authored_by_rejector = regex.search(r"(?<=\/users\/)" + str(msg.owner.id),
+                                                   pr_json['body'])
+            self_reject = pr_authored_by_rejector is not None
+    except Exception as e:
+        raise CmdException(str(e))
+    if not code_permissions and not self_reject:
+        raise CmdException("You need blacklist manager privileges to reject pull requests "
+                           "that aren't created by you.")
     if len(reason) < 20 and not force:
-        raise CmdException("Please provide an adequate reason for rejection (at least 20 characters long) so the user"
-                           " can learn from their mistakes. Use `-force` to force the reject")
+        raise CmdException("Please provide an adequate reason for rejection that is at least"
+                           " 20 characters long. Use `-force` to ignore this requirement.")
     rejected_image = "https://img.shields.io/badge/blacklisters-rejected-red"
     message_url = "https://chat.{}/transcript/{}?m={}".format(msg._client.host, msg.room.id, msg.id)
     chat_user_profile_link = "https://chat.{}/users/{}".format(msg._client.host, msg.owner.id)
     rejected_by_text = "[Rejected]({}) by [{}]({}) in {}.".format(message_url, msg.owner.name,
                                                                   chat_user_profile_link, msg.room.name)
+    if self_reject:
+        rejected_by_text = "[Self-rejected]({}) by [{}]({}) in {}.".format(message_url, msg.owner.name,
+                                                                           chat_user_profile_link, msg.room.name)
     reject_reason_text = " No rejection reason was provided.\n\n"
     if reason:
         reject_reason_text = " Reason: '{}'".format(reason)
     reject_reason_image_text = "\n\n![Rejected with SmokeyReject]({})".format(rejected_image)
+    if self_reject:
+        reject_reason_image_text = ""
     comment = rejected_by_text + reject_reason_text + reject_reason_image_text
     try:
-        message = GitManager.reject_pull_request(pr_id, comment)
+        message = GitManager.reject_pull_request(pr_id, comment, self_reject)
         return message
     except Exception as e:
         raise CmdException(str(e))

--- a/gitmanager.py
+++ b/gitmanager.py
@@ -73,7 +73,7 @@ class GitHubManager:
         return response.json()
 
     @classmethod
-    def get_pull_request(cls, pr_id, payload):
+    def get_pull_request(cls, pr_id, payload=""):
         """ Get pull requests info. """
         url = "https://api.github.com/repos/{}/pulls/{}".format(GlobalVars.bot_repo_slug, pr_id)
         return cls.call_api("GET", url, payload)
@@ -380,7 +380,7 @@ class GitManager:
             cls.gitmanager_lock.release()
 
     @classmethod
-    def reject_pull_request(cls, pr_id, comment=""):
+    def reject_pull_request(cls, pr_id, comment="", self_reject=False):
         response = requests.get("https://api.github.com/repos/{}/pulls/{}".format(GlobalVars.bot_repo_slug, pr_id),
                                 timeout=GlobalVars.default_requests_timeout)
         if not response:
@@ -405,6 +405,9 @@ class GitManager:
             if response:
                 if response.json()["state"] == "closed":
                     git.push('-d', origin_or_auth, ref)
+                    if self_reject:
+                        return "You self-closed pull request [#{0}](https://github.com/{1}/pull/{0}).".format(
+                            pr_id, GlobalVars.bot_repo_slug)
                     return "Closed pull request [#{0}](https://github.com/{1}/pull/{0}).".format(
                         pr_id, GlobalVars.bot_repo_slug)
 


### PR DESCRIPTION
This is #11285 but with a less messy commit history (and a small regex adjustment).

I'd have done rebase-foo on THAT PR instead, but my Git wizardry is... Novitiate. That's a word, right?

---

Implements feature request #8642

This PR allows users to reject/close (including `-force`) their own auto-created watch and blacklist PRs.

This was tested in [this chatroom](https://chat.stackexchange.com/transcript/message/65699938#65699938) (where I removed SD ignoring its own messages when considering them for commands and some other changes, the full diff of which is available [here](https://github.com/Charcoal-SE/SmokeDetector/pull/11285/commits/d3993d17b832c66085ef56a5cd063cf09dd07ff1) where I mistakenly committed them to this branch and had to remove them).

One small change I made was making the `payload` argument for `get_pull_request` an optional arg with a blank string as its default. This change has no effect elsewhere in the project as `get_pull_request` isn't used anywhere aside from in this PR's changes, and you don't need to supply a payload when performing a GET request for a PR anyway.

I also took the liberty to remove the "so the user can learn from their mistakes" content from the required-rejection CmdException. I have a couple of reasons for this removal:
- This wording makes no sense if the user is rejecting their own PR
- We frequently reject duplicate PRs. In such a case, there is no mistake being made.

## Known limitations:
This PR operates off of the chat messager's chat id, and so does submitting a watch PR. This can be different across chat servers, such as if a user submits a watch PR in SO chat and attempts to self-close it in Charcoal HQ. This will yield a `"You need blacklist manager privileges to reject pull requests that aren't created by you."` error.

Given that 95% of all watch/blacklist PRs occur in Charcoal HQ, I consider this an acceptable limitation.