### PR TITLE
SE WebSockets: timeouts, exception recovery, and reporting into chat

### DIFF
--- a/deletionwatcher.py
+++ b/deletionwatcher.py
@@ -12,7 +12,8 @@ import websocket
 from globalvars import GlobalVars
 import metasmoke
 import datahandling
-from helpers import log, get_se_api_default_params_questions_answers_posts_add_site, get_se_api_url_for_route
+from helpers import (log, get_se_api_default_params_questions_answers_posts_add_site, get_se_api_url_for_route,
+                     recover_websocket)
 from parsing import fetch_post_id_and_site_from_url, to_protocol_relative
 from tasks import Tasks
 
@@ -27,13 +28,23 @@ class DeletionWatcher:
     def __init__(self):
         if GlobalVars.no_deletion_watcher:
             return
+        # posts is a dict with the WebSocket action as keys {site_id}-question-{question_id} as keys
+        #   The values are a tuple: (post_id, post_site, post_type, post_url, [(callback, max_time)])
+        #   NOTE: This is not sufficient, as it doesn't account for watching multiple posts per question.
+        #   Actions are added when a post is subscribed. They are removed when a WebSocket message is received
+        #   indicating the first post subscribed for that question is deleted.
+        #   Upon reboot, questions are not resubscribed to if the questions has either been deleted or the later
+        #   of its creation or last edit date is >= 7200 seconds ago. Answers are never resubscribed to.
         self.posts = {}
         self.posts_lock = threading.Lock()
         self.save_handle = None
         self.save_handle_lock = threading.Lock()
 
         try:
-            self.socket = websocket.create_connection("wss://qa.sockets.stackexchange.com/")
+            self.socket = websocket.create_connection(GlobalVars.se_websocket_url,
+                                                      timeout=GlobalVars.se_websocket_timeout)
+            self.connect_time = time.time()
+            self.hb_time = None
         except websocket.WebSocketException:
             self.socket = None
             log('error', 'DeletionWatcher failed to create a websocket connection')
@@ -41,41 +52,55 @@ class DeletionWatcher:
 
         if datahandling.has_pickle(PICKLE_FILENAME):
             pickle_data = datahandling.load_pickle(PICKLE_FILENAME)
-            for post in DeletionWatcher._check_batch(pickle_data):
-                self.subscribe(post, pickle=False)
+            for post_url in DeletionWatcher._check_batch(pickle_data):
+                self.subscribe(post_url, pickle=False)
             self._schedule_save()
 
         threading.Thread(name="deletion watcher", target=self._start, daemon=True).start()
 
     def _start(self):
         while True:
-            msg = self.socket.recv()
+            try:
+                msg = self.socket.recv()
 
-            if msg:
-                msg = json.loads(msg)
-                action = msg["action"]
+                if msg:
+                    msg = json.loads(msg)
+                    action = msg["action"]
 
-                if action == "hb":
-                    self.socket.send("hb")
-                else:
-                    data = json.loads(msg["data"])
+                    if action == "hb":
+                        self.hb_time = time.time()
+                        self.socket.send("hb")
+                    else:
+                        data = json.loads(msg["data"])
 
-                    if data["a"] == "post-deleted":
-                        try:
-                            with self.posts_lock:
-                                post_id, _, _, post_url, callbacks = self.posts[action]
-
-                            if post_id == str(data["aId"] if "aId" in data else data["qId"]):
+                        if data["a"] == "post-deleted":
+                            try:
                                 with self.posts_lock:
-                                    del self.posts[action]
-                                Tasks.do(self._unsubscribe, action)
-                                Tasks.do(metasmoke.Metasmoke.send_deletion_stats_for_post, post_url, True)
+                                    post_id, _, _, post_url, callbacks = self.posts[action]
 
-                                for callback, max_time in callbacks:
-                                    if not max_time or time.time() < max_time:
-                                        callback()
-                        except KeyError:
-                            pass
+                                if post_id == str(data["aId"] if "aId" in data else data["qId"]):
+                                    with self.posts_lock:
+                                        del self.posts[action]
+                                    Tasks.do(self._unsubscribe, action)
+                                    Tasks.do(metasmoke.Metasmoke.send_deletion_stats_for_post, post_url, True)
+
+                                    for callback, max_time in callbacks:
+                                        if not max_time or time.time() < max_time:
+                                            callback()
+                            except KeyError:
+                                pass
+            except websocket.WebSocketException as e:
+                ws = self.socket
+                self.socket = None
+                self.socket = recover_websocket("DeletionWatcher", ws, self._subscribe_to_all_saved_posts, e,
+                                                self.connect_time, self.hb_time)
+                self.connect_time = time.time()
+                self.hb_time = None
+
+    def _subscribe_to_all_saved_posts(self):
+        with self.posts_lock:
+            for action in self.posts:
+                self._subscribe(self, action)
 
     def subscribe(self, post_url, callback=None, pickle=True, timeout=None):
         if GlobalVars.no_deletion_watcher:
@@ -152,17 +177,19 @@ class DeletionWatcher:
             res = requests.get(uri, params=params, timeout=GlobalVars.default_requests_timeout)
             json = res.json()
 
