### PR TITLE
PR search links: fix bookending, search titles, fix #9814

### DIFF
--- a/gitmanager.py
+++ b/gitmanager.py
@@ -196,18 +196,24 @@ class GitManager:
                     return (False, "Tell someone to set a GH token.")
 
                 payload = {"title": "{0}: {1} {2}".format(username, op.title(), item),
-                           "body": "[{0}]({1}) requests the {2} of the {3} `{4}`. See the MS search [here]"
-                                   "(https://metasmoke.erwaysoftware.com/search?utf8=%E2%9C%93{5}{6}) and the "
-                                   "Stack Exchange search [in text](https://stackexchange.com/search?q=%22{7}%22)"
-                                   ", [in URLs](https://stackexchange.com/search?q=url%3A%22{7}%22)"
-                                   ", and [in code](https://stackexchange.com/search?q=code%3A%22{7}%22)"
+                           "body": "[{username}]({user_link}) requests the {op} of the {blacklist} `{item}`"
+                                   ". See the MS search [here]"
+                                   "(https://metasmoke.erwaysoftware.com/search?utf8=%E2%9C%93{ms_search_option}{ms_search})"
+                                   " and the Stack Exchange search"
+                                   " [in text](https://stackexchange.com/search?q=%22{se_search}%22)"
+                                   ", [in URLs](https://stackexchange.com/search?q=url%3A%22{se_search}%22)"
+                                   ", and [in code](https://stackexchange.com/search?q=code%3A%22{se_search}%22)"
                                    ".\n"
-                                   "<!-- METASMOKE-BLACKLIST-{8} {4} -->".format(
-                                       username, chat_profile_link, op, blacklist,                # 0 1 2 3
-                                       item, ms_search_option,                                    # 4 5
-                                       quote_plus(_anchor(item, blacklist_type)),                 # 6
-                                       quote_plus(item.replace("\\W", " ").replace("\\.", ".")),  # 7
-                                       blacklist.upper()),                                        # 8
+                                   "<!-- METASMOKE-BLACKLIST-{BLACKLIST} {item} -->".format(
+                                       username=username,
+                                       user_link=chat_profile_link,
+                                       blacklist=blacklist,
+                                       BLACKLIST=blacklist.upper(),
+                                       op=op,
+                                       item=item,
+                                       ms_search_option=ms_search_option,
+                                       ms_search=quote_plus(_anchor(item, blacklist_type)),
+                                       se_search=quote_plus(item.replace("\\W", " ").replace("\\.", "."))),
                            "head": branch,
                            "base": "master"}
                 response = GitHubManager.create_pull_request(payload)

--- a/gitmanager.py
+++ b/gitmanager.py
@@ -28,7 +28,8 @@ from blacklists import *
 def _anchor(str_to_anchor, blacklist_type):
     """ Anchor a string according to the operation. """
     if blacklist_type in {Blacklist.WATCHED_KEYWORDS, Blacklist.KEYWORDS}:
-        return r"(?s:\b" + str_to_anchor + r"\b)"
+        # not using the full bookending because MSSQL doesn't support \w
+        return r"(?s:(?:^|\b)" + str_to_anchor + r"(?:\b|$))"
     else:
         return str_to_anchor
 


### PR DESCRIPTION
## 1. What does your pull request change or introduce to the project?

It fixes a few issues in the search links generated by `GitManager` when it creates a PR for a blacklist or watchlist item on behalf of a user who's not a blacklister:

1. The starting bookending for the Metasmoke search link has been changed from `(?s\b` to `(?s(?:^|\b)` to make it closer to the actual bookending used (currently `(?is)(?:^|\b|(?w:\b))(*PRUNE)`. When I tried `(?:^|\b|(?w:\b))` on MS search, it returned an error that `?w` is not supported, so I'm assuming fully supporting the meaning of `(?w:\b)` would be difficult, and I made no attempt to.
2. The ending bookending for the Metasmoke search link has been changed from `\b)` to `(?:\b|$))` to make it closer to the actual bookending used (currently `(?:\b|(?w:\b)|$)`.
3. The Metasmoke search link now searches multiple fields of the posts with `&or_search=1` where appropriate.
    **Note:** I believe this is not perfect for answer posts, because it seems the Metasmoke search doesn't currently have an option to search question titles but not answer titles. This would best be fixed by improving the Metasmoke search page to allow direct searches for an item being blacklisted. (Then the SmokeDetector code could be simplified.) Alternatively, the generated PR text could include two extra Metasmoke links, one which is for questions only (and includes the title) and the other for answers only (and doesn't include the title).
4. Regex comments are now stripped from the search text, fixing #9814.

This is related to Charcoal-SE/metasmoke#837, but I don't know if it will fix it or not.

I also refactored the PR text generation a little, to make it easier for me to read and to make it easier to test. While developing the code, you now can run

```
python -c 'import gitmanager; from blacklists import Blacklist; print(gitmanager._metasmoke_search("12345", Blacklist.NUMBERS))'
```

on the command line to get a Metasmoke search link, or

```
python -c 'import gitmanager; print(gitmanager._se_search("12345(?#no noram)"))'
```

to get the quoted SE search text.

## 2. What is the justification for the inclusion of your Pull Request (or, what problem does it solve?)

I believe it solves these (minor) problems:
- current Metasmoke search link doesn't work right for regexes that are anchored to the start (or end), but start (or end) with a non-word character.
- current Metasmoke search link doesn't search titles
- current Metasmoke search link doesn't search usernames unless it's for `blacklist-username`
- current SE search links include regex comments (see #9814).

## 3. Write meaningful commit messages ...

I've tried to do that.

## 4. Include comments in your code ...

I've tried to do that.

## 5. Use meaningful variable names ...

I've tried to do that.

## 6. What testing have you done?

I have only tested manually as described in heading 1.