### PR TITLE
Update watched_nses.yml: comment out cloudserverdns.co.in (NXDOMAIN)

### DIFF
--- a/watched_nses.yml
+++ b/watched_nses.yml
@@ -5305,7 +5305,9 @@ items:
 - ns: mobilecoderz.com.
 - ns: superappscloud.com.
 - ns: hiya.digital.
-- ns: cloudserverdns.co.in.
+- comment: NXDOMAIN 2024-09-29
+  disable: true
+  ns: cloudserverdns.co.in.
 - ns: shotz.site.
 - ns: digitaldwarka.com.
 - ns: partohost.net.


### PR DESCRIPTION
The most recent builds (e.g. https://github.com/Charcoal-SE/SmokeDetector/actions/runs/11093250846/job/30819305773) are failing with:
```
FAILED test/test_blacklists.py::test_yaml_nses@long_runner_1 - Exception: 1 entry failed to validate in watched_nses.yml
    cloudserverdns.co.in. in watched_nses.yml for dns.resolver.NXDOMAIN
```
This change comments out the entry in watched_nses.yml.