### PR TITLE
DeletionWatcher: fix crashing issue; handle sites with > 100 posts; don't truncate sites to 10 posts upon reboot

### DIFF
--- a/globalvars.py
+++ b/globalvars.py
@@ -177,6 +177,7 @@ class GlobalVars:
     se_api_url_base = "https://api.stackexchange.com/2.4/"
     se_api_default_params = {
         'key': 'IAkbitmze4B8KpacUfLqkw((',
+        'pagesize': '100',
     }
     se_api_default_params_questions_answers_posts = se_api_default_params.copy()
     se_api_default_params_questions_answers_posts.update({


### PR DESCRIPTION
This PR does:
1. Prevents crashing SD when the response to `DeletionWatcher`'s SE API requests isn't valid JSON. This should resolve the issue that caused all of our SD instances to go offline during the spam wave.
2. BUG FIX: not truncate the number of posts per site to 10 upon reboot. This was happening because the `pagesize` was left as the default 10, even when more posts were requested. Thus, only data from the first 10 would be returned. This was solved by adding a default `pagesize` parameter of `100` to all SE API requests globally. For places where we specifically set that value, those will override the default.
3. BUG FIX: Handle sites with > 100 posts being watched by `DeletionWatcher`. That > 100 posts/site wasn't accounted for was the underlying cause of the crash.
4. BUG FIX: Continue with the sites when no `items` are returned from the SE API request instead of bailing out and not processing further sites (and now, potentially, chunks of posts).

Testing, or what's visible of it (just a bunch of SD restart messages), started at https://chat.stackexchange.com/transcript/message/66515763#66515763