### PR TITLE
Update watched_nses.yml - re-disable cloudxspeed.com

### DIFF
--- a/watched_nses.yml
+++ b/watched_nses.yml
@@ -5184,7 +5184,8 @@ items:
   - now1.dns.com.
   - now2.dns.com.
 - ns: thcservers.com.
-- comment: NXDOMAIN 2023-08-30; enabled again 2024-10-18
+- comment: NXDOMAIN 2023-08-30; enabled again 2024-10-18; disabled again 2024-11-24 (NXDOMAIN)
+  disable: true
   ns: cloudxspeed.com.
 - ns: xmarthost.com.
 - ns: hostzet.com.


### PR DESCRIPTION
Resolves recent build failures based on cloudxspeed.com being NXDOMAIN again.

MX Toolbox result: https://mxtoolbox.com/SuperTool.aspx?action=mx%3acloudxspeed.com&run=toolpage

e.g.  https://github.com/Charcoal-SE/SmokeDetector/actions/runs/11996884075/job/33441859183 and https://github.com/Charcoal-SE/SmokeDetector/actions/runs/11996884075/job/33441859292