### PR TITLE
Prevent trying to fetch reply parent data for replies not to SD

### DIFF
--- a/test/test_chatcommunicate.py
+++ b/test/test_chatcommunicate.py
@@ -314,7 +314,8 @@ def test_on_msg(get_last_messages, post_msg):
     with chatcommunicate._rooms_lock, chatcommunicate._prefix_commands_lock, chatcommunicate._reply_commands_lock:
         client = Fake({
             "_br": {
-                "user_id": 1337
+                "user_id": 1337,
+                "user_name": "SmokeDetector",
             },
 
             "host": "stackexchange.com"
@@ -337,8 +338,11 @@ def test_on_msg(get_last_messages, post_msg):
 
                 "parent": None,
                 "content": "shoutouts to simpleflips"
-            }
+            },
+            "data": {
+            },
         }, spec=chatcommunicate.events.MessagePosted)
+        msg1.data = {}
 
         chatcommunicate.on_msg(msg1, client)
 
@@ -355,8 +359,11 @@ def test_on_msg(get_last_messages, post_msg):
                 "id": 999,
                 "parent": None,
                 "content": "!!/not_actually_a_command"
-            }
+            },
+            "data": {
+            },
         }, spec=chatcommunicate.events.MessagePosted)
+        msg2.data = {}
 
         chatcommunicate.on_msg(msg2, client)
 
@@ -373,8 +380,11 @@ def test_on_msg(get_last_messages, post_msg):
                 "id": 999,
                 "parent": None,
                 "content": "!!/a_command"
-            }
+            },
+            "data": {
+            },
         }, spec=chatcommunicate.events.MessagePosted)
+        msg3.data = {}
 
         mock_command = Mock(side_effect=lambda *_, **kwargs: "hi" if not kwargs["quiet_action"] else "")
         chatcommunicate._prefix_commands["a-command"] = (mock_command, (0, 0))
@@ -475,8 +485,13 @@ def test_on_msg(get_last_messages, post_msg):
 
                 "id": 1000,
                 "content": "asdf"
-            }
+            },
+            "data": {
+            },
         }, spec=chatcommunicate.events.MessageEdited)
+        msg4.data = {
+            "parent_id": 100,
+        }
 
         chatcommunicate.on_msg(msg4, client)
 
@@ -498,8 +513,14 @@ def test_on_msg(get_last_messages, post_msg):
 
                 "id": 1000,
                 "content": "@SmokeDetector why   "
+            },
+            "data": {
             }
         }, spec=chatcommunicate.events.MessageEdited)
+        msg5.data = {
+            "parent_id": 100,
+            "show_parent": True,
+        }
 
         chatcommunicate._reply_commands["why"] = (mock_command, (0, 0))
 
@@ -543,8 +564,11 @@ def test_on_msg(get_last_messages, post_msg):
                 "id": 1000,
                 "parent": None,
                 "content": "sd why - 2why 2why- 2- why- "
-            }
+            },
+            "data": {
+            },
         }, spec=chatcommunicate.events.MessageEdited)
+        msg6.data = {}
 
         get_last_messages.side_effect = lambda _, num: (Fake({"id": i}) for i in range(num))
         chatcommunicate.on_msg(msg6, client)

--- a/watched_keywords.txt
+++ b/watched_keywords.txt
@@ -76298,3 +76298,4 @@
 1756056968	Jeff Schaller	global\.psnpsn\.com
 1756058108	Jeff Schaller	manoknapulamodapks\.com
 1756063942	VLAZ	dockflow\.appitstudio\.com
+1756071315	Jeff Schaller	stotramala\.com


### PR DESCRIPTION
This expands on PR #14794, preventing SD from attempting to get data for the reply parent when the message being replied to is not from the user under which SD is running. In addition, a reply is sent to chat upon the HTTP errors we're logging and ignoring. This should result in both the user being informed that what they wanted to happen didn't occur, but also result in a further exception if we're blocked from posting, which would mean rebooting is probably a good idea.

Note the HTTP errors appear to be upon ChatExchange trying to fetch the transcript page containing the message, which it then scrapes for the data for all of the messages on the page. It would probably be better to use the chat events endpoint and get the events instead, which is in JSON. This would, however, provide different data as it would get the N messages prior to (and including) the desired message, rather than the messages that happen to be on the same transcript page, which would likely be messages both before and after the desired message.

This is a second similar PR, as I, unfortunately, merged the previous PR into the similarly named branch in Charcoal-SE/SmokeDetector, instead of the master branch.