### PR TITLE
Update and improve util.py CLI script

### DIFF
--- a/chatcommands.py
+++ b/chatcommands.py
@@ -2825,8 +2825,9 @@ def normalize_number(msg, pattern):
     :param pattern:
     :return: A string
     """
-    minimally_validate_content_source(msg)
-    pattern = get_pattern_from_content_source(msg)
+    if msg is not None:
+        minimally_validate_content_source(msg)
+        pattern = get_pattern_from_content_source(msg)
     full_entry_list, processed_as_set, normalized = phone_numbers.process_numlist([pattern])
     return "Strict normalization: `" + phone_numbers.normalize(pattern) + \
            "`; Normalized numbers used by the number detections: `" + str(normalized) + "`"
@@ -2841,8 +2842,9 @@ def deobfuscate_number(msg, pattern):
     :param pattern:
     :return: A string
     """
-    minimally_validate_content_source(msg)
-    pattern = get_pattern_from_content_source(msg)
+    if msg is not None:
+        minimally_validate_content_source(msg)
+        pattern = get_pattern_from_content_source(msg)
     deobfuscated = phone_numbers.deobfuscate(pattern)
     normalized_deobfuscated = phone_numbers.normalize(deobfuscated)
     return "Deobfuscated: `" + deobfuscated + "`; deobfuscated and normalized: `" + normalized_deobfuscated + "`"

--- a/util.py
+++ b/util.py
@@ -30,6 +30,12 @@ def util_bisect(*args):
         print(chatcommands.bisect.__func__(None, s) + "\n")
 
 
+@utility("bisect-number", "finds out which number blacklist/watchlist item matches a number")
+def util_bisect_number(*args):
+    for s in args:
+        print(chatcommands.bisect_number.__func__(None, s) + "\n")
+
+
 @utility("exit", "exit this utility (interactive mode)")
 def util_exit():
     exit()

--- a/util.py
+++ b/util.py
@@ -36,6 +36,18 @@ def util_bisect_number(*args):
         print(chatcommands.bisect_number.__func__(None, s) + "\n")
 
 
+@utility("deobfuscate-number", "show the results of homoglyph deobfuscating, and number normalizations, for a number pattern")
+def util_deobfuscate_number(*args):
+    for s in args:
+        print(chatcommands.deobfuscate_number.__func__(None, s) + "\n")
+
+
+@utility("normalize-number", "show the number normalizations for a number pattern")
+def util_normalize_number(*args):
+    for s in args:
+        print(chatcommands.normalize_number.__func__(None, s) + "\n")
+
+
 @utility("exit", "exit this utility (interactive mode)")
 def util_exit():
     exit()

--- a/util.py
+++ b/util.py
@@ -145,6 +145,30 @@ def util_blacklist_number(*args):
     findspam.FindSpam.reload_blacklists()
 
 
+def unblacklist(pattern):
+    for blacklist_name in ['KEYWORDS', 'WEBSITES', 'USERNAMES', 'NUMBERS']:
+        exists, _line = Blacklist(getattr(Blacklist, blacklist_name)).exists(pattern)
+        if exists:
+            ensure_blacklist_faked(blacklist_name)
+            Blacklist(getattr(Blacklist, blacklist_name)).remove(pattern)
+            return blacklist_name
+    return None
+
+
+@utility("unblacklist", "pretend it has been removed from the blacklists")
+def util_unblacklist(*args):
+    changes_made = False
+    for s in args:
+        removed_from = unblacklist(s)
+        if removed_from is not None:
+            print("Removed `{}` from {}.\n".format(s, removed_from))
+            changes_made = True
+        else:
+            print("No such item `{}` in blacklist.\n".format(s))
+    if changes_made:
+        findspam.FindSpam.reload_blacklists()
+
+
 @utility("exit", "exit this utility (interactive mode)")
 def util_exit():
     # delete all temporary blacklist copies

--- a/util.py
+++ b/util.py
@@ -61,7 +61,7 @@ def main_loop(args):
         return
 
     desc, func = utilities[name]
-    func_args = inspect.getargspec(func)
+    func_args = inspect.getfullargspec(func)
     min_args = len(func_args[0] or "") - len(func_args[3] or "")
     if len(args) < min_args:
         print("Too few arguments")

--- a/util.py
+++ b/util.py
@@ -36,7 +36,7 @@ def util_bisect_number(*args):
         print(chatcommands.bisect_number.__func__(None, s) + "\n")
 
 
