### PR TITLE
chatcommunicate.on_msg: check ChatExchange parent_username instead of @

### DIFF
--- a/chatcommunicate.py
+++ b/chatcommunicate.py
@@ -349,9 +349,9 @@ def on_msg(msg, client):
             message.content = message.content[:-6]
 
     if (msg.data.get('parent_id') and msg.data.get('show_parent')
-            and message.content.startswith('@{} '.format(client._br.user_name.replace(' ', '')))):
+            and msg.data.get('parent_username') == client._br.user_name):
         # show_parent indicates it's a direct reply, not an @mention assumed reply.
-        # For direct replies, the entire username is at the start of the reply, stripped of spaces.
+        # For direct replies, the entire username is in parent_username.
         # We test for the reply @mention matching our current user_name, because we want to avoid fetching the
         # parent message from SE chat when we don't already have it and aren't actually interested in it.
         # The parent message is fetched lazily, so not until we actually try to get data from it.

--- a/test/test_chatcommunicate.py
+++ b/test/test_chatcommunicate.py
@@ -512,7 +512,7 @@ def test_on_msg(get_last_messages, post_msg):
                 },
 
                 "id": 1000,
-                "content": "@SmokeDetector why   "
+                "content": "why   "
             },
             "data": {
             }
@@ -520,6 +520,7 @@ def test_on_msg(get_last_messages, post_msg):
         msg5.data = {
             "parent_id": 100,
             "show_parent": True,
+            "parent_username": "SmokeDetector",
         }
 
         chatcommunicate._reply_commands["why"] = (mock_command, (0, 0))
@@ -545,7 +546,7 @@ def test_on_msg(get_last_messages, post_msg):
         post_msg.reset_mock()
         mock_command.reset_mock()
 
-        msg5.message.content = "@SmokeDetector why@!@#-"
+        msg5.message.content = "why@!@#-"
         chatcommunicate.on_msg(msg5, client)
 
         post_msg.assert_not_called()


### PR DESCRIPTION
With the September 2025 chat UI changes, SmokeDetector stopped responding to replies. This appears to have been due to two changes in the UI:
- the initial "@ UserName" has been moved into the `<a><span>` which has the reply arrow
- the class name of this anchor has been changed from `reply-info` to `reply-info-container`.

@balpha's [PR 186 on upstream ChatExchange](https://github.com/Manishearth/ChatExchange/pull/186), when cherry-picked onto [our fork](https://github.com/Charcoal-SE/ChatExchange), fixes the loading of the reply info.

However, the code in `chatcommunicate.on_msg()` had been relying on the "@ UserName" string to compare with the username SmokeDetector is being run under. That string is now being stripped out of the message `content` somewhere. But it's present in `parent_username`, so this PR changes the check to compare with `parent_username` instead of the beginning of `content`.

I ran this code in an instance on my laptop for a short time, and everything appeared to be working:
- `status` and `alive` commands worked
- replies not to the SmokeDetector user were ignored
- the `why` reply was understood
- editing a reply into `why` was also understood