### PR TITLE
Support for blacklisting a user network-wide

### DIFF
--- a/apigetpost.py
+++ b/apigetpost.py
@@ -16,6 +16,7 @@ class PostData:
         self.owner_url = None
         self.owner_name = None
         self.owner_rep = None
+        self.owner_acct_id = None
         self.title = None
         self.body = None
         self.body_markdown = None
@@ -33,7 +34,7 @@ class PostData:
             'title': self.title,
             'body': self.body,
             'body_markdown': self.body_markdown,
-            'owner': {'display_name': self.owner_name, 'link': self.owner_url, 'reputation': self.owner_rep},
+            'owner': {'display_name': self.owner_name, 'link': self.owner_url, 'reputation': self.owner_rep, 'account_id': self.owner_acct_id},
             'site': self.site,
             'question_id': self.post_id,
             'link': self.post_url,
@@ -82,6 +83,7 @@ def api_get_post(post_url):
         post_data.owner_name = html.unescape(item['owner']['display_name'])
         post_data.owner_url = item['owner']['link']
         post_data.owner_rep = item['owner']['reputation']
+        post_data.owner_acct_id = item['owner']['account_id']
     else:
         post_data.owner_name = ""
         post_data.owner_url = ""

--- a/classes/_Post.py
+++ b/classes/_Post.py
@@ -31,6 +31,7 @@ class Post:
         self._user_url = ""
         self._votes = {'downvotes': None, 'upvotes': None}
         self._edited = False
+        self._owner_account_id = None
 
         if parent is not None:
             if not isinstance(parent, Post):
@@ -143,7 +144,8 @@ class Post:
             'owner': {
                 'display_name': '_user_name',
                 'link': '_user_url',
-                'reputation': '_owner_rep'
+                'reputation': '_owner_rep',
+                'account_id': '_owner_account_id'
             },
             'question_id': '_post_id',
             'answer_id': '_post_id',
@@ -220,6 +222,10 @@ class Post:
     @property
     def post_score(self):
         return int(self._post_score)
+    
+    def get_account_id(self) -> int:
+        # TODO: should this have @property?
+        return int(self._owner_account_id)
 
     @property
     def post_site(self):

--- a/globalvars.py
+++ b/globalvars.py
@@ -173,7 +173,7 @@ class GlobalVars:
     # accurately from the correct route. However, for scanning posts, we also want the question data associated
     # with an answer.
     se_api_question_answer_post_filter = \
-        "!scxINmJWAnjuckNJkP9YfbG196DrCj)DDXQjRKUGfp-QzZ3b1nRh1Qitw7)FdyW_)iLrL8TBxFYZ1"
+        "!*b8DH81UdVw)kQyIDQMTMc9jrRZh7*x*46g(fPTyFh)C2d3Fp9kSnnFDHyiG5L3cG39qg66pgP63xLa74Uq"
     se_api_url_base = "https://api.stackexchange.com/2.4/"
     se_api_default_params = {
         'key': 'IAkbitmze4B8KpacUfLqkw((',

--- a/spamhandling.py
+++ b/spamhandling.py
@@ -42,11 +42,18 @@ def sum_weight(reasons: list):
             pass  # s += 0
     return s
 
+def is_post_owner_net_blacklisted(post: Post) -> bool:
+    """Check if the owner of a post is network-wide blacklisted"""
+    for acct_id, site in GlobalVars.blacklisted_users.keys():
+        if int(acct_id) == post.get_account_id() and site == "stackexchange.com":
+            return True
+    return False
 
 # noinspection PyMissingTypeHints
 def check_if_spam(post, dont_ignore_for=None):
     test, why = findspam.FindSpam.test_post(post)
-    if datahandling.is_blacklisted_user(parsing.get_user_from_url(post.user_url)):
+    net_blacklisted: bool = is_post_owner_net_blacklisted(post)
+    if datahandling.is_blacklisted_user(parsing.get_user_from_url(post.user_url)) or net_blacklisted:
         test.append("blacklisted user")
         blacklisted_user_data = datahandling.get_blacklisted_user_data(parsing.get_user_from_url(post.user_url))
         if len(blacklisted_user_data) > 1:
@@ -62,6 +69,8 @@ def check_if_spam(post, dont_ignore_for=None):
                 ms_url = datahandling.resolve_ms_link(rel_url) or to_metasmoke_link(rel_url)
                 why += "\nBlacklisted user - blacklisted for {} ({}) by {}".format(
                     blacklisted_post_url, ms_url, blacklisted_by)
+            if net_blacklisted:
+                why += "\nNetwork-wide blacklisted user"
             else:
                 why += "\n" + u"Blacklisted user - blacklisted by {}".format(blacklisted_by)
     if test:


### PR DESCRIPTION
Resolves #6845.
This PR:

- [x] Adds the account ID to the `Post` class. It may be better to not do that in this PR, and instead use [the change\(s\) Makyen describes here](https://chat.stackexchange.com/transcript/11540?m=66878132) instead.
- [x] Updates `addblu` and `rmblu` text to note a network-wide blacklist.
- [ ] Change `addblu` and `rmblu` to note if a user is already network-wide blacklisted if changing a site blacklist
- [ ] Figure out the API filter - I wasn't seeing the `account_id` with the existing filter, although I'm not sure why. I've changed it for testing, but I (or someone else) need to look into that properly
- [x] Change the `isblu` text based on if they're (a) on the site blacklist & (b) if they're on the network-wide blacklist
- [ ] Decide if `isblu` should list site blacklists when checking a SE account
- [ ] Determine if `get_acount_id(self) -> int` should have `@property`
- [x] Add a note in the `check_if_spam` function - not sure if I did that correctly
- [ ] Keep/remove type hints - for the new code, I've added type hints as I find they improve maintainability/readability, but I could remove them. See also #7425.
- [ ] Properly write `is_user_net_blacklisted(user: tuple[str, str]) -> bool`, which determines if a given user is network-wide blacklisted. I wasn't sure how to approach this without a `Post` object to rely on (e.g., if called from `!!/isblu`), so I wrote some placeholder code, but the `else` section needs to be worked on.
- [ ] `.format(...)` vs [f-strings](https://docs.python.org/3/tutorial/inputoutput.html#tut-f-strings) - I opted to use f-strings in `!!/isblu` considering I was changing the strings anyways. In other places (e.g., `!!/addblu`), I left it as `.format(...)` as I was changing that function less. Still, if I shouldn't use them here, I can replace the f-strings I used with `.format(...)`