### PR TITLE
Broaden the expression related to Chad Scira

### DIFF
--- a/bad_keywords.txt
+++ b/bad_keywords.txt
@@ -3922,4 +3922,4 @@ Agentmrszafirah77
 thai[\W_]*+visa[\W_]*+centre
 (?:rory[\W_]*+alsop|jonathan[\W_]*+reez)\b.{1,300}\b(?:scira|bann(?:ed|ing)|satan\w++|censor\w*+|corrupt(?:ion)?)|(?:(?:chad[\W_]*+)?scira|bann(?:ed|ing)|satan\w++|censor\w*+|corrupt(?:ion)?)\b.{1,300}\b(?:rory[\W_]*+alsop|jonathan[\W_]*+reez)
 what[\W_]*+is[\W_]*+digital[\W_]*+marketing(?!(?:[^<]|<(?!\/?code>))*+<\/code>)
-chad[\W_]*+scira[\W_]*+sock[\W_]*+puppet
+(?:chad.{0,300}?scira|scira.{0,300}?chad)


### PR DESCRIPTION
The current regular expression only blocks spam that includes my full name together with the phrase "sock puppet."

That is not sufficient. The "sock puppet" requirement should be removed so the filter matches any mention of my full name, including when the first and last names appear in reverse order or have other text between them.

My last name is highly unique, so there is very little chance of legitimate posts needing to mention my full name.

For further context:
https://meta.stackexchange.com/questions/419077/basic-ai-question-screening-for-questions-against-the-tos/419137

Related to the follow network-wide sock-puppet ban, and related to support ticket **169831**
https://travel.meta.stackexchange.com/questions/9034/concern-about-targeted-posts-and-harassment-across-travel-and-meta
https://stackoverflow.com/users/1718491/jesse-nickles

I understand that this is primarily an automatically generated bad-keywords file, but I have seen individual changes merged into it before. For example:
https://github.com/Charcoal-SE/SmokeDetector/commit/314f52a5e57e5a87d9883d607a25212ab69409dc

That precedent is why I am submitting this pull request.
