### PR TITLE
disable NS watch of apktunnel.com

### DIFF
--- a/watched_nses.yml
+++ b/watched_nses.yml
@@ -5859,7 +5859,9 @@ items:
 - ns: vietnix.vn.
 - ns: greengeeks.net.
 - ns: movavi.net.
-- ns: apktunnel.com.
+- comment: NXDOMAIN 2025-07-08
+  disable: true
+  ns: apktunnel.com.
 - ns: dan.com.
 - ns: sprintsmsservice.com.
 - ns: 040services.net.


### PR DESCRIPTION
apktunnel.com is returning NXDOMAIN as of today, which causes `test_blacklists.py::test_yaml_nses` to fail
ICANN says it expired 2025-05-27
I set it to disabled in the YML file, though it looks like it [might never have triggered](https://metasmoke.erwaysoftware.com/search?utf8=%E2%9C%93&why_is_regex=1&why=apktunnel%5C.com)