### PR TITLE
Disable multivpshost.com entry in watched_nses.yml due to NXDOMAIN

### DIFF
--- a/watched_nses.yml
+++ b/watched_nses.yml
@@ -5905,7 +5905,9 @@ items:
 - ns: cnmsn.net.
 - ns: cloudswebserver.com.
 - ns: webinfomatrix.com.
-- ns: multivpshost.com.
+- comment: NXDOMAIN 2025-11-05
+  disable: true
+  ns: multivpshost.com.
 - ns: registerdomain.net.za.
 - ns: spaceship.net.
 - ns: combiz.org.


### PR DESCRIPTION
disabled multivpshost.com; starting causing build errors at https://github.com/Charcoal-SE/SmokeDetector/actions/runs/19094900262 (November 5, 2025 02:45)