### PR TITLE
GitHubManager: don't set HTTPBasicAuth if no username or password configured

### DIFF
--- a/gitmanager.py
+++ b/gitmanager.py
@@ -40,7 +40,10 @@ class GitHubManager:
         still_using_usernames_nudge = " By the way, tell my owner to [set up personal access tokens]" \
                                       "(//chat.stackexchange.com/transcript/message/55007870#55007870)" \
                                       " when they have time :)"
-        auth_args = {"auth": HTTPBasicAuth(GlobalVars.github_username, GlobalVars.github_password)}
+        if GlobalVars.github_username or GlobalVars.github_password:
+            auth_args = {"auth": HTTPBasicAuth(GlobalVars.github_username, GlobalVars.github_password)}
+        else:
+            auth_args = {}
     else:
         still_using_usernames_nudge = ""
         auth_args = {"headers": {'Authorization': 'token {}'.format(GlobalVars.github_access_token)}}


### PR DESCRIPTION
Previously `GitHubManager` had configured HTTPBasicAuth with empty username and password, when no access token, username, or password was set. This has started to make `test_chatcommands::test_reject` fail, with GitHub returning a 401 error. When no auth is configured, GitHub gives no error and the test passes.

The changes to `GitHubManager` should have no effect if any GitHub authentication is configured in `config`.