### PR TITLE
TestRoomReports.setUp(): properly call reset_mock() to avoid spurious test failures

### DIFF
--- a/test/test_spamhandling.py
+++ b/test/test_spamhandling.py
@@ -83,7 +83,7 @@ class TestRoomReports(TestCase):
 
     def setUp(self):
         print('\n\n-------------------------------Set up test------------------------------------')
-        chatcommunicate.tell_rooms.reset_mock
+        chatcommunicate.tell_rooms.reset_mock()
         # .reset_mock counts as a call. We don't want that.
         chatcommunicate.tell_rooms.call_count = 0
 


### PR DESCRIPTION
There was a simple typo in `TestRoomReports.setUp()`, so that the mock wasn't being reset, which meant that if `test_handle_spam_repeating_characters()` was run after `test_handle_spam_offensive_title()` in the same process, it would always fail.