### PR TITLE
Disable automatic DNS tests on *_nses.yml unless tests run with SD_TEST_NS_DNS=1

### DIFF
--- a/blacklists.py
+++ b/blacklists.py
@@ -296,13 +296,15 @@ class YAMLParserNS(YAMLParserCIDR):
         """
         return item.rstrip().lower()
 
-    def _validate(self, item):
+    def _validate(self, item, validate_dns=True):
         def item_check(ns):
             if not host_regex.match(ns):
                 raise ValueError(
                     '{0} does not look like a valid host name'.format(ns))
             if item.get('disable', None):
                 return False
+            if not validate_dns:
+                return True
             # Extend lifetime if we are running a test
             extra_params = dict()
             if "pytest" in sys.modules:
@@ -362,8 +364,12 @@ class YAMLParserNS(YAMLParserCIDR):
         with ThreadPoolExecutor(max_workers=10) as executor:
             return list(executor.map(self._validate, list_to_validate, timeout=300))
 
-    def validate(self):
+    def validate(self, validate_dns=True):
         parsed_list = self._parse()
+        if not validate_dns:
+            for item in parsed_list:
+                self._validate(item, validate_dns=False)
+            return
         log('info', 'Validation Pass 1:')  # Just a blank line
         results_pass1 = self.validate_list(parsed_list)
         entries_with_exception = [entry for entry in results_pass1 if entry is not True]
@@ -448,5 +454,5 @@ class Blacklist:
     def exists(self, item):
         return self._parser.exists(item)
 
-    def validate(self):
-        return self._parser.validate()
+    def validate(self, *args, **kwargs):
+        return self._parser.validate(*args, **kwargs)

--- a/test/test_blacklists.py
+++ b/test/test_blacklists.py
@@ -1,4 +1,5 @@
 import yaml
+import os
 from os import unlink
 import regex
 from globalvars import GlobalVars
@@ -140,8 +141,8 @@ def test_remote_diff():
     assert not files_changed(false_diff, file_set)
 
 
-def yaml_validate_existing(filename, cls):
-    return Blacklist((filename, cls)).validate()
+def yaml_validate_existing(filename, cls, *args, **kwargs):
+    return Blacklist((filename, cls)).validate(*args, **kwargs)
 
 
 def test_yaml_blacklist():
@@ -234,8 +235,14 @@ def test_yaml_nses():
     unlink('test_nses.yml')
 
 
+@pytest.mark.skipif(not os.environ.get("SD_TEST_NS_DNS"), reason="These DNS failures don't cause improper operation")
 # test_yaml_nses currently takes 105s to run, so we want it to start up first, with everything else running in parallel.
 @pytest.mark.xdist_group(name="long_runner_1")
-def test_yaml_nses_validate():
-    yaml_validate_existing('blacklisted_nses.yml', YAMLParserNS)
-    yaml_validate_existing('watched_nses.yml', YAMLParserNS)
+def test_yaml_nses_validate_dns():
+    yaml_validate_existing('blacklisted_nses.yml', YAMLParserNS, validate_dns=True)
+    yaml_validate_existing('watched_nses.yml', YAMLParserNS, validate_dns=True)
+
+
+def test_yaml_nses_validate_quick():
+    yaml_validate_existing('blacklisted_nses.yml', YAMLParserNS, validate_dns=False)
+    yaml_validate_existing('watched_nses.yml', YAMLParserNS, validate_dns=False)


### PR DESCRIPTION
When a domain listed (and not disabled) in blacklisted_nses.yml or watched_nses.yml expires or is misconfigured, we get a lot of spam of failing tests in CHQ, because `tests/test_blacklists.py::test_yaml_nses_validate` does DNS lookups for these.

But with the current code, these DNS failures don't cause improper operation of the spam checks: nothing would crash, and there'd only be extra FPs if a NS domain was bought by a new, innocent party. We can always disable a domain if and when FPs appear.

This PR disables the DNS lookups when tests are run under normal settings, continues to test for malformed entries in the YML files, and allows doing the full test by setting the environment variable `SD_TEST_NS_DNS=1`. This means:
- no more CI errors filling up CHQ for this particular situation
- no more needing to write and review PRs to clean up CHQ for this
- if someone really wants to do this test, they'll need to remember to set the variable

Changes made to accomplish this:
- `test_yaml_nses_validate()` renamed to `test_yaml_nses_validate_dns()`, and isn't run unless env var `SD_TEST_NS_DNS=1`
- new `test_yaml_nses_validate_quick()` does only non-DNS checks of the entries