### PR TITLE
add sciencedirect.com to ASN whitelist

### DIFF
--- a/findspam.py
+++ b/findspam.py
@@ -122,7 +122,7 @@ ASN_WHITELISTED_WEBSITES = [
     "wikileaks.org",
     # Additional added not as part of a systematic investigation:
     "ntp.org", "cpu-world.com", "caniuse.com", "guru99.com", "fontawesome.com",
-    "nirsoft.net",
+    "nirsoft.net", "sciencedirect.com",
     # Added to prevent having 3 detections on just the domain.
     "writingexplained.org", "eitren.com"]
 


### PR DESCRIPTION
https://stackexchange.com/search?q=url%3A%22sciencedirect.com%22 gives 16450 results, and we have 121 FPs now (against 8 TPs, probably not many of them because of the link to that domain), so it makes sense to whitelist this domain. I am not sure *where* exactly to put it into the whitelist though ...