### PR TITLE
refactor: replace deprecated datetime.utcnow() with datetime.now(timezone.utc)

### DIFF
--- a/ws.py
+++ b/ws.py
@@ -21,7 +21,7 @@ from threading import Thread
 import traceback
 from bodyfetcher import BodyFetcher
 import chatcommunicate
-from datetime import datetime
+from datetime import datetime, timezone
 from spamhandling import check_if_spam_json
 from globalvars import GlobalVars
 from datahandling import (load_pickle, PICKLE_STORAGE, load_files, filter_auto_ignored_posts,
@@ -232,7 +232,7 @@ def check_socket_connections():
     socket_failure = False
     with chatcommunicate._clients_lock:
         for client in chatcommunicate._clients.values():
-            if client.last_activity and (datetime.utcnow() - client.last_activity).total_seconds() >= 60:
+            if client.last_activity and (datetime.now(timezone.utc) - client.last_activity).total_seconds() >= 60:
                 socket_failure = True
     if socket_failure:
         exit_mode("socket_failure")
@@ -319,7 +319,7 @@ while not GlobalVars.no_se_activity_scan:
 
     except Exception as e:
         exc_type, exc_obj, exc_tb = sys.exc_info()
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         delta = now - GlobalVars.startup_utc_date
         seconds = delta.total_seconds()
         tr = traceback.format_exc()


### PR DESCRIPTION
Replace deprecated `datetime.utcnow()` with `datetime.now(timezone.utc)` in ws.py.

`datetime.utcnow()` is deprecated in Python 3.12 and removed in 3.14. This change uses the recommended timezone-aware alternative.