### PR TITLE
chatcommunicate.on_msg(): don't crash on HTTPErrors when checking reply parent

### DIFF
--- a/chatcommunicate.py
+++ b/chatcommunicate.py
@@ -356,6 +356,8 @@ def on_msg(msg, client):
 
                 result = dispatch_reply_command(message.parent, message, cmd)
                 send_reply_if_not_blank(room_ident, message.id, result)
+        except requests.HTTPError:
+            log_current_exception(log_level='debug')
         except ValueError:
             pass
     elif message.content.lower().startswith("sd "):


### PR DESCRIPTION
### 1. What does your pull request change or introduce to the project?

In `chatcommunicate.on_msg()`, if an `HTTPError` is encountered checking the `parent` of the message (the message that was being replied to), it's caught and logged, but not re-raised. Without this, the exception was immediately crashing SmokeDetector, forcing a restart. 

### 2. What is the justification for the inclusion of your Pull Request (or, what problem does it solve?)

Avoids unnecessary crashes and restarts. In particular, avoids a vicious circle of unnecessary crashes and restarts.

Stack Exchange often refuses the requests in this part of the code with 403 errors. While a better fix would be for Stack Exchange to *not* do that, this patch makes SmokeDetector more resilient to the errors: instead of crashing and restarting the entire instance, it simply stops trying to figure out what the message was replying to, and goes on with the rest of its business.

### 3. Write meaningful commit messages

Tried to do that.

### 4. Include comments in your code to help guide reviewers through what you intend for the sub-portions of your code to be doing.

Very short patch. I think it's self-explanatory.

### 5. Use meaningful variable names.

Very short patch. Didn't need any.

### 6. What testing have you done?

I ran an instance for a short while in [the "Charcoal Test" room](https://chat.stackexchange.com/rooms/65945/charcoal-test), long enough to trigger some of these particular 403 errors. As expected, I saw them in the text log, but the instance did not crash.