### PR TITLE
Support short multiline messages

### DIFF
--- a/chatcommunicate.py
+++ b/chatcommunicate.py
@@ -341,10 +341,15 @@ def on_msg(msg, client):
 
             return
 
+    check_ending_div = False
     if message.content.startswith("<div class='partial'>"):
         message.content = message.content[21:]
-        if message.content.endswith("</div>"):
-            message.content = message.content[:-6]
+        check_ending_div = True
+    elif message.content.startswith("<div class='full'>"):
+        message.content = message.content[18:]
+        check_ending_div = True
+    if check_ending_div and message.content.endswith("</div>"):
+        message.content = message.content[:-6]
 
     if message.parent:
         try:


### PR DESCRIPTION
This PR fixes #12803 by supporting short multiline messages in SD. For example, it makes `!!/location<NEWLINE>Hello` work.

Here's a [before](https://chat.stackexchange.com/transcript/message/66607179) and [after](https://chat.stackexchange.com/transcript/message/66607174).

The issue was short multiline messages start with `<div class='full'>`, which SD doesn't know to remove. As a result, it doesn't see the message as starting with either `!!/` or `sdc ` and ignores the messages. There's multiple ways to handle the ending `</div>` (see [this Stack Overflow question](https://stackoverflow.com/q/21612910)). I opted to use a `bool` variable, but I'm happy to go with something else too.