### PR TITLE
EditWatcher and DeletionWatcher bug fixes

### DIFF
--- a/deletionwatcher.py
+++ b/deletionwatcher.py
@@ -92,8 +92,8 @@ class DeletionWatcher:
             except websocket.WebSocketException as e:
                 ws = self.socket
                 self.socket = None
-                self.socket = recover_websocket(self.__class__.__name__, ws, self._subscribe_to_all_saved_posts, e,
-                                                self.connect_time, self.hb_time)
+                self.socket = recover_websocket(self.__class__.__name__, ws, e, self.connect_time, self.hb_time)
+                self._subscribe_to_all_saved_posts()
                 self.connect_time = time.time()
                 self.hb_time = None
 

--- a/deletionwatcher.py
+++ b/deletionwatcher.py
@@ -36,9 +36,9 @@ class DeletionWatcher:
         #   Upon reboot, questions are not resubscribed to if the questions has either been deleted or the later
         #   of its creation or last edit date is >= 7200 seconds ago. Answers are never resubscribed to.
         self.posts = {}
-        self.posts_lock = threading.Lock()
+        self.posts_lock = threading.RLock()
         self.save_handle = None
-        self.save_handle_lock = threading.Lock()
+        self.save_handle_lock = threading.RLock()
 
         try:
             self.socket = websocket.create_connection(GlobalVars.se_websocket_url,

--- a/deletionwatcher.py
+++ b/deletionwatcher.py
@@ -153,9 +153,9 @@ class DeletionWatcher:
         with self.save_handle_lock:
             if self.save_handle:
                 self.save_handle.cancel()
-            save_handle = Tasks.do(self._save)
+            save_handle = Tasks.do(self.save)
 
-    def _save(self):
+    def save(self):
         pickle_output = {}
 
         with self.posts_lock:

--- a/editwatcher.py
+++ b/editwatcher.py
@@ -81,8 +81,8 @@ class EditWatcher:
             except websocket.WebSocketException as e:
                 ws = self.socket
                 self.socket = None
-                self.socket = recover_websocket(self.__class__.__name__, ws, self._subscribe_to_all_saved_posts, e,
-                                                self.connect_time, self.hb_time)
+                self.socket = recover_websocket(self.__class__.__name__, ws, e, self.connect_time, self.hb_time)
+                self._subscribe_to_all_saved_posts()
                 self.connect_time = time.time()
                 self.hb_time = None
 

--- a/editwatcher.py
+++ b/editwatcher.py
@@ -29,9 +29,9 @@ class EditWatcher:
         # posts is a dict with the WebSocket action, {site_id}-question-{question_id}, as keys
         # with each value being: (site_id, hostname, question_id, max_time)
         self.posts = {}
-        self.posts_lock = threading.Lock()
+        self.posts_lock = threading.RLock()
         self.save_handle = None
-        self.save_handle_lock = threading.Lock()
+        self.save_handle_lock = threading.RLock()
 
         try:
             self.socket = websocket.create_connection(GlobalVars.se_websocket_url,

--- a/editwatcher.py
+++ b/editwatcher.py
@@ -180,9 +180,9 @@ class EditWatcher:
         with self.save_handle_lock:
             if self.save_handle:
                 self.save_handle.cancel()
-            save_handle = Tasks.do(self._save)
+            save_handle = Tasks.do(self.save)
 
-    def _save(self):
+    def save(self):
         with self.posts_lock:
             copy = self.posts.copy()
 

--- a/globalvars.py
+++ b/globalvars.py
@@ -92,6 +92,7 @@ class GlobalVars:
     api_backoff_time = 0
     default_requests_timeout = 60
     deletion_watcher = None
+    edit_watcher = None
     se_websocket_url = "wss://qa.sockets.stackexchange.com/"
     se_websocket_timeout = 7 * 60  # 7 minutes; heartbeats from SE are every 5 minutes
 

--- a/helpers.py
+++ b/helpers.py
@@ -531,14 +531,13 @@ def tell_debug_rooms_recovered_websocket(which_ws, exception, connect_time, hb_t
     tell_rooms_with('debug', timestamp + message_without_timestamp)
 
 
-def recover_websocket(which_ws, ws, subscribe, exception, connect_time, hb_time):
+def recover_websocket(which_ws, ws, exception, connect_time, hb_time):
     log_current_exception(log_level="warning")
     if ws:
         ws.close()  # Close the socket, if it's not already closed
         ws = None
     try:
         ws = websocket.create_connection(GlobalVars.se_websocket_url, timeout=GlobalVars.se_websocket_timeout)
-        subscribe()
         tell_debug_rooms_recovered_websocket(which_ws, exception, connect_time, hb_time)
         return ws
     except websocket.WebSocketException:

--- a/helpers.py
+++ b/helpers.py
@@ -27,6 +27,7 @@ from globalvars import GlobalVars
 
 
 def exit_mode(*args, code=0):
+    # This code is executed whenever we exit, even when the exit is caused by an exception.
     args = set(args)
 
     if not (args & {'standby', 'no_standby'}):
@@ -39,9 +40,29 @@ def exit_mode(*args, code=0):
 
     # Flush any buffered queue timing data
     import datahandling  # this must not be a top-level import in order to avoid a circular import
-    datahandling.flush_queue_timings_data()
-    datahandling.store_post_scan_stats()
-    datahandling.store_recently_scanned_posts()
+    try:
+        datahandling.flush_queue_timings_data()
+    except Exception:
+        log_current_exception()
+    try:
+        datahandling.store_post_scan_stats()
+    except Exception:
+        log_current_exception()
+    try:
+        datahandling.store_recently_scanned_posts()
+    except Exception:
+        log_current_exception()
+    # Store other pickles as we exit
+    try:
+        if GlobalVars.edit_watcher:
+            GlobalVars.edit_watcher.save()
+    except Exception:
+        log_current_exception()
+    try:
+        if GlobalVars.deletion_watcher:
+            GlobalVars.deletion_watcher.save()
+    except Exception:
+        log_current_exception()
 
     # We have to use '_exit' here, because 'sys.exit' only exits the current
     # thread (not the current process).  Unfortunately, this results in


### PR DESCRIPTION
This fixes a few/several issues in EditWatcher and DeletionWatcher:
* EditWatcher and DeletionWatcher weren't actually rewatching the questions they were watching when those WebSocket was "recovered". This was a bug I introduced when going a bit too far with DRY in that code. Basically, they were both attempting to resubscribe to their `self.socket` WebSocket prior to the new WebSocket reference being stored in `self.socket`
* More aggressively unsubscribe to questions in EditWatcher. Questions were previously unsubscribed only if there was something received about that question after the time expired. Now, all expired questions are unsubscribed upon each receipt of a message. This keeps the total number of questions subscribed to from expanding throughout the time between reboots.
* EditWatcher wasn't actually saving its pickle, so posts weren't rewatched upon reboot.
* Move saving both pickles into the main `exit_mode()` code, which is executed even if we're exiting due to an exception, so we don't need to repeatedly save the pickles.

There are still more issues to handle in DeletionWatcher, particularly #11539 and #11540.

Testing of this was done in [Makyen+Test+02 about here](https://chat.stackexchange.com/transcript/97026?m=65883051#65883051). Primary verification was done by adding additional logging to the WebSocket actions and manually looking through the console logs.