### PR TITLE
Remove 'Cow' from user lists in rooms.yml

### DIFF
--- a/rooms.yml
+++ b/rooms.yml
@@ -215,7 +215,6 @@ stackexchange.com:
       - 2000097  # Elements in Space
       - 4566097  # Can O' Spam
       - 5392262  # General Grievance (Calculuswhiz on MS)
-      - 15725245 # Cow
       - 22084389 # mozway
       - 12413463 # stumblebee
       - 26518992 # Fastnlight
@@ -642,7 +641,6 @@ stackoverflow.com:
       - 72095    # Ryan M
       - 11421497 # cigien
       - 7156005  # Vega
-      - 15725245 # Cow
       - 21866301 # CPlus
       - 22718731 # cocomac
       - 5392262  # General Grievance (Calculuswhiz on MS)


### PR DESCRIPTION
Removed 'Cow' from the list of users in two sections. Requested at https://chat.stackexchange.com/transcript/message/69011441#69011441