### PR TITLE
whitelist minecraft.wiki from "Potentially bad IP"

### DIFF
--- a/findspam.py
+++ b/findspam.py
@@ -145,6 +145,7 @@ WHITELISTED_IP_HOSTNAMES = [
     "log.info",
     "maindomain.com",
     "material.angular.io",
+    "minecraft.wiki",
     "model.fit",
     "newsite.com",
     "nextjs.org",


### PR DESCRIPTION
Added `minecraft.wiki` to `WHITELISTED_IP_HOSTNAMES`.

So far there have been 21 FP. None of the 24 TP were because of this domain being specifically spammed.

Tested using `pytest` and `util.py`.