### PR TITLE
call .raise_for_status() before .json() for certain requests

### DIFF
--- a/chatcommands.py
+++ b/chatcommands.py
@@ -1204,10 +1204,12 @@ def pull(alias_used='pull'):
 
     request = requests.get('https://api.github.com/repos/{}/git/refs/heads/deploy'.format(
         GlobalVars.bot_repo_slug), timeout=GlobalVars.default_requests_timeout)
+    request.raise_for_status()
     latest_sha = request.json()["object"]["sha"]
     request = requests.get(
         'https://api.github.com/repos/{}/commits/{}/statuses'.format(GlobalVars.bot_repo_slug, latest_sha),
         timeout=GlobalVars.default_requests_timeout)
+    request.raise_for_status()
     states = []
     for ci_status in request.json():
         state = ci_status["state"]
@@ -1903,6 +1905,7 @@ def is_user_an_admin(msg):
         'per_page': 100
     }
     user_response = Metasmoke.get(ms_route, params=params)
+    user_response.raise_for_status()
     user_response.encoding = 'utf-8-sig'
     user_response = user_response.json()
     chat_host = msg._client.host
@@ -2001,6 +2004,7 @@ def whois(msg, role):
         'per_page': 100
     }
     user_response = Metasmoke.get(ms_route, params=params)
+    user_response.raise_for_status()
     user_response.encoding = 'utf-8-sig'
     user_response = user_response.json()
 

--- a/metasmoke.py
+++ b/metasmoke.py
@@ -474,6 +474,7 @@ class Metasmoke:
             headers = {'content-type': 'application/json'}
             response = Metasmoke.post("/status-update.json",
                                       data=json.dumps(payload), headers=headers, ignore_down=True)
+            response.raise_for_status()
 
             try:
                 response = response.json()
@@ -516,7 +517,9 @@ class Metasmoke:
         headers = {'Content-type': 'application/json'}
         try:
             response = Metasmoke.get("/api/users/code_privileged",
-                                     data=json.dumps(payload), headers=headers).json()['items']
+                                     data=json.dumps(payload), headers=headers)
+            response.raise_for_status()
+            response = response.json()['items']
         except Exception as e:
             log('error', e)
             return
@@ -543,7 +546,9 @@ class Metasmoke:
             'urls': post_url
         }
         try:
-            response = Metasmoke.get("/api/v2.0/posts/urls", params=payload).json()
+            response = Metasmoke.get("/api/v2.0/posts/urls", params=payload)
+            response.raise_for_status()
+            response = response.json()
         except Exception as e:
             log('error', e)
             return False, []
@@ -555,7 +560,9 @@ class Metasmoke:
             id = str(response["items"][-1]["id"])
             payload = {'key': GlobalVars.metasmoke_key}
 
-            flags = Metasmoke.get("/api/v2.0/posts/" + id + "/flags", params=payload).json()
+            flags = Metasmoke.get("/api/v2.0/posts/" + id + "/flags", params=payload)
+            flags.raise_for_status()
+            flags = flags.json()
 
             if len(flags["items"]) > 0:
                 return True, [user["username"] for user in flags["items"][0]["autoflagged"]["users"]]
@@ -610,14 +617,18 @@ class Metasmoke:
 
         if url is not None:
             params = {"key": GlobalVars.metasmoke_key, "urls": url, "filter": "GFGJGHFJNFGNHKNIKHGGOMILHKLJIFFN"}
-            response = Metasmoke.get("/api/v2.0/posts/urls", params=params).json()
+            response = Metasmoke.get("/api/v2.0/posts/urls", params=params)
+            response.raise_for_status()
+            response = response.json()
         elif ids is not None:
             post_id, site = ids
             site = parsing.api_parameter_from_link(site)
             params = {"key": GlobalVars.metasmoke_key, "filter": "GFGJGHFJNFGNHKNIKHGGOMILHKLJIFFN"}
 
             try:
-                response = Metasmoke.get("/api/v2.0/posts/uid/{}/{}".format(site, post_id), params=params).json()
+                response = Metasmoke.get("/api/v2.0/posts/uid/{}/{}".format(site, post_id), params=params)
+                response.raise_for_status()
+                response = response.json()
             except AttributeError:
                 response = None
 
@@ -641,7 +652,9 @@ class Metasmoke:
             'urls': parsing.to_protocol_relative(post_url)
         }
         try:
-            response = Metasmoke.get('/api/v2.0/posts/urls', params=payload).json()
+            response = Metasmoke.get('/api/v2.0/posts/urls', params=payload)
+            response.raise_for_status()
+            response = response.json()
         except AttributeError:
             return None
         except Exception as e:


### PR DESCRIPTION
Addresses #15227. `.json()` on Metasmoke requests was causing an error like

```
requests.exceptions.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

so this calls `raise_for_status()` first, which will raise an `HTTPError` instead if it's a 4xx or 5xx HTTP error.

I also did this in `chatcommands.pull()`, because that method appears to assume a successful response.

I didn't do this for:

- the other GitHub API requests: seems we might rely on parsing the JSON body of an error response
- StackExchange API requests: seems we might rely on parsing the JSON body of an error response
- the ChatExchange call in `chatcommunicate.sendmessages()`: seems there is some error handling in ChatExchange
- `findspam.toxic_check()`: looks as if errors are returned as JSON
- `Metasmoke.get()` itself: `MetasmokeCache.fetch_from_api()` calls `.get()` and then handles the status code separately
- `BodyFetcher.make_api_call_for_site()`: all exceptions are swallowed, so makes no difference
- `deletionwatcher._check_batch()`: this code appears to have been obsolete for over a year