+            if 'backoff' in json:
+                DeletionWatcher.next_request_time = time.time() + json['backoff']
+
             if "items" not in json:
                 log('warning',
                     'DeletionWatcher API request received no items in response (code {})'.format(res.status_code))
                 log('warning', res.text)
+                # This really should do a better job of recovery, as we could retry and/or go to the next site.
                 return
 
-            if 'backoff' in json:
-                DeletionWatcher.next_request_time = time.time() + json['backoff']
-
             for post in json['items']:
-                if time.time() - post["creation_date"] < 7200:
+                compare_date = post["last_edit_date"] if "last_edit_date" in post else post["creation_date"]
+                if time.time() - compare_date < 7200:
                     yield to_protocol_relative(post["link"]).replace("/q/", "/questions/")
 
     def _unsubscribe(self, action):

--- a/globalvars.py
+++ b/globalvars.py
@@ -92,6 +92,8 @@ class GlobalVars:
     api_backoff_time = 0
     default_requests_timeout = 60
     deletion_watcher = None
+    se_websocket_url = "wss://qa.sockets.stackexchange.com/"
+    se_websocket_timeout = 7 * 60  # 7 minutes; heartbeats from SE are every 5 minutes
 
     not_privileged_warning = \
         "You are not a privileged user. Please see " \

--- a/ws.py
+++ b/ws.py
@@ -36,7 +36,8 @@ import requests
 import dns.resolver
 # noinspection PyPackageRequirements
 from tld.utils import update_tld_names, TldIOError
-from helpers import exit_mode, log, Helpers, log_exception, add_to_global_bodyfetcher_queue_in_new_thread
+from helpers import (exit_mode, log, Helpers, log_exception, add_to_global_bodyfetcher_queue_in_new_thread,
+                     tell_debug_rooms_recovered_websocket)
 from flovis import Flovis
 from tasks import Tasks
 
@@ -246,7 +247,7 @@ log('info', 'MS host: {}'.format(GlobalVars.metasmoke_host))
 
 def setup_websocket(attempt, max_attempts):
     try:
-        ws = websocket.create_connection("wss://qa.sockets.stackexchange.com/")
+        ws = websocket.create_connection(GlobalVars.se_websocket_url, timeout=GlobalVars.se_websocket_timeout)
         ws.send("155-questions-active")
         return ws
     except websocket.WebSocketException:
@@ -275,6 +276,8 @@ def init_se_websocket_or_reboot(max_tries, tell_debug_room_on_error=False):
 
 if not GlobalVars.no_se_activity_scan:
     ws = init_se_websocket_or_reboot(MAX_SE_WEBSOCKET_RETRIES)
+    ws_connect_time = time.time()
+    ws_hb_time = None
 
 GlobalVars.deletion_watcher = DeletionWatcher()
 GlobalVars.edit_watcher = EditWatcher()
@@ -294,6 +297,7 @@ while not GlobalVars.no_se_activity_scan:
             message = json.loads(a)
             action = message["action"]
             if action == "hb":
+                ws_hb_time = time.time()
                 ws.send("hb")
             if action == "155-questions-active":
                 data = json.loads(message['data'])
@@ -319,8 +323,7 @@ while not GlobalVars.no_se_activity_scan:
         delta = now - GlobalVars.startup_utc_date
         seconds = delta.total_seconds()
         tr = traceback.format_exc()
-        exception_only = ''.join(traceback.format_exception_only(type(e), e))\
-                           .strip()
+        exception_only = ''.join(traceback.format_exception_only(type(e), e)).strip()
         n = os.linesep
         logged_msg = str(now) + " UTC" + n + exception_only + n + tr + n + n
         log('error', logged_msg)
@@ -329,10 +332,11 @@ while not GlobalVars.no_se_activity_scan:
             # noinspection PyProtectedMember
             exit_mode("early_exception")
         if not GlobalVars.no_se_activity_scan:
+            ws.close()  # Close the prior WebSocket, if open.
             ws = init_se_websocket_or_reboot(MAX_SE_WEBSOCKET_RETRIES, tell_debug_room_on_error=True)
-
-        chatcommunicate.tell_rooms_with("debug", "{}: SE WebSocket: recovered from `{}`"
-                                                 .format(GlobalVars.location, exception_only))
+            tell_debug_rooms_recovered_websocket("main SE", e, ws_connect_time, ws_hb_time)
+            ws_connect_time = time.time()
+            ws_hb_time = None
 
 while GlobalVars.no_se_activity_scan:
     # Sleep for longer than the automatic restart


### PR DESCRIPTION
* Recover from DeletionWatcher and EditWatcher SE WebSocket exceptions
* For the main SE WebSocket, EditWatcher, and DeletionWatcher, uniformly report SE WebSocket recovery into chat debug rooms, including seconds since the connection was made and seconds from last heartbeat.
* Add timeouts for SE WebSockets: 7 minutes (420 seconds). Normal operation is that SE sends a heartbeat every 5 minutes, so we should timeout shortly after that.
* Resolves #7043
* Fixes a bug in DeletionWatcher where expiration was always based upon post `creation_date`, rather than using `last_edit_date`, if it exists.


Testing for this begins [here](https://chat.stackexchange.com/transcript/message/65811005#65811005).