### PR TITLE
Disable attichosting.com in watched_nses.yml - NXDOMAIN as of 2025-11-26

### DIFF
--- a/watched_nses.yml
+++ b/watched_nses.yml
@@ -5735,7 +5735,9 @@ items:
 - ns: lyfsoft.com.
 - ns: hostyuga.net.
 - ns: hostiq.ua.
-- ns: attichosting.com.
+- comment: nxdomain 2025-11-26
+  disable: true
+  ns: attichosting.com.
 - ns: speakatoo.com.
 - ns: zoomnameserver.com.
 - ns: parastorage.com.


### PR DESCRIPTION
Added comment and disabled DNS entry for attichosting.com. Started causing build failures ~5 hours ago: https://github.com/Charcoal-SE/SmokeDetector/actions/runs/19696416091