-@utility("deobfuscate-number", "show the results of homoglyph deobfuscating, and number normalizations, for a number pattern")
+@utility("deobfuscate-number", "homoglyph deobfuscate and normalize a number pattern")
 def util_deobfuscate_number(*args):
     for s in args:
         print(chatcommands.deobfuscate_number.__func__(None, s) + "\n")
@@ -46,6 +46,42 @@ def util_deobfuscate_number(*args):
 def util_normalize_number(*args):
     for s in args:
         print(chatcommands.normalize_number.__func__(None, s) + "\n")
+
+
+@utility("test-question", "test if text would be automatically reported as a question body")
+def util_test_question(*args):
+    for s in args:
+        print(chatcommands.test.__func__(s, alias_used='test-question') + "\n")
+
+
+@utility("test-answer", "test if text would be automatically reported as an answer body")
+def util_test_answer(*args):
+    for s in args:
+        print(chatcommands.test.__func__(s, alias_used='test-answer') + "\n")
+
+
+@utility("test-user", "test if text would be automatically reported as username")
+def util_test_user(*args):
+    for s in args:
+        print(chatcommands.test.__func__(s, alias_used='test-user') + "\n")
+
+
+@utility("test-title", "test if text would be automatically reported as a question title")
+def util_test_title(*args):
+    for s in args:
+        print(chatcommands.test.__func__(s, alias_used='test-title') + "\n")
+
+
+@utility("test", "test if text would be automatically reported as a post, title, or username")
+def util_test(*args):
+    for s in args:
+        print(chatcommands.test.__func__(s, alias_used='test') + "\n")
+
+
+@utility("test-json", "test if post, given in JSON, would be automatically reported")
+def util_test_json(*args):
+    for s in args:
+        print(chatcommands.test.__func__(s, alias_used='test-json') + "\n")
 
 
 @utility("exit", "exit this utility (interactive mode)")


### PR DESCRIPTION
## 1. What does your pull request change or introduce to the project?

It updates the `util.py` CLI so that it works on Python 3.11+ and supports more commands than just `bisect`. The following new commands call into the same internal code as their namesake chat commands:

- `bisect-number`
- `deobfuscate-number`
- `normalize-number`
- `test-question`
- `test-answer`
- `test-user`
- `test-title`
- `test`
- `test-json`

The following new commands create temporary copies of the relevant blacklists, then manually add or remove items from these temporary copies, so that subsequent calls to `bisect-*` or `test-*` commands will test these modifications. They don't run the full logic of their namesake chat commands:

- `blacklist-keyword`
- `blacklist-website`
- `blacklist-username`
- `blacklist-number`
- `unblacklist`

## 2. What is the justification for the inclusion of your Pull Request (or, what problem does it solve?)

It lets someone test the blacklists outside of the chat, by cloning the SmokeDetector repository and installing the dependencies. If they want to test a lot of different things, it avoids spamming a chatroom. Furthermore, they could use this to test new regexes using the actual SmokeDetector code, before creating a commit on the public repository.

`util.py` used to be able to do this for `bisect`, but that was broken due to the removal of `inspect.getargspec()` in Python 3.11. I tried to fix that and extend the functionality in a similar way to what used to exist.

## 3. Write meaningful commit messages ...

I used brief commit messages because, by more or less duplicating the chat commands in `util.py`, it seemed the changes would be relatively self-explanatory.

## 4. Include comments in your code ...

A few comments were added to `util.py`, but it mostly relies on the `@utility` decorator's strings and the function and variable names.

The only changes outside of `util.py` were in `normalize_number()` and `deobfuscate_number()` in `chatcommands`: instead of assuming `msg` is not `None`, these methods now treat `msg=None` similar to how `bisect()` and `bisect_number()` already do, by falling back to the passed-in `pattern` argument.

## 5. Use meaningful variable names ...

I've tried to do that.

## 6. What testing have you done?

I have only tested it by running `util.py` myself and playing around with it. `util.py` wasn't working anyhow, so I'm assuming I can't have broken it too badly (or that many people have been using it).

I believe the only way it could introduce errors in other parts of SmokeDetector is if there was code relying on `deobfuscate_number()` or `normalize_number()` returning an error on `msg=None`. I don't see any error handling code there, so I'm hoping there's no requirement for it to error.