### PR TITLE
Add ability to have users_custom.yml

### DIFF
--- a/chatcommunicate.py
+++ b/chatcommunicate.py
@@ -194,7 +194,9 @@ def parse_room_config(path):
     with open(path, "r", encoding="utf-8") as room_config:
         room_dict = yaml.safe_load(room_config.read())
 
-    with open("users.yml", "r", encoding="utf-8") as user_config:
+    users_yml_path = "users_custom.yml" if os.path.exists("users_custom.yml") else "users.yml"
+
+    with open(users_yml_path, "r", encoding="utf-8") as user_config:
         user_data = yaml.safe_load(user_config.read())
 
     inherits = []


### PR DESCRIPTION
This adds the ability to override the users.yml file with a users_custom.yml file for testing. The feature needed for running test instances that was missing is the ability for the runner of the test instance to give a user SD privileges without changing users.yml from the text that's stored in the GitHub repository. This PR resolves that problem by adding the ability to have a users_custom.yml file that is conceptually similar to rooms_custom.yml.