### PR TITLE
blacklists.py: normalize items when comparing for duplicates

### DIFF
--- a/blacklists.py
+++ b/blacklists.py
@@ -205,6 +205,9 @@ class YAMLParserCIDR(BlacklistParser):
         with open(self._filename, 'w', encoding='utf-8') as f:
             yaml.dump(d, f)
 
+    def _normalize(self, item):
+        return item.rstrip()
+
     def _validate(self, item):
         ip_regex = regex.compile(r'''
             (?(DEFINE)(?P<octet>
@@ -242,10 +245,11 @@ class YAMLParserCIDR(BlacklistParser):
         prikey = self.SCHEMA_PRIKEY
 
         def add_callback(d):
+            item_normalized = self._normalize(item[prikey])
             for compare in d['items']:
-                if compare[prikey] == item[prikey]:
-                    raise ValueError('{0} already in list {1}'.format(
-                        item[prikey], d['items']))
+                if self._normalize(compare[prikey]) == item_normalized:
+                    raise KeyError('{0} already in list {1}'.format(
+                        compare[prikey], d['items']))
             d['items'].append(item)
 
         self._write(add_callback)

--- a/test/test_blacklists.py
+++ b/test/test_blacklists.py
@@ -162,9 +162,9 @@ def test_yaml_blacklist():
         blacklist.add('1.3.34')
     with pytest.raises(ValueError) as e:
         blacklist.add({'ip': '1.3.4'})
-    with pytest.raises(ValueError) as e:
+    with pytest.raises(KeyError) as e:
         blacklist.add({'ip': '1.2.3.4'})
-    with pytest.raises(ValueError) as e:
+    with pytest.raises(KeyError) as e:
         blacklist.add({'ip': '2.3.4.5'})
     with pytest.raises(ValueError) as e:
         blacklist.remove({'ip': '34.45.56.67'})
@@ -195,9 +195,9 @@ def test_yaml_asn():
         blacklist.add('123')
     with pytest.raises(ValueError) as e:
         blacklist.add({'asn': 'invalid'})
-    with pytest.raises(ValueError) as e:
+    with pytest.raises(KeyError) as e:
         blacklist.add({'asn': '123'})
-    with pytest.raises(ValueError) as e:
+    with pytest.raises(KeyError) as e:
         blacklist.add({'asn': '234'})
     with pytest.raises(ValueError) as e:
         blacklist.remove({'asn': '9897'})
@@ -226,8 +226,10 @@ def test_yaml_nses():
     blacklist = Blacklist(('test_nses.yml', YAMLParserNS))
     assert 'example.com.' in blacklist.parse()
     assert 'EXAMPLE!COM.' not in blacklist.parse()
-    with pytest.raises(ValueError) as e:
+    with pytest.raises(KeyError) as e:
         blacklist.add({'ns': 'example.com.'})
+    with pytest.raises(KeyError) as e:
+        blacklist.add({'ns': 'EXAMPLE.COM.'})
     with pytest.raises(ValueError) as e:
         blacklist.add({'ns': 'EXAMPLE!COM.'})
     assert 'example.net.' not in blacklist.parse()


### PR DESCRIPTION
test/test_blacklists.py: restore case-insensitive duplicate test case

Changed the code to raise KeyError in this scenario, so the related test cases had to be updated.