### PR TITLE
Update watched_nses.yml: re-disable nccloud.shop

### DIFF
--- a/watched_nses.yml
+++ b/watched_nses.yml
@@ -5685,7 +5685,8 @@ items:
 - ns: cbcamerica.org.
 - ns: wpdns.host.
 - ns: serverforme.xyz.
-- comment: nxdomain 2023-11-07; enabled again 2024-10-18
+- comment: nxdomain 2023-11-07; enabled again 2024-10-18; re-disabled 2025-02-01
+  disable: true
   ns: nccloud.shop.
 - ns: attorneyvirginiamaryland.com.
 - ns: dynamicsalessolutions.co.uk.


### PR DESCRIPTION
nccloud.shop has been triggering CI failures of "dns.resolver.NXDOMAIN" this morning: https://github.com/Charcoal-SE/SmokeDetector/actions/runs/13088726918/job/36522944474 and https://github.com/Charcoal-SE/SmokeDetector/actions/runs/13088521908/job/36522532569 for two examples.