### PR TITLE
re-disable matkaparivar.in in watched_nses.yml

### DIFF
--- a/watched_nses.yml
+++ b/watched_nses.yml
@@ -4429,7 +4429,8 @@ items:
 - ns: speedydns.net.
 - ns: webhost.pro.
 - ns: visiondns.net.
-- comment: 2021-08-03 SERVFAIL; eabled again 2024-10-18
+- comment: 2021-08-03 SERVFAIL; enabled again 2024-10-18; disabled again 2025-01-02
+  disable: true
   ns: matkaparivar.in.
 - ns: vdns.vn.
 - ns: ocyber.us.


### PR DESCRIPTION
https://github.com/Charcoal-SE/SmokeDetector/actions/runs/12582691045/job/35068797142 and several previous runs had failures on this entry:

> FAILED test/test_blacklists.py::test_yaml_nses@long_runner_1 - Exception: 1 entry failed to validate in watched_nses.yml
    matkaparivar.in. in watched_nses.yml for dns.resolver.NXDOMAIN