### PR TITLE
Security: Command Injection via Shell=True in _Git_Windows.py

### DIFF
--- a/_Git_Windows.py
+++ b/_Git_Windows.py
@@ -13,7 +13,7 @@ GitError = sp.CalledProcessError
 
 def _call_process(execcmd, _ok_code=None, return_data=True, return_tuple=False):
     execcmd = ('git',) + execcmd
-    proc = sp.Popen(execcmd, stdout=sp.PIPE, stderr=sp.PIPE, shell=True)
+    proc = sp.Popen(execcmd, stdout=sp.PIPE, stderr=sp.PIPE, shell=False)
     (stdout, stderr) = proc.communicate()
     retcode = proc.returncode
     if retcode != 0:


### PR DESCRIPTION
## Summary

Security: Command Injection via Shell=True in _Git_Windows.py

## Problem

**Severity**: `High` | **File**: `_Git_Windows.py:L18`

The `_call_process` function uses `subprocess.Popen` with `shell=True`, which is dangerous when combined with user-influenced input. While the current code appears to only use hardcoded git commands, the `__getattribute__` method allows dynamic method names to be converted to command arguments. If any user-controlled input reaches this code path, it could lead to command injection.

## Solution

Remove `shell=True` and pass the command as a list directly to `subprocess.Popen`. Validate and sanitize all inputs that could reach the command execution. Consider using `subprocess.run` with explicit argument lists instead of string interpolation.

## Changes

- `_Git_Windows.py` (modified)