### PR TITLE
fix catastrophic backtracking

### DIFF
--- a/watched_keywords.txt
+++ b/watched_keywords.txt
@@ -6469,7 +6469,7 @@
 1544635783	Makyen	ca\.papersowl\.com
 1544635791	Makyen	wobbiewobbit\.com
 1544654286	Makyen	atten\.com
-1544674518	Makyen	\w*(?:约炮|約炮)\w*(?#slang for sex)
+1544674518	Makyen	(?=\w*(?:约炮|約炮))\w*(?:约炮|約炮)\w*(?#slang for sex)
 1544680688	Tetsuya Yamamoto	hifigadget\.com
 1544681529	Tetsuya Yamamoto	satishbrothersandsons\.com
 1544682225	Tetsuya Yamamoto	germanycar\.com\.vn


### PR DESCRIPTION
1544674518 in watched_keywords.txt

Possible alternatives:
1. just limit how much context we need:
https://chat.stackexchange.com/transcript/message/66302917
2. Use a named capture group too
this would reduce the time for the matching cases, by a tiny margin.