### PR TITLE
Unwatch IP pair 104.21.22.135 + 172.67.205.25

### DIFF
--- a/watched_cidrs.yml
+++ b/watched_cidrs.yml
@@ -445,7 +445,9 @@ items:
 - ip: 104.21.22.111
 - ip: 104.21.22.13
 - ip: 104.21.22.133
-- ip: 104.21.22.135
+- comment: gradle-wrapper.properties - 0/24 over 2 months
+  disable: true
+  ip: 104.21.22.135
 - ip: 104.21.22.138
 - ip: 104.21.22.146
 - ip: 104.21.22.200

--- a/watched_cidrs.yml
+++ b/watched_cidrs.yml
@@ -3848,7 +3848,9 @@ items:
 - ip: 172.67.205.220
 - ip: 172.67.205.224
 - ip: 172.67.205.226
-- ip: 172.67.205.25
+- comment: gradle-wrapper.properties - 0/15 over 2 months
+  disable: true
+  ip: 172.67.205.25
 - ip: 172.67.205.252
 - ip: 172.67.205.28
 - ip: 172.67.205.5


### PR DESCRIPTION
[No TP since watch](https://metasmoke.erwaysoftware.com/search?utf8=%E2%9C%93&why_is_regex=1&why=104%5C.21%5C.22%5C.135), all FPs due to [`gradle-wrapper.properties`](https://metasmoke.erwaysoftware.com/search?utf8=%E2%9C%93&why_is_regex=1&why=gradle-wrapper%5C.properties) (which apparently resolves o_O).