### PR TITLE
Disable offshoric.com entry in watched_nses.yml

### DIFF
--- a/watched_nses.yml
+++ b/watched_nses.yml
@@ -4097,7 +4097,9 @@ items:
   disable: true
   ns: vultr.com.
 - ns: directory92.com.
-- ns: offshoric.com.
+- comment: NXDOMAIN; expired 2025-11-04T20:57:17Z
+  disable: true
+  ns: offshoric.com.
 - ns: freehostia.com.
 - comment: has FPs, don't move to blacklist
   ns: hawkhost.com.


### PR DESCRIPTION
domain expired on 2025-11-04T20:57:17Z and started causing build failures due to NXDOMAIN. Ref: https://www.godaddy.com/whois/results.aspx?itc=dlp_domain_whois&domain=offshoric.com

The build failures started yesterday at https://github.com/Charcoal-SE/SmokeDetector/actions/runs/20283409277 through "now" (https://github.com/Charcoal-SE/SmokeDetector/actions/runs/20314481593).