### PR TITLE
README.md: fix broken image link

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ and accesses answers via the [Stack Exchange API](https://api.stackexchange.com/
 
 Example [chat post](https://chat.stackexchange.com/transcript/message/43579469):
 
-![Example chat post](https://i.stack.imgur.com/oLyfb.png)
+![Example chat post](https://i.sstatic.net/oLyfb.png)
 
 ## Documentation
 


### PR DESCRIPTION
Image moved from imgur to sstatic.net; Github no longer renders the old link correctly.