### PR TITLE
Update watched_nses.yml - disable hostnac.com (NXDOMAIN)

### DIFF
--- a/watched_nses.yml
+++ b/watched_nses.yml
@@ -4440,7 +4440,9 @@ items:
 - ns: matbao.net.
 - ns: matbao.vn.
 - ns: hostinger.vn.
-- ns: hostnac.com.
+- comment: NXDOMAIN 2025-05-08
+  disable: true
+  ns: hostnac.com.
 - ns: iserverplanet.net.
 - comment: no longer responding 2020-11-11
   disable: true


### PR DESCRIPTION
hostnac.com has been causing build errors for about the past 10 hours, starting with: https://github.com/Charcoal-SE/SmokeDetector/actions/runs/14901618248 and as recently as: https://github.com/Charcoal-SE/SmokeDetector/actions/runs/14912838315/job/41891197554; this comments out the entry.