### PR TITLE
watched_nses.yml: disable quickfix8.com, add quickfix20.com

### DIFF
--- a/watched_nses.yml
+++ b/watched_nses.yml
@@ -5700,7 +5700,10 @@ items:
 - ns: aheadwebhost.com.
 - ns: teammas.in.
 - ns: sectigoweb.com.
-- ns: quickfix8.com.
+- comment: nxdomain 2025-08-30 (clientHold)
+  disable: true
+  ns: quickfix8.com.
+- ns: quickfix20.com.
 - ns: cbcamerica.org.
 - ns: wpdns.host.
 - ns: serverforme.xyz.


### PR DESCRIPTION
quickfix8.com is returning NXDOMAIN due to a client hold. The current NS of quickwebsitefix.com are under quickfix20.com, and had previously been under quickfix8.com. So I disabled quickfix8.com with a comment and added quickfix20.com to watched_nses.yaml.